### PR TITLE
feat(0.2): Eval-data calibration fixtures (cost / hallucination / retrieval)

### DIFF
--- a/internal/calibration/runner.go
+++ b/internal/calibration/runner.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/pmclSF/terrain/internal/models"
 )
@@ -295,18 +296,33 @@ func matchFixture(labels FixtureLabels, signals []models.Signal, fixtureDir stri
 		return string(e.Type) + "\x00" + e.File
 	}
 
+	// Detectors that ingest external artifacts (eval framework outputs)
+	// stamp the absolute path of the artifact into Signal.Location.File.
+	// Labels list paths relative to the fixture directory, so we strip
+	// the fixture prefix before matching.
+	relSignalFile := func(sigFile string) string {
+		if sigFile == "" {
+			return ""
+		}
+		if rel, err := filepath.Rel(fixtureDir, sigFile); err == nil && !strings.HasPrefix(rel, "..") {
+			return filepath.ToSlash(rel)
+		}
+		return sigFile
+	}
+
 	for _, sig := range signals {
 		// Try to match against an expected (positive) label.
 		matched := false
+		sigFile := relSignalFile(sig.Location.File)
 		for i, exp := range labels.Expected {
 			if consumed[i] {
 				continue
 			}
-			if expectedKey(exp) == string(sig.Type)+"\x00"+sig.Location.File {
+			if expectedKey(exp) == string(sig.Type)+"\x00"+sigFile {
 				consumed[i] = true
 				out.Matches = append(out.Matches, Match{
 					Type:    sig.Type,
-					File:    sig.Location.File,
+					File:    sigFile,
 					Outcome: OutcomeTruePositive,
 					Notes:   exp.Notes,
 				})

--- a/internal/engine/calibration_integration_test.go
+++ b/internal/engine/calibration_integration_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -9,6 +10,11 @@ import (
 	"github.com/pmclSF/terrain/internal/engine"
 	"github.com/pmclSF/terrain/internal/models"
 )
+
+func exists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
 
 // TestCalibration_CorpusRunner runs the real engine pipeline against the
 // in-tree calibration corpus and confirms the runner reports sane
@@ -39,7 +45,25 @@ func TestCalibration_CorpusRunner(t *testing.T) {
 	}
 
 	analyse := func(fixturePath string) ([]models.Signal, error) {
-		result, err := engine.RunPipeline(fixturePath)
+		opts := engine.PipelineOptions{}
+		// Auto-discover per-fixture eval artifacts. Each path is added to
+		// PipelineOptions only when the file exists; fixtures without
+		// these artifacts behave exactly as before.
+		fixtureFile := func(rel string) string { return filepath.Join(fixturePath, rel) }
+		if exists(fixtureFile("eval-runs/promptfoo.json")) {
+			opts.PromptfooPaths = []string{fixtureFile("eval-runs/promptfoo.json")}
+		}
+		if exists(fixtureFile("eval-runs/deepeval.json")) {
+			opts.DeepEvalPaths = []string{fixtureFile("eval-runs/deepeval.json")}
+		}
+		if exists(fixtureFile("eval-runs/ragas.json")) {
+			opts.RagasPaths = []string{fixtureFile("eval-runs/ragas.json")}
+		}
+		if exists(fixtureFile("baseline.json")) {
+			opts.BaselineSnapshotPath = fixtureFile("baseline.json")
+		}
+
+		result, err := engine.RunPipeline(fixturePath, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/calibration_integration_test.go
+++ b/internal/engine/calibration_integration_test.go
@@ -1,6 +1,7 @@
 package engine_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,6 +15,48 @@ import (
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// buildBaselineFile synthesises a baseline snapshot from any framework
+// artifacts found under baselineDir/eval-runs/ and writes it to a temp
+// file under outDir. Returns the temp file path or "" when no artifacts
+// were found. Author convenience: regression-shaped detector fixtures
+// (aiCostRegression, aiRetrievalRegression) only need to drop the
+// previous run's framework JSON into baseline/eval-runs/, not hand-author
+// a snapshot.
+func buildBaselineFile(t *testing.T, baselineDir, outDir string) string {
+	t.Helper()
+
+	opts := engine.PipelineOptions{}
+	if exists(filepath.Join(baselineDir, "eval-runs/promptfoo.json")) {
+		opts.PromptfooPaths = []string{filepath.Join(baselineDir, "eval-runs/promptfoo.json")}
+	}
+	if exists(filepath.Join(baselineDir, "eval-runs/deepeval.json")) {
+		opts.DeepEvalPaths = []string{filepath.Join(baselineDir, "eval-runs/deepeval.json")}
+	}
+	if exists(filepath.Join(baselineDir, "eval-runs/ragas.json")) {
+		opts.RagasPaths = []string{filepath.Join(baselineDir, "eval-runs/ragas.json")}
+	}
+	if len(opts.PromptfooPaths)+len(opts.DeepEvalPaths)+len(opts.RagasPaths) == 0 {
+		return ""
+	}
+
+	result, err := engine.RunPipeline(baselineDir, opts)
+	if err != nil {
+		t.Fatalf("buildBaselineFile: %v", err)
+	}
+
+	// The baseline snapshot only needs the EvalRuns the regression
+	// detectors look at; the rest is harmless to include.
+	bytes, err := json.Marshal(result.Snapshot)
+	if err != nil {
+		t.Fatalf("marshal baseline: %v", err)
+	}
+	out := filepath.Join(outDir, "baseline.synthesized.json")
+	if err := os.WriteFile(out, bytes, 0o644); err != nil {
+		t.Fatalf("write baseline: %v", err)
+	}
+	return out
 }
 
 // TestCalibration_CorpusRunner runs the real engine pipeline against the
@@ -61,6 +104,15 @@ func TestCalibration_CorpusRunner(t *testing.T) {
 		}
 		if exists(fixtureFile("baseline.json")) {
 			opts.BaselineSnapshotPath = fixtureFile("baseline.json")
+		} else if exists(fixtureFile("baseline")) {
+			// Synthesise the baseline snapshot from baseline/eval-runs/
+			// framework artifacts. Cheaper to author than a hand-written
+			// snapshot JSON with base64-encoded payloads.
+			tmpDir := t.TempDir()
+			synth := buildBaselineFile(t, fixtureFile("baseline"), tmpDir)
+			if synth != "" {
+				opts.BaselineSnapshotPath = synth
+			}
 		}
 
 		result, err := engine.RunPipeline(fixturePath, opts)

--- a/tests/calibration/eval-cost-regression/baseline/eval-runs/promptfoo.json
+++ b/tests/calibration/eval-cost-regression/baseline/eval-runs/promptfoo.json
@@ -1,0 +1,12 @@
+{
+  "evalId": "calibration-cost",
+  "createdAt": 1735603200,
+  "results": [
+    { "id": "case-a", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1200, "cost": 0.0024 } } },
+    { "id": "case-b", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1500, "cost": 0.0030 } } },
+    { "id": "case-c", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1800, "cost": 0.0036 } } },
+    { "id": "case-d", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1100, "cost": 0.0022 } } },
+    { "id": "case-e", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1400, "cost": 0.0028 } } }
+  ],
+  "stats": { "successes": 5, "failures": 0, "errors": 0 }
+}

--- a/tests/calibration/eval-cost-regression/eval-runs/promptfoo.json
+++ b/tests/calibration/eval-cost-regression/eval-runs/promptfoo.json
@@ -1,0 +1,12 @@
+{
+  "evalId": "calibration-cost",
+  "createdAt": 1735689600,
+  "results": [
+    { "id": "case-a", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1800, "cost": 0.0072 } } },
+    { "id": "case-b", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 2200, "cost": 0.0088 } } },
+    { "id": "case-c", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 2700, "cost": 0.0108 } } },
+    { "id": "case-d", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 1700, "cost": 0.0068 } } },
+    { "id": "case-e", "success": true, "score": 1.0, "response": { "tokenUsage": { "total": 2100, "cost": 0.0084 } } }
+  ],
+  "stats": { "successes": 5, "failures": 0, "errors": 0 }
+}

--- a/tests/calibration/eval-cost-regression/labels.yaml
+++ b/tests/calibration/eval-cost-regression/labels.yaml
@@ -1,0 +1,16 @@
+schemaVersion: 1
+fixture: eval-cost-regression
+description: |
+  Two paired Promptfoo runs, same five CaseIDs across both. Average
+  cost-per-case rose from 0.0028 → 0.0084, a +200% increase against
+  the 25% default threshold. aiCostRegression must fire on the
+  current run.
+
+  Exercises the regression-pair plumbing: the calibration runner
+  picks up baseline/eval-runs/promptfoo.json, synthesises a baseline
+  snapshot, and feeds it to the pipeline as Baseline alongside the
+  current eval-runs/promptfoo.json.
+expected:
+  - type: aiCostRegression
+    file: eval-runs/promptfoo.json
+    notes: "avg cost rose 0.0028 → 0.0084 (+200% vs 25% threshold)"

--- a/tests/calibration/eval-hallucination-rate/eval-runs/promptfoo.json
+++ b/tests/calibration/eval-hallucination-rate/eval-runs/promptfoo.json
@@ -1,0 +1,70 @@
+{
+  "evalId": "calibration-hallucination",
+  "createdAt": 1735689600,
+  "results": [
+    {
+      "id": "case-001",
+      "description": "summarise the policy",
+      "success": true,
+      "score": 1.0,
+      "namedScores": { "faithfulness": 0.95 }
+    },
+    {
+      "id": "case-002",
+      "description": "summarise the policy",
+      "success": false,
+      "score": 0.0,
+      "namedScores": { "faithfulness": 0.10 },
+      "failureReason": "model fabricated unsourced claims"
+    },
+    {
+      "id": "case-003",
+      "description": "summarise the policy",
+      "success": false,
+      "score": 0.0,
+      "namedScores": { "faithfulness": 0.20 },
+      "failureReason": "ungrounded answer not supported by the context"
+    },
+    {
+      "id": "case-004",
+      "description": "summarise the policy",
+      "success": false,
+      "score": 0.0,
+      "namedScores": { "faithfulness": 0.05 },
+      "failureReason": "hallucinated entity not in source"
+    },
+    {
+      "id": "case-005",
+      "description": "summarise the policy",
+      "success": true,
+      "score": 1.0,
+      "namedScores": { "faithfulness": 0.92 }
+    },
+    {
+      "id": "case-006",
+      "description": "summarise the policy",
+      "success": true,
+      "score": 1.0,
+      "namedScores": { "faithfulness": 0.97 }
+    },
+    {
+      "id": "case-007",
+      "description": "summarise the policy",
+      "success": true,
+      "score": 1.0,
+      "namedScores": { "faithfulness": 0.99 }
+    },
+    {
+      "id": "case-008",
+      "description": "summarise the policy",
+      "success": true,
+      "score": 1.0,
+      "namedScores": { "faithfulness": 0.90 }
+    }
+  ],
+  "stats": {
+    "successes": 5,
+    "failures": 3,
+    "errors": 0
+  }
+}

--- a/tests/calibration/eval-hallucination-rate/labels.yaml
+++ b/tests/calibration/eval-hallucination-rate/labels.yaml
@@ -1,0 +1,15 @@
+schemaVersion: 1
+fixture: eval-hallucination-rate
+description: |
+  A Promptfoo eval result file shows 3 of 8 cases (37.5%) hallucinated
+  — failure reasons mention "fabricated", "ungrounded", "hallucinated".
+  The default threshold is 5%, so the rate is well over. The detector
+  fires aiHallucinationRate on the run.
+
+  This is the first calibration fixture exercising the eval-data
+  ingestion path: the runner auto-discovers eval-runs/promptfoo.json
+  in the fixture root and feeds it to the pipeline as PromptfooPaths.
+expected:
+  - type: aiHallucinationRate
+    file: eval-runs/promptfoo.json
+    notes: "3/8 cases hallucinated, 37.5% > 5% threshold"

--- a/tests/calibration/eval-retrieval-regression/baseline/eval-runs/promptfoo.json
+++ b/tests/calibration/eval-retrieval-regression/baseline/eval-runs/promptfoo.json
@@ -1,0 +1,12 @@
+{
+  "evalId": "calibration-retrieval",
+  "createdAt": 1735603200,
+  "results": [
+    { "id": "case-1", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.91, "faithfulness": 0.93, "answer_relevancy": 0.90 } },
+    { "id": "case-2", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.88, "faithfulness": 0.92, "answer_relevancy": 0.89 } },
+    { "id": "case-3", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.93, "faithfulness": 0.95, "answer_relevancy": 0.92 } },
+    { "id": "case-4", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.86, "faithfulness": 0.91, "answer_relevancy": 0.88 } },
+    { "id": "case-5", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.90, "faithfulness": 0.94, "answer_relevancy": 0.91 } }
+  ],
+  "stats": { "successes": 5, "failures": 0, "errors": 0 }
+}

--- a/tests/calibration/eval-retrieval-regression/eval-runs/promptfoo.json
+++ b/tests/calibration/eval-retrieval-regression/eval-runs/promptfoo.json
@@ -1,0 +1,12 @@
+{
+  "evalId": "calibration-retrieval",
+  "createdAt": 1735689600,
+  "results": [
+    { "id": "case-1", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.62, "faithfulness": 0.93, "answer_relevancy": 0.88 } },
+    { "id": "case-2", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.55, "faithfulness": 0.92, "answer_relevancy": 0.86 } },
+    { "id": "case-3", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.68, "faithfulness": 0.95, "answer_relevancy": 0.90 } },
+    { "id": "case-4", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.51, "faithfulness": 0.91, "answer_relevancy": 0.85 } },
+    { "id": "case-5", "success": true, "score": 1.0, "namedScores": { "context_relevance": 0.60, "faithfulness": 0.94, "answer_relevancy": 0.89 } }
+  ],
+  "stats": { "successes": 5, "failures": 0, "errors": 0 }
+}

--- a/tests/calibration/eval-retrieval-regression/labels.yaml
+++ b/tests/calibration/eval-retrieval-regression/labels.yaml
@@ -1,0 +1,13 @@
+schemaVersion: 1
+fixture: eval-retrieval-regression
+description: |
+  Two paired Promptfoo runs, same five CaseIDs across both. The
+  context_relevance retrieval axis dropped from avg ≈0.90 → ≈0.59
+  (-31 pts vs the 5-pt default threshold). faithfulness and
+  answer_relevancy stayed within tolerance. aiRetrievalRegression
+  must fire on the current run, naming context_relevance as the
+  regressed axis.
+expected:
+  - type: aiRetrievalRegression
+    file: eval-runs/promptfoo.json
+    notes: "context_relevance avg 0.90 → 0.59 (-31 pts vs 5-pt threshold)"


### PR DESCRIPTION
## Summary

Closes the eval-data-detector calibration gap from PR #123's followups.
Three detectors that ingest framework eval results now have anchors in the
calibration corpus: `aiHallucinationRate`, `aiCostRegression`, and
`aiRetrievalRegression`. With these landed, all 12/12 AI detectors from the
round-4 plan have at least one calibration fixture at 1.00 precision/recall.

## Changes

- **Calibration runner extension**: auto-discovers per-fixture eval artifacts
  (`eval-runs/{promptfoo,deepeval,ragas}.json` and `baseline.json`) and feeds
  them to the pipeline as `PipelineOptions`. Fixtures without these files
  behave as before.

- **Path-relative matching in `matchFixture`**: eval-data detectors stamp the
  artifact's absolute path into `Signal.Location.File`; the matcher now
  normalises against the fixture dir so labels stay portable.

- **Baseline-from-fixture helper**: `buildBaselineFile` synthesises a baseline
  snapshot from `baseline/eval-runs/{promptfoo,deepeval,ragas}.json` rather
  than requiring a hand-written snapshot JSON with base64-encoded payloads.
  Regression-shaped fixtures only need two pairs of framework JSON files.

- **Three new calibration fixtures**:
  - `eval-hallucination-rate` — Promptfoo run with 3/8 hallucinated cases
    (37.5% > 5% threshold).
  - `eval-cost-regression` — paired runs, avg cost-per-case rose
    0.0028 → 0.0084 (+200% vs 25% threshold).
  - `eval-retrieval-regression` — paired runs with `context_relevance` avg
    dropping 0.90 → 0.59 (−31 pts vs 5-pt threshold).

## Corpus state after merge

- 27 fixtures × 33 distinct signal types at 1.00 precision/recall
- All 12/12 AI detectors covered
- Calibration gate is load-bearing — any future change that drops a labelled
  signal trips CI.

## Test plan

- [x] `make calibrate` reports 27/33 at 100%
- [x] `go test ./internal/... ./cmd/... -count=1` clean locally
- [ ] CI green on Ubuntu / macOS / Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)