### PR TITLE
feat(0.2.1): --fail-on and --timeout flags on terrain analyze

### DIFF
--- a/cmd/terrain/cmd_analyze.go
+++ b/cmd/terrain/cmd_analyze.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pmclSF/terrain/internal/analyze"
 	"github.com/pmclSF/terrain/internal/engine"
@@ -126,7 +127,7 @@ func relativeToRoot(path, root string) string {
 	return path
 }
 
-func runAnalyze(root string, jsonOutput bool, format string, verbose bool, writeSnap bool, coveragePath, coverageRunLabel string, runtimePaths string, gauntletPaths string, promptfooPaths string, deepevalPaths string, ragasPaths string, baselinePath string, slowThreshold float64, redactPaths bool) error {
+func runAnalyze(root string, jsonOutput bool, format string, verbose bool, writeSnap bool, coveragePath, coverageRunLabel string, runtimePaths string, gauntletPaths string, promptfooPaths string, deepevalPaths string, ragasPaths string, baselinePath string, slowThreshold float64, redactPaths bool, gate severityGate, timeout time.Duration) error {
 	parsedRuntime := parseRuntimePaths(runtimePaths)
 	parsedGauntlet := parseRuntimePaths(gauntletPaths)        // same comma-split logic
 	parsedPromptfoo := parseRuntimePaths(promptfooPaths)      // same comma-split logic
@@ -175,12 +176,13 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 	opt.RagasPaths = parsedRagas
 	opt.BaselineSnapshotPath = baselinePath
 	opt.OnProgress = newProgressFunc(jsonOutput)
-	// Honour Ctrl-C: pre-0.2.x analyze exited abruptly on SIGINT with no
-	// cleanup. runPipelineWithSignals wraps RunPipelineContext with a
-	// SIGINT-aware context so in-flight detectors check ctx.Err and
-	// unwind cooperatively. Same helper is used by every other
-	// analysis command since 0.2.
-	result, err := runPipelineWithSignals(root, opt)
+	// Honour Ctrl-C and the optional --timeout: pre-0.2.x analyze
+	// exited abruptly on SIGINT with no cleanup, and unbounded
+	// monorepo scans could block CI indefinitely.
+	// runPipelineWithSignalsAndTimeout wraps RunPipelineContext with a
+	// SIGINT-aware context plus an optional deadline so in-flight
+	// detectors check ctx.Err and unwind cooperatively.
+	result, err := runPipelineWithSignalsAndTimeout(root, opt, timeout)
 	if err != nil {
 		return fmt.Errorf("analysis failed: %w", err)
 	}
@@ -271,6 +273,14 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 		for _, hint := range hints {
 			fmt.Printf("  %s\n", hint)
 		}
+	}
+
+	// --fail-on gate: evaluated last so the report is always rendered
+	// before the exit code is decided. Returning errSeverityGateBlocked
+	// lets main.go map this to exitSeverityGateBlock without confusing
+	// it for an analysis error.
+	if blocked, summary := severityGateBlocked(gate, report.SignalSummary); blocked {
+		return fmt.Errorf("%w: --fail-on=%s matched %s", errSeverityGateBlocked, gate, summary)
 	}
 
 	return nil

--- a/cmd/terrain/cmd_analyze.go
+++ b/cmd/terrain/cmd_analyze.go
@@ -220,6 +220,24 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 		DiscoveredArtifacts: discovered,
 	})
 
+	// Compute the gate decision BEFORE rendering so it applies to every
+	// output format (json, sarif, annotation, html, text). Pre-fix, the
+	// gate check was at the bottom and the json/sarif/annotation
+	// branches early-returned before reaching it — `terrain analyze
+	// --json --fail-on=medium` silently exited 0 even with matching
+	// findings. The "JSON stdout purity" property the launch-readiness
+	// review asked for requires that the renderer completes (stdout
+	// stays a valid JSON document) AND the gate decision returns via
+	// the error channel (so main.go writes the gate message to stderr,
+	// not stdout).
+	gateBlocked, gateSummary := severityGateBlocked(gate, report.SignalSummary)
+	gateErr := func() error {
+		if gateBlocked {
+			return fmt.Errorf("%w: --fail-on=%s matched %s", errSeverityGateBlocked, gate, gateSummary)
+		}
+		return nil
+	}
+
 	if sarifOutput {
 		sarifLog := sarif.FromAnalyzeReportWithOptions(report, version, sarif.Options{
 			RedactPaths: redactPaths,
@@ -227,12 +245,15 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 		})
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(sarifLog)
+		if err := enc.Encode(sarifLog); err != nil {
+			return err
+		}
+		return gateErr()
 	}
 
 	if annotationOutput {
 		reporting.RenderGitHubAnnotations(os.Stdout, report)
-		return nil
+		return gateErr()
 	}
 
 	// `--write-snapshot` runs first so it persists regardless of the
@@ -248,13 +269,19 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 	}
 
 	if strings.EqualFold(strings.TrimSpace(format), "html") {
-		return reporting.RenderAnalyzeHTML(os.Stdout, report)
+		if err := reporting.RenderAnalyzeHTML(os.Stdout, report); err != nil {
+			return err
+		}
+		return gateErr()
 	}
 
 	if jsonOutput {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(report)
+		if err := enc.Encode(report); err != nil {
+			return err
+		}
+		return gateErr()
 	}
 
 	if verbose {
@@ -275,15 +302,10 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 		}
 	}
 
-	// --fail-on gate: evaluated last so the report is always rendered
-	// before the exit code is decided. Returning errSeverityGateBlocked
-	// lets main.go map this to exitSeverityGateBlock without confusing
-	// it for an analysis error.
-	if blocked, summary := severityGateBlocked(gate, report.SignalSummary); blocked {
-		return fmt.Errorf("%w: --fail-on=%s matched %s", errSeverityGateBlocked, gate, summary)
-	}
-
-	return nil
+	// --fail-on gate: text-mode renderer falls through to the same
+	// gateErr() the other branches use, so the gate decision applies
+	// uniformly across every output format.
+	return gateErr()
 }
 
 // runPolicyCheck evaluates the repository against its local policy.

--- a/cmd/terrain/cmd_pipeline_helpers.go
+++ b/cmd/terrain/cmd_pipeline_helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"time"
 
 	"github.com/pmclSF/terrain/internal/engine"
 )
@@ -23,7 +24,22 @@ import (
 // which matters more on long monorepo scans where the user may want
 // to abort mid-walk.
 func runPipelineWithSignals(root string, opt engine.PipelineOptions) (*engine.PipelineResult, error) {
+	return runPipelineWithSignalsAndTimeout(root, opt, 0)
+}
+
+// runPipelineWithSignalsAndTimeout extends runPipelineWithSignals with
+// an optional timeout. When timeout > 0, the analysis context is
+// cancelled after the duration elapses and the pipeline returns
+// context.DeadlineExceeded. CI users running on large monorepos
+// reach for this when an unbounded analysis would block their
+// pipeline indefinitely.
+func runPipelineWithSignalsAndTimeout(root string, opt engine.PipelineOptions, timeout time.Duration) (*engine.PipelineResult, error) {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 	return engine.RunPipelineContext(ctx, root, opt)
 }

--- a/cmd/terrain/cmd_severity_gate.go
+++ b/cmd/terrain/cmd_severity_gate.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/pmclSF/terrain/internal/analyze"
+)
+
+// errSeverityGateBlocked is the sentinel returned by runAnalyze when
+// `--fail-on` matches at least one finding. main.go uses errors.Is to
+// distinguish this from analysis errors and exit with
+// `exitSeverityGateBlock` (6) rather than the generic 1.
+var errSeverityGateBlocked = errors.New("severity gate blocked")
+
+// severityGate represents the threshold for `--fail-on`. Findings at
+// or above this severity cause the analyze command to exit with
+// `exitSeverityGateBlock`. Empty string means "no gate" (the default).
+type severityGate string
+
+const (
+	severityGateNone     severityGate = ""
+	severityGateCritical severityGate = "critical"
+	severityGateHigh     severityGate = "high"
+	severityGateMedium   severityGate = "medium"
+)
+
+// parseSeverityGate accepts the user-supplied flag value and returns a
+// validated gate, or an error explaining valid choices. We accept
+// canonical lowercase ("critical", "high", "medium") plus an empty
+// string for "no gate".
+func parseSeverityGate(s string) (severityGate, error) {
+	v := strings.ToLower(strings.TrimSpace(s))
+	switch v {
+	case "":
+		return severityGateNone, nil
+	case "critical":
+		return severityGateCritical, nil
+	case "high":
+		return severityGateHigh, nil
+	case "medium":
+		return severityGateMedium, nil
+	default:
+		return severityGateNone, fmt.Errorf(
+			"invalid --fail-on %q: valid values are 'critical', 'high', 'medium' (or unset to disable)",
+			s,
+		)
+	}
+}
+
+// severityGateBlocked returns (true, summary) when the report contains
+// at least one signal at or above the configured threshold. The
+// summary is a one-line, human-readable description of which severity
+// counts triggered the gate, suitable for printing to stderr before
+// exit.
+func severityGateBlocked(gate severityGate, summary analyze.SignalBreakdown) (bool, string) {
+	switch gate {
+	case severityGateNone:
+		return false, ""
+	case severityGateCritical:
+		if summary.Critical > 0 {
+			return true, fmt.Sprintf("%d critical finding(s)", summary.Critical)
+		}
+	case severityGateHigh:
+		if summary.Critical > 0 || summary.High > 0 {
+			return true, fmt.Sprintf(
+				"%d critical + %d high finding(s)",
+				summary.Critical, summary.High,
+			)
+		}
+	case severityGateMedium:
+		if summary.Critical > 0 || summary.High > 0 || summary.Medium > 0 {
+			return true, fmt.Sprintf(
+				"%d critical + %d high + %d medium finding(s)",
+				summary.Critical, summary.High, summary.Medium,
+			)
+		}
+	}
+	return false, ""
+}

--- a/cmd/terrain/cmd_severity_gate.go
+++ b/cmd/terrain/cmd_severity_gate.go
@@ -60,22 +60,35 @@ func severityGateBlocked(gate severityGate, summary analyze.SignalBreakdown) (bo
 		return false, ""
 	case severityGateCritical:
 		if summary.Critical > 0 {
-			return true, fmt.Sprintf("%d critical finding(s)", summary.Critical)
+			return true, fmt.Sprintf("%d critical %s", summary.Critical, plural(summary.Critical, "finding"))
 		}
 	case severityGateHigh:
-		if summary.Critical > 0 || summary.High > 0 {
+		total := summary.Critical + summary.High
+		if total > 0 {
 			return true, fmt.Sprintf(
-				"%d critical + %d high finding(s)",
-				summary.Critical, summary.High,
+				"%d critical + %d high (%d %s total)",
+				summary.Critical, summary.High, total, plural(total, "finding"),
 			)
 		}
 	case severityGateMedium:
-		if summary.Critical > 0 || summary.High > 0 || summary.Medium > 0 {
+		total := summary.Critical + summary.High + summary.Medium
+		if total > 0 {
 			return true, fmt.Sprintf(
-				"%d critical + %d high + %d medium finding(s)",
-				summary.Critical, summary.High, summary.Medium,
+				"%d critical + %d high + %d medium (%d %s total)",
+				summary.Critical, summary.High, summary.Medium, total, plural(total, "finding"),
 			)
 		}
 	}
 	return false, ""
+}
+
+// plural is a small helper to avoid the awkward `n thing(s)` notation
+// in user-visible text. Mirrors the pluralization helper added in the
+// 0.2 polish PRs (internal/reporting/plural.go) but kept local here
+// so the cmd package doesn't pull in reporting just for one call.
+func plural(n int, singular string) string {
+	if n == 1 {
+		return singular
+	}
+	return singular + "s"
 }

--- a/cmd/terrain/cmd_severity_gate_test.go
+++ b/cmd/terrain/cmd_severity_gate_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -58,9 +60,12 @@ func TestSeverityGateBlocked(t *testing.T) {
 	}{
 		{"none gate never blocks", severityGateNone, bd{Critical: 5, High: 3}, false, ""},
 		{"critical: 0 critical passes", severityGateCritical, bd{High: 99, Medium: 99}, false, ""},
-		{"critical: 1 critical blocks", severityGateCritical, bd{Critical: 1}, true, "1 critical"},
+		{"critical: 1 critical blocks (singular)", severityGateCritical, bd{Critical: 1}, true, "1 critical finding"},
+		{"critical: 3 critical blocks (plural)", severityGateCritical, bd{Critical: 3}, true, "3 critical findings"},
 		{"high: critical+high blocks on critical", severityGateHigh, bd{Critical: 2, High: 0}, true, "2 critical + 0 high"},
 		{"high: critical+high blocks on high", severityGateHigh, bd{Critical: 0, High: 5}, true, "0 critical + 5 high"},
+		{"high: total count + plural", severityGateHigh, bd{Critical: 2, High: 5}, true, "(7 findings total)"},
+		{"high: total count singular", severityGateHigh, bd{High: 1}, true, "(1 finding total)"},
 		{"high: medium-only passes", severityGateHigh, bd{Medium: 99, Low: 99}, false, ""},
 		{"medium: any of the three blocks", severityGateMedium, bd{Medium: 1}, true, "0 critical + 0 high + 1 medium"},
 		{"medium: low-only passes", severityGateMedium, bd{Low: 99}, false, ""},
@@ -77,5 +82,105 @@ func TestSeverityGateBlocked(t *testing.T) {
 				t.Errorf("summary %q does not contain %q", summary, tc.wantSubstr)
 			}
 		})
+	}
+}
+
+// TestRunAnalyze_GateBlocksOnFixture is an end-to-end exercise of the
+// `--fail-on` path that the launch-readiness review flagged as missing.
+// It runs `runAnalyze` against the calibration corpus (which we know
+// contains medium+ severity findings) and asserts:
+//
+//  1. The function returns `errSeverityGateBlocked` (so main.go maps to
+//     exit code 6).
+//  2. The error message contains the expected severity counts.
+//  3. The report renders to stdout *before* the error returns — i.e.,
+//     stdout is non-empty when the gate fires (the gate decision is the
+//     last thing that happens, not the first).
+func TestRunAnalyze_GateBlocksOnFixture(t *testing.T) {
+	root := fixtureRoot(t)
+
+	stdout, err := captureRun(func() error {
+		return runAnalyze(
+			root, false, "", false, false,
+			"", "", "", "", "", "", "", "",
+			defaultSlowThresholdMs, false,
+			severityGateMedium, 0,
+		)
+	})
+
+	// The fixture has medium+ findings — gate should fire.
+	if !errors.Is(err, errSeverityGateBlocked) {
+		t.Fatalf("expected errSeverityGateBlocked, got %v", err)
+	}
+
+	// Error message should be informative (severity counts + label).
+	if !strings.Contains(err.Error(), "--fail-on=medium") {
+		t.Errorf("error message missing --fail-on label: %v", err)
+	}
+
+	// Report renders before the gate check — stdout must be non-empty.
+	// Pre-fix, a gate that returns before the report renders would
+	// produce empty stdout; the user would only see the gate message
+	// without context. This test locks in the "render-then-gate"
+	// invariant.
+	if len(stdout) == 0 {
+		t.Error("stdout is empty — report should render before the gate fires")
+	}
+	if !strings.Contains(string(stdout), "Terrain") {
+		t.Errorf("stdout missing report header; got: %s", string(stdout))
+	}
+}
+
+// TestRunAnalyze_JSONStdoutPurity verifies that with `--json` enabled
+// AND `--fail-on` matching, the JSON snapshot lands on stdout cleanly
+// and is parseable as JSON. The gate message goes to the returned
+// error (which main.go writes to stderr) so stdout stays a valid JSON
+// document. This is the "JSON stdout purity" property the launch-
+// readiness review asked for.
+func TestRunAnalyze_JSONStdoutPurity(t *testing.T) {
+	root := fixtureRoot(t)
+
+	stdout, err := captureRun(func() error {
+		return runAnalyze(
+			root, true, "", false, false,
+			"", "", "", "", "", "", "", "",
+			defaultSlowThresholdMs, false,
+			severityGateMedium, 0,
+		)
+	})
+
+	// Gate fired (expected for the fixture).
+	if !errors.Is(err, errSeverityGateBlocked) {
+		t.Fatalf("expected errSeverityGateBlocked, got %v", err)
+	}
+
+	// JSON purity: the entire stdout body must parse as JSON. If the
+	// gate message had leaked into stdout, the parse would fail.
+	var parsed map[string]any
+	if jsonErr := json.Unmarshal(stdout, &parsed); jsonErr != nil {
+		t.Errorf("stdout is not valid JSON (gate message leaked into JSON?): %v\nstdout:\n%s", jsonErr, stdout)
+	}
+}
+
+// TestRunAnalyze_GatePassesWhenSeverityAbsent verifies the inverse:
+// `--fail-on critical` against a fixture whose worst severity is
+// medium returns nil (no gate block).
+func TestRunAnalyze_GatePassesWhenSeverityAbsent(t *testing.T) {
+	root := fixtureRoot(t)
+
+	_, err := captureRun(func() error {
+		return runAnalyze(
+			root, false, "", false, false,
+			"", "", "", "", "", "", "", "",
+			defaultSlowThresholdMs, false,
+			severityGateCritical, 0,
+		)
+	})
+
+	// The fixture's worst severity is below critical — gate should NOT
+	// fire. Any non-nil error here is unexpected (analysis failure or
+	// gate misfire).
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
 	}
 }

--- a/cmd/terrain/cmd_severity_gate_test.go
+++ b/cmd/terrain/cmd_severity_gate_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/analyze"
+)
+
+func TestParseSeverityGate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in     string
+		want   severityGate
+		errSub string
+	}{
+		{"", severityGateNone, ""},
+		{"critical", severityGateCritical, ""},
+		{"CRITICAL", severityGateCritical, ""},
+		{"  high  ", severityGateHigh, ""},
+		{"medium", severityGateMedium, ""},
+		{"low", "", "invalid --fail-on"},
+		{"info", "", "invalid --fail-on"},
+		{"garbage", "", "invalid --fail-on"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseSeverityGate(tc.in)
+			if tc.errSub != "" {
+				if err == nil {
+					t.Fatalf("expected error matching %q, got nil", tc.errSub)
+				}
+				if !strings.Contains(err.Error(), tc.errSub) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("parseSeverityGate(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSeverityGateBlocked(t *testing.T) {
+	t.Parallel()
+	type bd = analyze.SignalBreakdown
+	cases := []struct {
+		name        string
+		gate        severityGate
+		breakdown   bd
+		wantBlocked bool
+		wantSubstr  string
+	}{
+		{"none gate never blocks", severityGateNone, bd{Critical: 5, High: 3}, false, ""},
+		{"critical: 0 critical passes", severityGateCritical, bd{High: 99, Medium: 99}, false, ""},
+		{"critical: 1 critical blocks", severityGateCritical, bd{Critical: 1}, true, "1 critical"},
+		{"high: critical+high blocks on critical", severityGateHigh, bd{Critical: 2, High: 0}, true, "2 critical + 0 high"},
+		{"high: critical+high blocks on high", severityGateHigh, bd{Critical: 0, High: 5}, true, "0 critical + 5 high"},
+		{"high: medium-only passes", severityGateHigh, bd{Medium: 99, Low: 99}, false, ""},
+		{"medium: any of the three blocks", severityGateMedium, bd{Medium: 1}, true, "0 critical + 0 high + 1 medium"},
+		{"medium: low-only passes", severityGateMedium, bd{Low: 99}, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			blocked, summary := severityGateBlocked(tc.gate, tc.breakdown)
+			if blocked != tc.wantBlocked {
+				t.Errorf("severityGateBlocked(%q, %+v) blocked = %v, want %v",
+					tc.gate, tc.breakdown, blocked, tc.wantBlocked)
+			}
+			if tc.wantSubstr != "" && !strings.Contains(summary, tc.wantSubstr) {
+				t.Errorf("summary %q does not contain %q", summary, tc.wantSubstr)
+			}
+		})
+	}
+}

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -35,6 +35,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -79,6 +80,11 @@ const defaultSlowThresholdMs = 5000.0
 //	     `terrain explain <target>` when the entity doesn't exist.
 //	     Lets CI distinguish "the thing you asked about isn't here"
 //	     from "the analysis crashed."
+//	6 — Severity gate block. Returned by `terrain analyze --fail-on`
+//	     when the report contains at least one finding at or above the
+//	     requested severity. Same pattern as code 4 (AI gate); CI
+//	     scripts can branch on "the analysis succeeded but the gate
+//	     blocked us" without parsing stderr.
 //
 // Splitting code 2 cleanly into "usage" vs "policy" is a behavior-breaking
 // change that needs a migration window. It's documented in 0.2 as an
@@ -96,6 +102,10 @@ const (
 	// commands collapsed not-found into exit 1, indistinguishable from
 	// a real analysis crash.
 	exitNotFound = 5
+	// exitSeverityGateBlock signals that `--fail-on` blocked a
+	// successful analysis. Code 6 leaves room for code 3 (planned for
+	// "policy fail" once 2 is split) without colliding.
+	exitSeverityGateBlock = 6
 )
 
 func main() {
@@ -126,9 +136,20 @@ func main() {
 		baselineFlag := analyzeCmd.String("baseline", "", "path to a previous snapshot JSON file; enables regression-aware detectors (aiCostRegression, aiRetrievalRegression)")
 		slowThreshold := analyzeCmd.Float64("slow-threshold", defaultSlowThresholdMs, "slow test threshold in ms")
 		redactPathsFlag := analyzeCmd.Bool("redact-paths", false, "rewrite absolute paths in --format=sarif output to repo-relative form (or basename if outside repo)")
+		failOnFlag := analyzeCmd.String("fail-on", "", "exit "+fmt.Sprintf("%d", exitSeverityGateBlock)+" when at least one finding is at or above this severity (critical|high|medium)")
+		timeoutFlag := analyzeCmd.Duration("timeout", 0, "abort the analysis after this duration (e.g. 5m); 0 means no timeout")
 		_ = analyzeCmd.Parse(os.Args[2:])
 		mountPositionalAsRoot("analyze", analyzeCmd.Args(), rootFlag)
-		if err := runAnalyze(*rootFlag, *jsonFlag, *formatFlag, *verboseFlag, *writeSnapshot, *coverageFlag, *coverageRunLabelFlag, *runtimeFlag, *gauntletFlag, *promptfooFlag, *deepevalFlag, *ragasFlag, *baselineFlag, *slowThreshold, *redactPathsFlag); err != nil {
+		gate, gateErr := parseSeverityGate(*failOnFlag)
+		if gateErr != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", gateErr)
+			os.Exit(exitUsageError)
+		}
+		if err := runAnalyze(*rootFlag, *jsonFlag, *formatFlag, *verboseFlag, *writeSnapshot, *coverageFlag, *coverageRunLabelFlag, *runtimeFlag, *gauntletFlag, *promptfooFlag, *deepevalFlag, *ragasFlag, *baselineFlag, *slowThreshold, *redactPathsFlag, gate, *timeoutFlag); err != nil {
+			if errors.Is(err, errSeverityGateBlocked) {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				os.Exit(exitSeverityGateBlock)
+			}
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -60,17 +60,18 @@ var (
 
 const defaultSlowThresholdMs = 5000.0
 
-// Exit codes. CI scripts can distinguish failure modes from these without
-// parsing stderr. The 0.1.2 contract preserves historical semantics: codes
-// 0–2 keep their existing meanings, and the new code (4) is additive.
+// Exit codes. CI scripts can distinguish failure modes from these
+// without parsing stderr. Codes 0–2 preserve their pre-0.1.2 meanings;
+// codes 4+ are additive.
 //
 //	0 — success
 //	1 — runtime / analysis error (file not found, parse failed, IO error)
-//	2 — usage error OR policy violation (overloaded for back-compat; both
-//	     meanings retained because at least one consumer pattern-matches
-//	     `exit 2 == policy fail today`)
-//	3 — reserved (0.2 will move policy violations here once we publish a
-//	     migration guide; do not use for new codepaths)
+//	2 — usage error OR policy violation (overloaded for back-compat;
+//	     both meanings retained because at least one consumer pattern-
+//	     matches `exit 2 == policy fail today`)
+//	3 — reserved for "policy violation" once code 2's overload is
+//	     split. The split is a behavior-breaking change that needs a
+//	     migration window; do not use for new codepaths until then.
 //	4 — AI gate block. Returned by `terrain ai run --baseline` when the
 //	     `actionBlock` decision fires (e.g., a high-severity AI signal
 //	     introduced vs. baseline). Reserved by `exitAIGateBlock` so a
@@ -86,9 +87,9 @@ const defaultSlowThresholdMs = 5000.0
 //	     scripts can branch on "the analysis succeeded but the gate
 //	     blocked us" without parsing stderr.
 //
-// Splitting code 2 cleanly into "usage" vs "policy" is a behavior-breaking
-// change that needs a migration window. It's documented in 0.2 as an
-// explicit milestone in docs/release/0.2.md.
+// Splitting code 2 cleanly into "usage" vs "policy" is a behavior-
+// breaking change that needs a migration window. The split is
+// documented as a 0.2.x → 0.3 milestone in docs/release/0.2.md.
 const (
 	exitOK              = 0
 	exitError           = 1
@@ -143,6 +144,13 @@ func main() {
 		gate, gateErr := parseSeverityGate(*failOnFlag)
 		if gateErr != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", gateErr)
+			os.Exit(exitUsageError)
+		}
+		// Negative timeouts have no meaning; reject explicitly so the
+		// user gets a clear error rather than an immediate
+		// context.DeadlineExceeded that looks like an analysis failure.
+		if *timeoutFlag < 0 {
+			fmt.Fprintf(os.Stderr, "error: --timeout must be non-negative (got %s)\n", *timeoutFlag)
 			os.Exit(exitUsageError)
 		}
 		if err := runAnalyze(*rootFlag, *jsonFlag, *formatFlag, *verboseFlag, *writeSnapshot, *coverageFlag, *coverageRunLabelFlag, *runtimeFlag, *gauntletFlag, *promptfooFlag, *deepevalFlag, *ragasFlag, *baselineFlag, *slowThreshold, *redactPathsFlag, gate, *timeoutFlag); err != nil {


### PR DESCRIPTION
## Summary

Closes the platform/SRE adoption gap flagged in the 0.2.0 launch-readiness review (Item 40, Item 39). Two CI-grade flags on \`terrain analyze\`:

- \`--fail-on critical|high|medium\` — exit with new code 6 when at least one finding is at or above the requested severity. Standard CI gate.
- \`--timeout <duration>\` — abort the analysis after the duration elapses (e.g. \`5m\`, \`30s\`). Wraps the existing SIGINT-aware context with a deadline.

## Approach

- New \`cmd/terrain/cmd_severity_gate.go\` — pure functions over \`analyze.SignalBreakdown\` plus an \`errSeverityGateBlocked\` sentinel. Tested at unit level; no engine coupling.
- \`runPipelineWithSignals\` becomes a 0-timeout shim around the new \`runPipelineWithSignalsAndTimeout\`, so the six other callsites (\`impact\`, \`explain\`, \`pr\`, \`ai *\`) keep their contract and can adopt the flag in follow-up PRs without churning this one.
- Gate evaluated last in \`runAnalyze\` so the report renders first, then the exit code is decided.
- Exit code 6 added to the conventions block. Code 3 stays reserved for the planned policy-vs-usage split.

## Manual smoke (against the Terrain repo itself)

\`\`\`
$ terrain analyze --fail-on critical    → exit 0  (no critical findings)
$ terrain analyze --fail-on medium      → exit 6  (\"0 critical + 493 high + 169 medium finding(s)\")
$ terrain analyze --fail-on bogus       → exit 2  (usage error)
$ terrain analyze --timeout 100ms       → analysis aborts cleanly with context.DeadlineExceeded
\`\`\`

## Test plan

- [x] \`TestParseSeverityGate\` — canonical / case-insensitive / whitespace / invalid inputs
- [x] \`TestSeverityGateBlocked\` — the threshold cascade (critical / critical+high / critical+high+medium) plus the gate-none always-pass case
- [x] \`go test ./...\` and \`go vet ./...\` clean
- [x] Three manual exit-code smokes above

## Out of scope

\`--new-findings-only --baseline <path>\` from the plan — needs the stable finding IDs work (Phase 3.1) to ship clean across renamed files. Tracked for a 0.2.x follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
