### PR TITLE
fix(0.2): truth-up the public surface before tag

### DIFF
--- a/.github/workflows/terrain-ai.yml
+++ b/.github/workflows/terrain-ai.yml
@@ -1,4 +1,4 @@
-name: Terrain AI Validation
+name: Terrain AI Risk Review
 
 on:
   pull_request:
@@ -60,7 +60,7 @@ jobs:
           # Check which AI surfaces are affected by this change
           ./terrain pr --base "${{ github.event.pull_request.base.sha }}" --json > /tmp/pr-analysis.json
 
-          # Extract AI validation section
+          # Extract AI risk review section
           AI_SELECTED=$(jq '.ai.selectedScenarios // 0' /tmp/pr-analysis.json)
           AI_TOTAL=$(jq '.ai.totalScenarios // 0' /tmp/pr-analysis.json)
           UNCOVERED=$(jq '[.ai.uncoveredContexts // [] | length] | add' /tmp/pr-analysis.json)
@@ -84,14 +84,14 @@ jobs:
           echo "action=$ACTION" >> "$GITHUB_OUTPUT"
           echo "reason=$REASON" >> "$GITHUB_OUTPUT"
 
-      - name: Generate AI validation comment
+      - name: Generate AI risk review comment
         id: ai-comment
         if: steps.ai-check.outputs.skip != 'true'
         run: |
           {
             echo 'body<<TERRAIN_AI_EOF'
-            echo '<!-- terrain-ai-validation -->'
-            echo '### Terrain AI Validation'
+            echo '<!-- terrain-ai-risk-review -->'
+            echo '### Terrain AI Risk Review'
             echo ''
 
             TOTAL="${{ steps.ai-check.outputs.total_surfaces }}"
@@ -118,11 +118,11 @@ jobs:
             echo ''
 
             if [ "$ACTION" = "block" ]; then
-              echo '**Decision: BLOCKED** — AI validation failed.'
+              echo '**Decision: BLOCKED** — AI risk review found blocking signals.'
               echo ''
               echo "Reason: ${{ steps.ai-run.outputs.reason }}"
             elif [ "$ACTION" = "warn" ]; then
-              echo '**Decision: WARNING** — Review AI validation results.'
+              echo '**Decision: WARNING** — review the AI risk findings before merging.'
               echo ''
               echo "Reason: ${{ steps.ai-run.outputs.reason }}"
             else
@@ -139,7 +139,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: '<!-- terrain-ai-validation -->'
+          body-includes: '<!-- terrain-ai-risk-review -->'
 
       - name: Post or update AI comment
         if: steps.ai-check.outputs.skip != 'true'
@@ -153,5 +153,5 @@ jobs:
       - name: Fail if AI gate blocks
         if: steps.ai-run.outputs.action == 'block'
         run: |
-          echo "::error::Terrain AI validation blocked this PR: ${{ steps.ai-run.outputs.reason }}"
+          echo "::error::Terrain AI risk review blocked this PR: ${{ steps.ai-run.outputs.reason }}"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,65 @@ Post-0.2 work tracked separately.
 ## [0.2.0] — 2026-05-02 — AI parity, calibration gate, CLI compression
 
 The release that turns Terrain's AI story into something testable. Twelve
-new AI detectors ship with calibration anchors at 100% precision/recall
-on a 27-fixture corpus; the CLI surface compresses 35→11 commands; the
+new AI detectors ship with calibration anchors at **100% recall on a
+27-fixture corpus** (the gate is a recall regression gate; per-detector
+*precision* floors against a labeled-repo corpus are deferred to 0.3 —
+see `docs/release/0.2-known-gaps.md`). The CLI surface compresses 35→11
+canonical commands while keeping every legacy alias working. The
 calibration runner becomes a load-bearing regression gate. Per
 `docs/release/0.2.md`.
+
+### What's stable in 0.2
+
+Read this before adopting 0.2 in CI. Source of truth for per-feature
+detail is `docs/release/feature-status.md`.
+
+**Stable** — covered by tests, documented behavior, won't change shape
+in 0.2.x:
+
+- repository scan + framework detection (Tier-1 frameworks)
+- snapshot generation + schema versioning
+- signal registry + manifest export
+- AI surface inventory (prompt/agent/tool/context/eval/model/scenario)
+- Promptfoo / DeepEval / Ragas eval-artifact ingestion
+- recall regression gate via the 27-fixture calibration corpus
+- 10 of 12 new AI detectors marked `[stable]`
+- canonical 11-command CLI shape (legacy aliases still work; removal
+  targets 0.3)
+
+**Experimental** — useful but not yet hardened; expect signal/UX
+changes:
+
+- `aiPromptInjectionRisk` and `aiFewShotContamination` detectors
+  (regex-based; AST-grade taint is 0.3 work)
+- `terrain serve` local HTTP server (no auth model, localhost-only)
+- `terrain portfolio` multi-repo analysis
+- portfolio-level scoring thresholds
+- AI surface inference *precision* (recall is calibration-anchored;
+  precision against a labeled-repo corpus is 0.3)
+
+**Planned (0.3)**:
+
+- per-detector precision benchmarking against a labeled-repo corpus
+- AST-grade taint analysis for prompt injection
+- suppression model (`.terrain/suppressions.yaml`) and the false-
+  positive workflow it enables
+- `terrain ai gate` standalone command
+- plugin architecture for community adapters
+- sandboxing for eval execution
+- removal of the legacy CLI aliases (with a 0.2.x deprecation runway)
 
 ### AI detector batch (12/12 from the round-4 plan)
 
 10 ship `[stable]`, 2 ship `[experimental]`. 11 of 12 carry calibration
-anchors at 1.00 precision/recall on the per-detector fixture corpus;
-`aiHardcodedAPIKey` ships without a fixture (constructing a non-example
-real-shaped key would risk repository secret-scanner alerts — see
+anchors at **1.00 recall** on the per-detector fixture corpus; precision
+on the same corpus is also 1.00, but the fixture corpus is small (27
+fixtures) and only labeled signals participate, so the precision number
+should be read as "the detectors don't fire spuriously on the *seeded*
+shapes" rather than as a real-world precision floor. The labeled-repo
+precision benchmark is 0.3 work. `aiHardcodedAPIKey` ships without a
+calibration fixture (constructing a non-example real-shaped key would
+risk repository secret-scanner alerts — see
 `docs/release/0.2-known-gaps.md` for the calibration plan in 0.3).
 
 - **`aiHardcodedAPIKey`** `[stable]` — config files leaking provider API
@@ -232,14 +280,18 @@ Drift fails `make docs-verify` (CI gate).
 - **`terrain ai run` captures eval framework output** to
   `.terrain/artifacts/`.
 - **Cosign keyless signing + npm provenance + SLSA attestations** on
-  every release archive. *Caveat*: the npm postinstaller verifier
-  (`bin/terrain-installer.js`) **degrades to checksum-only** when
-  `cosign` is not installed on the host (returns
-  `verified: false, reason: 'cosign-missing'`) rather than aborting.
-  The hard-fail framing in `docs/release/0.2.md` overstates the
-  current behavior. Promoting to mandatory cosign verification
-  (with `TERRAIN_INSTALLER_SKIP_VERIFY=1` as the documented
-  escape) is on the 0.2.x list.
+  every release archive. The npm postinstall verifier
+  (`bin/terrain-installer.js`) requires cosign by default and
+  hard-fails when it isn't on `PATH`. Two opt-out env vars are
+  supported and documented in the failure message:
+  `TERRAIN_INSTALLER_ALLOW_MISSING_COSIGN=1` for checksum-only
+  verification, `TERRAIN_INSTALLER_SKIP_VERIFY=1` to skip
+  verification entirely. *Known UX gap (tracked for 0.2.1)*:
+  `bin/postinstall.js` currently catches the verifier error and
+  prints a warning rather than failing `npm install`, so a host
+  without cosign gets a successful install + a deferred fetch
+  retry on first run. Either propagating the failure or surfacing
+  it loudly on first run is on the 0.2.1 list.
 
 ### Changed
 
@@ -611,7 +663,7 @@ AI surfaces receive the same CI treatment as regular tests:
 - Impact selection: `terrain ai run --base main` selects only impacted eval scenarios
 - Protection gaps: changed AI surfaces without eval coverage appear in `terrain impact` and `terrain pr`
 - Policy enforcement: 7 AI-specific policy rules (`block_on_safety_failure`, `block_on_uncovered_context`, etc.)
-- PR comments: AI Validation section in `terrain pr` output (markdown + text)
+- PR comments: AI Risk Review section in `terrain pr` output (markdown + text)
 - GitHub Action: `terrain-ai.yml` template for AI CI gates
 - Health insights: uncovered AI surfaces appear in `terrain insights`
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,34 @@
 # Terrain
 
-**Map your test terrain.** Understand your test system in 30 seconds.
+**Map your test terrain.** Understand your test system in seconds — typical
+service repos in 5–15s, large monorepos take longer (the headline "30
+seconds" claim refers to repos ≤ 1,000 test files; see Performance below).
 
 ```bash
 # Homebrew
 brew install pmclSF/terrain/mapterrain
 
-# npm
+# npm — note: requires cosign on PATH for signed-binary verification.
+# brew install cosign  (macOS / Linux)
+# scoop install cosign (Windows)
+# Set TERRAIN_INSTALLER_ALLOW_MISSING_COSIGN=1 to fall back to checksum-only,
+# or TERRAIN_INSTALLER_SKIP_VERIFY=1 to skip verification entirely.
 npm install -g mapterrain
 
 cd your-repo
 terrain analyze
 ```
 
-That's it. No config, no setup, no test execution required.
+No config and no test execution are required for the basic scan. Stronger
+findings (runtime health, eval regression, policy enforcement) are unlocked
+by optional artifacts; degrade gracefully when absent.
 
 > **New here?** Read the [Quickstart Guide](docs/quickstart.md) to understand your first report in 5 minutes.
+> **What ships in 0.2?** See [What 0.2 is and isn't](#what-02-is-and-isnt) below before adopting in CI.
 
 ---
 
-Terrain is a test system intelligence platform. It reads your repository — test code, source structure, coverage data, runtime artifacts, ownership files, and local policy — and builds a structural model of how your tests relate to your code. From that model it surfaces risk, quality gaps, redundancy, fragile dependencies, and migration readiness, all without running a single test.
+Terrain is a test system intelligence platform. It reads your repository — test code, source structure, and (when available) coverage data, runtime artifacts, ownership files, and local policy — and builds a structural model of how your tests relate to your code. From that model it surfaces risk, quality gaps, redundancy, fragile dependencies, and migration readiness on a best-effort basis without running a single test.
 
 The core idea: every codebase has a *test terrain* — the shape of its testing infrastructure, the density of coverage across areas, the hidden fault lines where a fixture change cascades into thousands of tests. Terrain makes that shape visible and navigable so you can make informed decisions about what to test, what to fix, and where to invest.
 
@@ -214,9 +223,45 @@ It's worth stating what Terrain *doesn't* try to do, because the test-tooling sp
 - **Not an LLM eval framework.** Terrain understands AI surfaces (prompts, scenarios, RAG pipelines) and the eval *artifacts* that promptfoo / DeepEval / Ragas produce, but it doesn't run the evals itself. Use those tools to execute; use Terrain to analyze what they produce in CI.
 - **Not a test-flake whack-a-mole tool.** Terrain reports flakiness as a signal among many. If your only need is "rerun flaky tests until they pass", point-tools like `pytest-rerunfailures` or `jest-circus` ship that directly.
 - **Not a developer-productivity dashboard.** Terrain measures the test system, not the people writing tests. It deliberately produces no leaderboards, no per-developer metrics, no "engineer productivity" rankings. Ownership data is used for routing, not scoring.
-- **Not a service.** Terrain runs locally and in your CI. There is no SaaS offering, no telemetry sent off your infrastructure, no account required. Reports stay where you produce them.
+- **Not a service.** Terrain analysis is local. No SaaS, no analytics, no account required. Reports stay where you produce them. (Note: `npm install -g mapterrain` and `brew install` download signed binaries from GitHub Releases as part of installation; analysis itself does not phone home.)
 
 If you're evaluating Terrain against another tool and the boundary isn't obvious, please open an issue — we'll write the comparison entry under `docs/compare/`.
+
+## What 0.2 Is and Isn't
+
+Read this before adopting in CI. Source of truth per-feature is
+[`docs/release/feature-status.md`](docs/release/feature-status.md);
+this is the summary view.
+
+**Stable in 0.2** — covered by tests, documented behavior, won't change
+shape in 0.2.x:
+
+- repository scan + framework detection (Tier-1 frameworks)
+- snapshot generation + schema versioning
+- signal registry + manifest export
+- AI surface inventory (prompt / agent / tool / context / eval / model / scenario)
+- Promptfoo / DeepEval / Ragas eval-artifact ingestion
+- recall regression gate via the 27-fixture calibration corpus
+- 10 of the 12 new AI detectors marked `[stable]`
+- canonical 11-command CLI shape (legacy aliases still work; removal targets 0.3)
+
+**Experimental** — useful but not yet hardened; expect signal/UX changes:
+
+- `aiPromptInjectionRisk` and `aiFewShotContamination` detectors (regex-based; AST-grade taint is 0.3)
+- `terrain serve` local HTTP server (no auth, localhost-only, single-developer use)
+- `terrain portfolio` multi-repo analysis
+- portfolio-level scoring thresholds
+- AI surface inference *precision* (recall is calibration-anchored; precision against a labeled-repo corpus is 0.3)
+
+**Planned for 0.3**:
+
+- per-detector precision benchmarking against a labeled-repo corpus
+- AST-grade taint analysis for prompt injection
+- suppression model (`.terrain/suppressions.yaml`) and the false-positive workflow it enables
+- `terrain ai gate` standalone command
+- plugin architecture for community adapters
+- sandboxing for eval execution
+- removal of the legacy CLI aliases (with a 0.2.x deprecation runway)
 
 ## Who Uses Terrain
 
@@ -448,7 +493,7 @@ jobs:
 | `terrain summary` | Executive summary with risk, trends, benchmark readiness |
 | `terrain focus` | Prioritized next actions |
 | `terrain posture` | Detailed posture breakdown with measurement evidence |
-| `terrain portfolio` | Portfolio intelligence: cost, breadth, leverage, redundancy |
+| `terrain portfolio` | Portfolio intelligence: cost, breadth, leverage, redundancy. *(Top-level canonical command, but feature-status: experimental — multi-repo rollups solidify in 0.3.)* |
 | `terrain metrics` | Aggregate metrics scorecard |
 | `terrain compare` | Compare two snapshots for trend tracking |
 | `terrain select-tests` | Recommend protective test set for a change |

--- a/cmd/terrain/cmd_serve.go
+++ b/cmd/terrain/cmd_serve.go
@@ -13,18 +13,18 @@ import (
 // runServe starts the local Terrain HTTP server.
 //
 // The server is intended for single-developer use on a trusted machine.
-// For 0.1.2 it is marked [experimental] in feature-status.md because the
-// HTML dashboard surface is still minimal; flags exist now so 0.2 work
-// can extend behavior without breaking the CLI contract.
+// It is marked [experimental] in feature-status.md and ships with
+// **no authentication** — security relies on localhost-only binding
+// (127.0.0.1 by default) plus origin/referer checks. Do not expose it
+// on a multi-user machine without external auth (e.g. an SSH tunnel).
+// Not production-ready; not a "team dashboard."
 //
 // Flags wired through to internal/server.Config:
 //
 //	--root      repository root to analyze
 //	--port      bind port (default 8421)
 //	--host      bind host (default 127.0.0.1; opt-in for non-localhost)
-//	--read-only forbid future state-changing API endpoints (today a no-op,
-//	             reserved so users who flip it now keep their guarantees
-//	             when 0.2 introduces write APIs)
+//	--read-only enforce HTTP 405 on state-changing endpoints (active in 0.2)
 func runServe(root string, port int, host string, readOnly bool) error {
 	absRoot, err := filepath.Abs(root)
 	if err != nil {

--- a/docs/architecture/19-ai-scenario-and-eval-model.md
+++ b/docs/architecture/19-ai-scenario-and-eval-model.md
@@ -17,7 +17,7 @@
 
 ### Graph Nodes
 
-Five node types support AI validation in the dependency graph:
+Five node types support AI risk review in the dependency graph:
 
 | Node Type | Family | Status | Purpose |
 |-----------|--------|--------|---------|
@@ -31,7 +31,7 @@ Scenario nodes implement `ValidationTarget` and participate in all validation qu
 
 ### Reasoning Path
 
-The full AI validation reasoning path traverses five graph families:
+The full AI risk review reasoning path traverses five graph families:
 
 ```
 CodeSurface → BehaviorSurface → Scenario → Environment → ExecutionRun

--- a/docs/cli-spec.md
+++ b/docs/cli-spec.md
@@ -490,8 +490,8 @@ Two workflow templates are provided in `.github/workflows/`:
 ### `terrain-pr.yml` — Test Selection Gate
 Runs on every PR. Analyzes impact, selects relevant tests, runs them, and posts a PR comment with the results.
 
-### `terrain-ai.yml` — AI Validation Gate
-Runs on every PR. Checks AI surface coverage, runs impact-scoped eval scenario selection, and posts a PR comment with AI validation results. Blocks the PR if the AI gate returns "block" (uncovered safety-critical surfaces, accuracy regressions, etc.).
+### `terrain-ai.yml` — AI Risk Review Gate
+Runs on every PR. Checks AI surface coverage, runs impact-scoped eval scenario selection, and posts a PR comment summarizing the AI risk review (uncovered surfaces, blocking signals, eval regressions). Blocks the PR if the gate returns "block" (uncovered safety-critical surfaces, accuracy regressions, etc.). The 0.2 detector set is regex/heuristic for the AI surface area; AST-grade taint analysis and labeled-repo precision floors land in 0.3.
 
 Both workflows are opt-in — copy them to your repository's `.github/workflows/` directory to enable.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,12 +10,19 @@ installer) ship for:
 
 | OS | Architectures | Tier |
 |----|---------------|------|
-| Linux | amd64, arm64 | Tier 1 (full CI matrix) |
-| macOS | amd64, arm64 | Tier 1 (full CI matrix) |
-| Windows | amd64 | Tier 1 (full CI matrix) |
+| Linux | amd64, arm64 | Tier 1 (extended CI: race detector, determinism, smoke) |
+| macOS | amd64, arm64 | Tier 1 binary target (CI: unit-test parity) |
+| Windows | amd64 | Tier 1 binary target (CI: unit-test parity) |
 | Windows arm64 | — | Not built (planned 0.3) |
 
-Tier 1 means CI runs `go test ./...` on every PR before merge.
+Tier 1 means a pre-built binary ships for that OS/arch and `go test
+./...` runs in CI on every PR before merge. Extended gates (race
+detector, byte-identical determinism check, post-release smoke) run on
+Linux only today; macOS and Windows are unit-test parity. The
+linux/amd64 release archive is the only platform smoke-tested
+post-publish — extending to darwin/arm64 and windows/amd64 is on the
+0.2.x release-workflow list.
+
 Source builds work on any platform Go 1.23+ supports.
 
 ## Build-time
@@ -33,7 +40,9 @@ Source builds work on any platform Go 1.23+ supports.
 
 Terrain's `analyze` command structurally models tests for the
 following frameworks. "Tier" reflects fixture coverage in the
-calibration corpus and conversion-direction A-grade ratings.
+calibration corpus. (Conversion-direction A-grade ratings, originally
+planned to feed this tier, slipped to 0.3 — see `CHANGELOG.md`
+"Deferred to 0.3".)
 
 | Framework | Language | Tier |
 |-----------|----------|------|

--- a/docs/integrations/gauntlet.md
+++ b/docs/integrations/gauntlet.md
@@ -98,7 +98,7 @@ terrain analyze --root . \
 ### AI Workflow
 
 ```bash
-# 1. See what Terrain knows about your AI validation
+# 1. See what Terrain knows about your AI risk review
 terrain ai list
 
 # 2. Run Gauntlet execution

--- a/docs/personas/frontend.md
+++ b/docs/personas/frontend.md
@@ -21,7 +21,7 @@ weak points are.
 - **Mock-heavy unit tests** — components mocked so deeply the test
   validates the mock instead of the component (`mockHeavyTest`).
 - **Snapshot saturation** — components with ten snapshots and zero
-  behavioural assertions (`snapshotHeavyTest`). Snapshots are valid;
+  behavioral assertions (`snapshotHeavyTest`). Snapshots are valid;
   ten of them on one component usually isn't.
 - **Coverage blind spots** — exported components with no test, or
   tested only at the E2E layer (slow, brittle, expensive

--- a/docs/product/terrain-overview.md
+++ b/docs/product/terrain-overview.md
@@ -142,7 +142,7 @@ Terrain now ships the framework conversion and migration surface directly in the
 - **6 AI commands** — ai list, ai doctor, ai run, ai replay, ai record, ai baseline
 - **5 debug commands** — debug graph, coverage, fanout, duplicates, depgraph
 
-**AI Validation:**
+**AI Risk Review:**
 - **Scenario model** — first-class validation targets alongside tests
 - **Prompt and dataset inference** — naming convention detection in JS/TS and Python
 - **Scenario impact detection** — changed prompt/dataset surfaces mapped to impacted scenarios

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,7 +147,7 @@ terrain ai run --base main --dry-run
 terrain ai doctor
 ```
 
-Terrain gives AI surfaces the same CI treatment as regular tests — impact-scoped selection, protection gap detection, and policy enforcement.
+Terrain starts giving AI surfaces CI-visible structure: inventory, impact-scoped eval selection where configured, protection-gap detection, and reviewable risk signals. Suppression workflows and labeled-repo precision floors are 0.3 work — see [`docs/release/0.2-known-gaps.md`](release/0.2-known-gaps.md) for what 0.2 covers and what it doesn't.
 
 ## The four primary questions
 

--- a/docs/rules/ai/prompt-injection-risk.md
+++ b/docs/rules/ai/prompt-injection-risk.md
@@ -13,7 +13,7 @@ User-controlled input is concatenated into a prompt without escaping, system-pro
 
 ## Remediation
 
-Use a prompt template with explicit user-content boundaries, or run user input through a sanitiser.
+Use a prompt template with explicit user-content boundaries, or run user input through a sanitizer.
 
 ## Promotion plan
 
@@ -112,7 +112,7 @@ prompt = (
 ## Why it might be a false positive
 
 - The "user input" variable is actually trusted (e.g. a hard-coded
-  config value, or already-sanitised). Add an `expectedAbsent` entry
+  config value, or already-sanitized). Add an `expectedAbsent` entry
   in the relevant calibration fixture.
 - The `prompt` variable name is reused for something that isn't
   actually a prompt (e.g. a CLI prompt string). Rename or add a
@@ -124,5 +124,5 @@ prompt = (
   AST-precise taint analysis lands in 0.3.
 - Skips comment-only lines. A genuinely vulnerable line that ends
   with a trailing `# explanatory comment` is still flagged.
-- Doesn't recognize framework-specific sanitisers — your
+- Doesn't recognize framework-specific sanitizers — your
   `escape(user_input)` is treated identically to the bare value.

--- a/docs/rules/ai/safety-eval-missing.md
+++ b/docs/rules/ai/safety-eval-missing.md
@@ -91,7 +91,7 @@ once the scenario covers the surface.
 ## Why it might be a false positive
 
 - The surface is a non-user-facing prompt (e.g. an internal tool's
-  prompt that takes only sanitised input). Mark the surface as such
+  prompt that takes only sanitized input). Mark the surface as such
   via the `safety_required: false` field on the surface declaration,
   or add an `expectedAbsent: aiSafetyEvalMissing` entry in the
   calibration fixture.

--- a/docs/signals/manifest.json
+++ b/docs/signals/manifest.json
@@ -1016,7 +1016,7 @@
       "status": "experimental",
       "title": "Prompt-Injection-Shaped Concatenation",
       "description": "User-controlled input is concatenated into a prompt without escaping, system-prompt boundaries, or structured input boundaries.",
-      "remediation": "Use a prompt template with explicit user-content boundaries, or run user input through a sanitiser.",
+      "remediation": "Use a prompt template with explicit user-content boundaries, or run user input through a sanitizer.",
       "defaultSeverity": "high",
       "confidenceMin": 0.6,
       "confidenceMax": 0.85,

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -34,14 +34,18 @@ The local file exists so you (or your team) can optionally analyze usage pattern
 
 ```bash
 # Check current status
-terrain telemetry
+terrain config telemetry
 
 # Enable
-terrain telemetry --on
+terrain config telemetry --on
 
 # Disable
-terrain telemetry --off
+terrain config telemetry --off
 ```
+
+The bare `terrain telemetry` form is a legacy alias and prints a
+deprecation hint when `TERRAIN_LEGACY_HINT=1` is set. Removal targets
+0.3.
 
 Or set the environment variable (overrides file config):
 

--- a/docs/user-guides/getting-started.md
+++ b/docs/user-guides/getting-started.md
@@ -1,11 +1,40 @@
 # Getting Started with Terrain
 
+## Prerequisites
+
+The npm install path verifies signed binaries with cosign before
+extracting them. Cosign needs to be on `PATH` before you run `npm
+install`:
+
+```bash
+# macOS / Linux
+brew install cosign
+# Linux (Debian/Ubuntu)
+apt-get install cosign     # 22.04+; otherwise use the Sigstore release
+# Windows
+scoop install cosign
+```
+
+If you can't or don't want to install cosign, two opt-out env vars
+are recognized by the npm installer:
+
+| Env var | Effect |
+|---------|--------|
+| `TERRAIN_INSTALLER_ALLOW_MISSING_COSIGN=1` | Falls back to checksum-only verification |
+| `TERRAIN_INSTALLER_SKIP_VERIFY=1` | Skips verification entirely (not recommended) |
+
+Homebrew and `go install` paths handle their own verification and
+do not need cosign on `PATH`.
+
+See [`docs/release/supply-chain.md`](../release/supply-chain.md) for
+the full signing / attestation story.
+
 ## Install
 
 ```bash
 brew install pmclSF/terrain/mapterrain
 # or
-npm install -g mapterrain
+npm install -g mapterrain          # see Prerequisites above re: cosign
 # or
 go install github.com/pmclSF/terrain/cmd/terrain@latest
 ```

--- a/internal/aidetect/prompt_injection.go
+++ b/internal/aidetect/prompt_injection.go
@@ -111,7 +111,7 @@ func (d *PromptInjectionDetector) Detect(snap *models.TestSuiteSnapshot) []model
 				Confidence:  0.7,
 				Location:    models.SignalLocation{File: relPath, Line: h.Line},
 				Explanation: h.Explanation,
-				SuggestedAction: "Use a prompt template with explicit user-content boundaries, or run user input through a sanitiser before concatenation.",
+				SuggestedAction: "Use a prompt template with explicit user-content boundaries, or run user input through a sanitizer before concatenation.",
 
 				SeverityClauses: []string{"sev-high-003"},
 				Actionability:   models.ActionabilityScheduled,
@@ -194,7 +194,7 @@ func scanFileForPromptInjection(path string) []injectionHit {
 				window += "\n" + lines[i+j]
 			}
 			if hasUserInputShape(window) {
-				explanation := "User-controlled input concatenated into a prompt-shaped variable without visible sanitisation."
+				explanation := "User-controlled input concatenated into a prompt-shaped variable without visible sanitization."
 				if !hasUserInputShape(text) {
 					explanation = "Prompt-shaped variable on this line is followed by user-controlled input on the next line(s); review concatenation for escape boundaries."
 				}

--- a/internal/aidetect/prompt_injection_test.go
+++ b/internal/aidetect/prompt_injection_test.go
@@ -54,7 +54,7 @@ function handle(req, res) {
 func TestPromptInjection_IgnoresClean(t *testing.T) {
 	t.Parallel()
 
-	// Templated prompt with sanitised input — no concatenation, no
+	// Templated prompt with sanitized input — no concatenation, no
 	// f-string boundary issue.
 	root := t.TempDir()
 	rel := writeFile(t, root, "agent.py", `
@@ -68,7 +68,7 @@ def chat(user_input):
 	got := (&PromptInjectionDetector{Root: root}).Detect(&models.TestSuiteSnapshot{
 		TestFiles: []models.TestFile{{Path: rel}},
 	})
-	// .format() with sanitised input should not fire — neither pattern
+	// .format() with sanitized input should not fire — neither pattern
 	// matches user_input on the .format line.
 	if len(got) != 0 {
 		t.Errorf("clean handler should not fire, got %d signals: %+v", len(got), got)

--- a/internal/airun/artifact.go
+++ b/internal/airun/artifact.go
@@ -1,4 +1,4 @@
-// Package airun implements the artifact model for AI validation runs,
+// Package airun implements the artifact model for AI risk review runs,
 // including content hashing for reproducibility and replay support.
 package airun
 

--- a/internal/changescope/analyze.go
+++ b/internal/changescope/analyze.go
@@ -49,7 +49,7 @@ func AnalyzePR(scope *impact.ChangeScope, snap *models.TestSuiteSnapshot) *PRAna
 	// Build posture delta.
 	pr.PostureDelta = buildPostureDelta(result)
 
-	// Build AI validation summary.
+	// Build AI risk review summary.
 	pr.AI = buildAIValidationSummary(result, snap)
 
 	// Build summary.

--- a/internal/changescope/changescope_test.go
+++ b/internal/changescope/changescope_test.go
@@ -524,7 +524,7 @@ func TestBuildAIValidationSummary_WithScenarios(t *testing.T) {
 }
 
 // TestBuildAIValidationSummary_WithSignals locks in the contract that
-// the AI validation summary in `terrain pr` output is impact-scoped:
+// the AI risk review summary in `terrain pr` output is impact-scoped:
 // only AI signals whose Location.File appears in the PR's changed-
 // files set are reported as Blocking / Warning. Pre-fix the loop
 // included every AI signal in the snapshot, so a doc-only PR

--- a/internal/changescope/dedup_test.go
+++ b/internal/changescope/dedup_test.go
@@ -329,7 +329,7 @@ func TestSummarizeFindingsBySeverity(t *testing.T) {
 // --- AI PR Section Tests ---
 
 // TestRenderPRSummaryMarkdown_AISection asserts the 0.2 contract for
-// the AI Validation section in `terrain pr --format markdown` output.
+// the AI Risk Review section in `terrain pr --format markdown` output.
 //
 // Pre-fix the section dumped one bullet per signal with the detector
 // taxonomy (`aiPromptInjectionRisk`) as the headline and no file
@@ -377,8 +377,8 @@ func TestRenderPRSummaryMarkdown_AISection(t *testing.T) {
 	output := buf.String()
 
 	// Section header.
-	if !strings.Contains(output, "### AI Validation") {
-		t.Error("expected AI Validation section")
+	if !strings.Contains(output, "### AI Risk Review") {
+		t.Error("expected AI Risk Review section")
 	}
 	// Capabilities + scenario count framing.
 	if !strings.Contains(output, "refund-explanation") || !strings.Contains(output, "enterprise-search") {
@@ -435,7 +435,7 @@ func TestRenderPRSummaryMarkdown_NoAISection(t *testing.T) {
 	RenderPRSummaryMarkdown(&buf, pr)
 	output := buf.String()
 
-	if strings.Contains(output, "AI Validation") {
+	if strings.Contains(output, "AI Risk Review") {
 		t.Error("expected no AI section for traditional PR")
 	}
 }
@@ -477,8 +477,8 @@ func TestRenderPRSummaryMarkdown_MixedTraditionalAndAI(t *testing.T) {
 	if !strings.Contains(output, "Recommended tests") {
 		t.Error("expected traditional Recommended tests section")
 	}
-	if !strings.Contains(output, "### AI Validation") {
-		t.Error("expected AI Validation section")
+	if !strings.Contains(output, "### AI Risk Review") {
+		t.Error("expected AI Risk Review section")
 	}
 	if !strings.Contains(output, "search-quality") {
 		t.Error("expected AI scenario in output")

--- a/internal/changescope/model.go
+++ b/internal/changescope/model.go
@@ -65,7 +65,7 @@ type PRAnalysis struct {
 	// Limitations notes data gaps.
 	Limitations []string `json:"limitations,omitempty"`
 
-	// AI holds the AI validation summary for this PR.
+	// AI holds the AI risk review summary for this PR.
 	AI *AIValidationSummary `json:"ai,omitempty"`
 
 	// ImpactResult is the full impact analysis result.

--- a/internal/changescope/render.go
+++ b/internal/changescope/render.go
@@ -31,7 +31,7 @@ import (
 //
 //   ---
 //
-//   ### AI Validation
+//   ### AI Risk Review
 //
 //   ---
 //
@@ -141,7 +141,7 @@ func RenderPRSummaryMarkdown(w io.Writer, pr *PRAnalysis) {
 		renderTestRecommendations(line, pr)
 	}
 
-	// --- AI Validation ---
+	// --- AI Risk Review ---
 	if pr.AI != nil {
 		hr()
 		renderAISection(line, pr)
@@ -175,7 +175,7 @@ func RenderPRSummaryMarkdown(w io.Writer, pr *PRAnalysis) {
 // renderFindingsCards renders up to limit findings using the parallel
 // "card" shape — file path first in code-format, severity badge in
 // line, dash separator, plain description, and an optional action
-// arrow. Matches the AI Validation render so the whole comment has a
+// arrow. Matches the AI Risk Review render so the whole comment has a
 // consistent visual rhythm. Trails a blank line so the next section
 // header has breathing room.
 func renderFindingsCards(line func(string, ...any), findings []ChangeScopedFinding, limit int) {
@@ -401,9 +401,9 @@ func RenderChangeScopedReport(w io.Writer, pr *PRAnalysis) {
 		blank()
 	}
 
-	// AI validation summary.
+	// AI risk review summary.
 	if ai := pr.AI; ai != nil {
-		line("AI Validation")
+		line("AI Risk Review")
 		line(strings.Repeat("-", 40))
 		line("  Scenarios: %d of %d selected", ai.SelectedScenarios, ai.TotalScenarios)
 		if len(ai.ImpactedCapabilities) > 0 {
@@ -453,14 +453,14 @@ func RenderChangeScopedReport(w io.Writer, pr *PRAnalysis) {
 	}
 }
 
-// renderAISection renders the AI validation summary in markdown.
+// renderAISection renders the AI risk review summary in markdown.
 func renderAISection(line func(string, ...any), pr *PRAnalysis) {
 	ai := pr.AI
 	if ai == nil {
 		return
 	}
 
-	line("### AI Validation")
+	line("### AI Risk Review")
 	line("")
 
 	// Compact context line: capabilities + scenarios in one row.

--- a/internal/policy/config.go
+++ b/internal/policy/config.go
@@ -58,7 +58,7 @@ type Rules struct {
 	AI *AIRules `yaml:"ai"`
 }
 
-// AIRules defines CI policy for AI validations.
+// AIRules defines CI policy for AI risk review.
 //
 // Example .terrain/policy.yaml:
 //

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,8 +4,12 @@
 // endpoints at /api/*. By default it binds to localhost only (127.0.0.1)
 // and is intended for local development use, not production deployment.
 //
-// Security posture (0.1.2):
+// Security posture (0.2.0):
 //
+//   - **No authentication.** Security relies entirely on localhost-only
+//     binding plus origin/referer validation. Adopters running on
+//     multi-user hosts must front the server with external auth
+//     (e.g. an SSH tunnel).
 //   - Bind address defaults to 127.0.0.1; opt-in via Config.Host to bind
 //     elsewhere (with a stderr warning).
 //   - Origin / Referer validation on every request rejects cross-origin
@@ -13,13 +17,17 @@
 //     http://127.0.0.1:8421/api/analyze from an unrelated tab return 403.
 //   - Security response headers (CSP, X-Frame-Options, X-Content-Type-Options,
 //     Referrer-Policy) are set on every response.
-//   - Optional read-only flag disables future state-changing endpoints
-//     before they ship in 0.2; today every handler is read-only so the
-//     flag is a no-op gate.
+//   - Read-only flag enforces HTTP 405 on state-changing endpoints.
 //
-// Sandboxing AI eval execution and authentication for shared dev hosts is
-// 0.3 work; until then, do not expose `terrain serve` on a multi-user
-// machine without external auth (e.g. an SSH tunnel).
+// Known issues tracked for 0.2.1:
+//   - The analysis call inside getResult holds Server.mu for the full
+//     analysis duration, so one long analysis serializes all server
+//     requests behind it. Singleflight-based fix is on the 0.2.1 list.
+//   - HTTP handlers don't thread the request context into the engine,
+//     so client disconnect doesn't cancel in-flight analyses. Same PR.
+//
+// Sandboxing AI eval execution and an actual auth model are 0.3 work;
+// until then, this is a *local development tool*, not a team dashboard.
 package server
 
 import (

--- a/internal/signals/manifest.go
+++ b/internal/signals/manifest.go
@@ -794,7 +794,7 @@ var allSignalManifest = []ManifestEntry{
 		Domain: models.CategoryAI, Status: StatusExperimental,
 		Title:           "Prompt-Injection-Shaped Concatenation",
 		Description:     "User-controlled input is concatenated into a prompt without escaping, system-prompt boundaries, or structured input boundaries.",
-		Remediation:     "Use a prompt template with explicit user-content boundaries, or run user input through a sanitiser.",
+		Remediation:     "Use a prompt template with explicit user-content boundaries, or run user input through a sanitizer.",
 		DefaultSeverity: models.SeverityHigh,
 		ConfidenceMin:   0.6, ConfidenceMax: 0.85,
 		EvidenceSources: []string{"structural-pattern"},


### PR DESCRIPTION
## Summary

A senior-engineer launch-readiness review of 0.2.0 (~65 items, 2026-05-02) flagged that the codebase is more honest than its public surface — README, CHANGELOG, quickstart, the PR-comment workflow, and the compatibility doc all overstated what 0.2 actually delivers. This PR is the **truth-up only**: every user-visible claim now matches the code on the day v0.2.0 is tagged.

This is **Phase 1** of the launch-readiness plan. Phase 2 is tagging v0.2.0; the suppression model, command registry, and SARIF audit are 0.2.1 / 0.2.2 work.

## What changed

**CHANGELOG (3 corrections):**
- Headline calibration claim: "100% precision/recall on a 27-fixture corpus" → "100% **recall**; precision floors against a labeled-repo corpus deferred to 0.3."
- Cosign installer block rewritten to match actual code: hard-fail by default with two documented opt-out env vars. The `bin/postinstall.js` failure-swallow is now explicitly tracked for 0.2.1.
- New "What's stable in 0.2" section right under the headline (stable / experimental / planned).

**"AI Validation" → "AI Risk Review" rename** across the workflow, PR-comment template, decision strings, comment-marker HTML id, code comments, CHANGELOG references, and several user-facing docs. Internal dev scorecards left as historical artifacts. Avoids the "AI validation / AI safety / AI security" framing until 0.3 ships precision metrics + AST taint flow + sandboxing.

**README + quickstart:**
- Headline "30 seconds" promise qualified inline.
- "Reads your repository ..." now says "when available" / "best effort" so coverage / runtime artifact dependence is honest.
- "No SaaS / no telemetry" splits runtime from installation.
- Quickstart line 150 ("same CI treatment as regular tests") rewritten.
- New "What 0.2 Is and Isn't" section in README.
- Supporting-commands table: portfolio gets an explicit "(canonical, experimental)" qualifier.

**Doc drift fixes:**
- `docs/telemetry.md`: `terrain telemetry` → `terrain config telemetry`.
- `docs/compatibility.md`: Tier-1 description corrected (extended gates on Linux only; macOS/Windows are unit-test parity); dropped the deferred A-grade rating reference.
- `docs/user-guides/getting-started.md`: new Prerequisites section documenting cosign install + opt-out env vars.

**Server stale comments + honest scope:**
- `0.1.2` references removed.
- `internal/server/server.go`: security-posture block rewritten for 0.2.0; documents the request-context-not-wired and mutex-blocking-analysis bugs as known issues tracked for 0.2.1 rather than silently shipping.

**British spelling sweep:**
- `sanitiser` / `sanitised` / `sanitisation` → American spellings across source, tests, and rule docs. Manifest regenerated.
- `behavioural` → `behavioral` in docs/personas.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` and `go test ./internal/testdata/` green (golden suite passes; PR-comment render tests updated to expect "AI Risk Review")
- [x] `make docs-verify` green (manifest regenerated for the spelling fix)
- [x] `grep -rn "AI [Vv]alidation\b" .github docs README.md CHANGELOG.md cmd internal` returns 0 hits in user-facing paths
- [x] `grep -rn "sanitiser\|sanitised\|behaviour" docs internal cmd README.md` returns 0 hits
- [x] `grep -rn "0\.1\.2" internal/server cmd/terrain/cmd_serve.go` returns 0 hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
