### PR TITLE
feat(0.2): parity rubric + baseline scores (Track 0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ PR_DESCRIPTION.md
 *.tmp
 tmp/
 temp/
+terrain-parity-gate

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,3 +105,60 @@ Repository scan → Signal detection → Risk scoring → Snapshot → Reporting
 ```
 
 See [DESIGN.md](DESIGN.md) for the full architecture overview, [docs/architecture/](docs/architecture/) for detailed design documents, and the [CLI spec](docs/cli-spec.md) for the complete command reference.
+
+## Parity gate (lifting maturity uniformly)
+
+Terrain enforces a **parity gate** so no functional area drifts behind
+the others. The gate measures every shipping area against a 17-axis
+rubric (7 product / 7 engineering / 3 UI/visual). Per-pillar floors
+apply:
+
+| Pillar | Floor | Block release? |
+|--------|-------|----------------|
+| Gate | every cell ≥ 4 | yes |
+| Understand | every cell ≥ 3 | yes |
+| Align | every cell ≥ 3 | soft (warn-only) |
+
+### How to lift a cell in your PR
+
+1. Find the cell you're improving in `docs/release/parity/scores.yaml`.
+2. Update the score (1–5) and replace the evidence line with a
+   one-line pointer to the change you're making (file:line, test
+   name, or short rationale).
+3. If your change touches the audit doc's narrative,
+   `docs/release/0.2.x-maturity-audit.md` updates in the same PR.
+4. Run `make pillar-parity` locally — your change should move at
+   least one cell; CI will compare the diff.
+
+### Source-of-truth split
+
+- **Structural** rubric (areas, axes, level definitions, floors,
+  uniformity gates): `docs/release/parity/rubric.yaml`. Changes
+  rarely; anything that moves cells around or redefines what "3"
+  means lives here.
+- **Per-cell scores**: `docs/release/parity/scores.yaml`. Changes
+  every parity-lift PR. The shape is `area_id → axis_id → {score,
+  evidence}`.
+- **Human-readable companion**: `docs/release/0.2.x-maturity-audit.md`.
+  Same data, prose form. Update both together.
+
+### Local commands
+
+```bash
+make pillar-parity            # full matrix + per-pillar verdict
+make pillar-parity-floor      # compact: just the floor map
+make pillar-parity-json       # JSON for tooling
+```
+
+Exit codes: `0` if every hard-gate pillar is at or above its floor
+(soft warns are OK), `1` if any hard-gate pillar is below its floor,
+`2` for usage errors (missing files, malformed YAML).
+
+### Uniformity gates
+
+In addition to per-cell floors, the rubric defines seven uniformity
+gates that catch *unevenness* across detectors / frameworks /
+commands / outputs (e.g. "every detector has the same eight required
+fields", "every Tier-1 framework reaches the same axis floor"). These
+are tracked as advisory in 0.2.0 and become hard gates in 0.2.x. See
+the `uniformity_gates` block in `rubric.yaml`.

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,23 @@ docs-gen:
 docs-verify:
 	@scripts/docs-verify.sh
 
+# ── Parity gate ────────────────────────────────────────────
+# Reads docs/release/parity/{rubric,scores}.yaml and emits the
+# pillar-parity matrix + verdict. Exits non-zero when any pillar
+# is below its hard-gate floor (Gate ≥ 4, Understand ≥ 3 in 0.2.0).
+# Soft gates (Align in 0.2.0) print a WARN banner but do not fail.
+# Source-of-truth doc is `docs/release/0.2.x-maturity-audit.md`.
+pillar-parity:
+	@go run ./cmd/terrain-parity-gate
+
+# JSON form for CI integration / external tooling.
+pillar-parity-json:
+	@go run ./cmd/terrain-parity-gate --json
+
+# Compact form: per-area + per-pillar floor map only.
+pillar-parity-floor:
+	@go run ./cmd/terrain-parity-gate --floor-map
+
 # ── Calibration corpus ──────────────────────────────────────
 # Runs the engine pipeline against every fixture under tests/calibration/
 # and prints precision/recall per detector. Today a smoke gate (advisory

--- a/cmd/terrain-parity-gate/main.go
+++ b/cmd/terrain-parity-gate/main.go
@@ -1,0 +1,532 @@
+// terrain-parity-gate reads the parity rubric + current scores and emits
+// a human-readable matrix plus a pass/fail verdict against per-pillar
+// floor requirements.
+//
+// This is the machine-readable enforcement of the parity gate defined in
+// `docs/release/0.2.x-maturity-audit.md`. The audit doc is the human-
+// readable companion; this tool is what `make pillar-parity` runs and
+// what CI uses as a hard gate.
+//
+// Inputs (defaults; override with --rubric / --scores):
+//
+//	docs/release/parity/rubric.yaml — pillars / areas / axes / floors / uniformity gates
+//	docs/release/parity/scores.yaml — current per-cell scores with evidence
+//
+// Output modes:
+//
+//	default       — pretty-print matrix + per-pillar verdict to stdout
+//	--json        — emit a single JSON object with the same content
+//	--floor-map   — only the per-area / per-pillar floor map (compact)
+//
+// Exit codes:
+//
+//	0 — every pillar at or above its floor (release-gate clears)
+//	1 — at least one pillar below its hard-gate floor (release blocked)
+//	2 — usage error (missing files, malformed YAML)
+//
+// Soft gates (e.g. "align" in 0.2.0) print a WARN banner but do not fail.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ── Rubric types (mirror the YAML shape) ─────────────────────────────
+
+type pillar struct {
+	ID              string `yaml:"id"`
+	Name            string `yaml:"name"`
+	Job             string `yaml:"job"`
+	ExternalFraming string `yaml:"external_framing"`
+	Priority        int    `yaml:"priority"`
+}
+
+type area struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Pillar      string `yaml:"pillar"`
+	Tier        int    `yaml:"tier"`
+	Surface     string `yaml:"surface"`
+	Description string `yaml:"description"`
+}
+
+type axis struct {
+	ID          string            `yaml:"id"`
+	Name        string            `yaml:"name"`
+	Lens        string            `yaml:"lens"` // product | engineering | visual
+	Description string            `yaml:"description"`
+	Levels      map[string]string `yaml:"levels"`
+}
+
+type uniformityGate struct {
+	ID          string `yaml:"id"`
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+	AppliesTo   string `yaml:"applies_to"`
+	VerifiedBy  string `yaml:"verified_by"`
+	Blocking    bool   `yaml:"blocking"`
+}
+
+type rubric struct {
+	SchemaVersion   string           `yaml:"schema_version"`
+	Pillars         []pillar         `yaml:"pillars"`
+	PillarFloors    map[string]int   `yaml:"pillar_floors"`
+	SoftGates       []string         `yaml:"soft_gates"`
+	Areas           []area           `yaml:"areas"`
+	Axes            []axis           `yaml:"axes"`
+	UniformityGates []uniformityGate `yaml:"uniformity_gates"`
+}
+
+// ── Score types ──────────────────────────────────────────────────────
+
+type cellScore struct {
+	Score    int    `yaml:"score"`
+	Evidence string `yaml:"evidence"`
+}
+
+type scores struct {
+	SchemaVersion         string                          `yaml:"schema_version"`
+	CapturedAt            string                          `yaml:"captured_at"`
+	CapturedAgainstCommit string                          `yaml:"captured_against_commit"`
+	Scores                map[string]map[string]cellScore `yaml:"scores"`
+}
+
+// ── Computed verdict ─────────────────────────────────────────────────
+
+type pillarVerdict struct {
+	Pillar      string `json:"pillar"`
+	Floor       int    `json:"floor"`
+	Required    int    `json:"required"`
+	Soft        bool   `json:"soft"`
+	Status      string `json:"status"` // PASS | FAIL | WARN
+	WeakestArea string `json:"weakestArea,omitempty"`
+	WeakestAxis string `json:"weakestAxis,omitempty"`
+}
+
+type areaVerdict struct {
+	Area        string         `json:"area"`
+	Pillar      string         `json:"pillar"`
+	Floor       int            `json:"floor"`
+	Cells       map[string]int `json:"cells"`
+	WeakestAxes []string       `json:"weakestAxes,omitempty"`
+}
+
+type report struct {
+	SchemaVersion         string          `json:"schemaVersion"`
+	CapturedAt            string          `json:"capturedAt"`
+	CapturedAgainstCommit string          `json:"capturedAgainstCommit"`
+	OverallStatus         string          `json:"overallStatus"`
+	Pillars               []pillarVerdict `json:"pillars"`
+	Areas                 []areaVerdict   `json:"areas"`
+}
+
+// ── Entry point ──────────────────────────────────────────────────────
+
+func main() {
+	rubricPath := flag.String("rubric", "docs/release/parity/rubric.yaml", "path to rubric.yaml")
+	scoresPath := flag.String("scores", "docs/release/parity/scores.yaml", "path to scores.yaml")
+	jsonOut := flag.Bool("json", false, "emit JSON instead of human-readable matrix")
+	floorMap := flag.Bool("floor-map", false, "emit only the floor map (per-area + per-pillar)")
+	flag.Parse()
+
+	r, err := loadRubric(*rubricPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+	s, err := loadScores(*scoresPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
+	if err := validate(r, s); err != nil {
+		fmt.Fprintf(os.Stderr, "error: rubric/scores validation failed: %v\n", err)
+		os.Exit(2)
+	}
+
+	rep := buildReport(r, s)
+
+	switch {
+	case *jsonOut:
+		emitJSON(os.Stdout, rep)
+	case *floorMap:
+		emitFloorMap(os.Stdout, rep)
+	default:
+		emitMatrix(os.Stdout, r, s, rep)
+	}
+
+	os.Exit(exitCode(rep))
+}
+
+// ── Loading ──────────────────────────────────────────────────────────
+
+func loadRubric(path string) (*rubric, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read rubric %q: %w", path, err)
+	}
+	var r rubric
+	if err := yaml.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("parse rubric %q: %w", path, err)
+	}
+	return &r, nil
+}
+
+func loadScores(path string) (*scores, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read scores %q: %w", path, err)
+	}
+	var s scores
+	if err := yaml.Unmarshal(body, &s); err != nil {
+		return nil, fmt.Errorf("parse scores %q: %w", path, err)
+	}
+	return &s, nil
+}
+
+// validate enforces structural invariants that the YAML schemas don't
+// catch on their own: every area in scores has a corresponding rubric
+// entry; every cell is scored; every score is in 1..5; pillar
+// references are valid.
+func validate(r *rubric, s *scores) error {
+	areaIDs := map[string]string{} // areaID → pillarID
+	for _, a := range r.Areas {
+		areaIDs[a.ID] = a.Pillar
+	}
+	axisIDs := map[string]bool{}
+	for _, a := range r.Axes {
+		axisIDs[a.ID] = true
+	}
+	pillarIDs := map[string]bool{}
+	for _, p := range r.Pillars {
+		pillarIDs[p.ID] = true
+	}
+
+	for _, a := range r.Areas {
+		// cross_cutting is allowed even though it isn't a numbered
+		// pillar — distribution lives there.
+		if a.Pillar != "cross_cutting" && !pillarIDs[a.Pillar] {
+			return fmt.Errorf("area %q references unknown pillar %q", a.ID, a.Pillar)
+		}
+	}
+
+	// Every scored area must be in the rubric.
+	for areaID := range s.Scores {
+		if _, ok := areaIDs[areaID]; !ok {
+			return fmt.Errorf("scored area %q is not in rubric", areaID)
+		}
+	}
+	// Every rubric area must be scored, and every cell must be in 1..5.
+	for areaID := range areaIDs {
+		areaScores, ok := s.Scores[areaID]
+		if !ok {
+			return fmt.Errorf("rubric area %q has no scores", areaID)
+		}
+		for axisID := range axisIDs {
+			c, ok := areaScores[axisID]
+			if !ok {
+				return fmt.Errorf("area %q axis %q is not scored", areaID, axisID)
+			}
+			if c.Score < 1 || c.Score > 5 {
+				return fmt.Errorf("area %q axis %q score %d is out of range [1,5]", areaID, axisID, c.Score)
+			}
+		}
+	}
+	return nil
+}
+
+// ── Verdict computation ──────────────────────────────────────────────
+
+func buildReport(r *rubric, s *scores) *report {
+	rep := &report{
+		SchemaVersion:         s.SchemaVersion,
+		CapturedAt:            s.CapturedAt,
+		CapturedAgainstCommit: s.CapturedAgainstCommit,
+	}
+
+	// Per-area floor map.
+	areasByPillar := map[string][]areaVerdict{}
+	for _, a := range r.Areas {
+		areaScores := s.Scores[a.ID]
+		floor, weakest := lowestCell(areaScores)
+		cells := map[string]int{}
+		for axisID, cs := range areaScores {
+			cells[axisID] = cs.Score
+		}
+		av := areaVerdict{
+			Area:        a.ID,
+			Pillar:      a.Pillar,
+			Floor:       floor,
+			Cells:       cells,
+			WeakestAxes: weakest,
+		}
+		rep.Areas = append(rep.Areas, av)
+		areasByPillar[a.Pillar] = append(areasByPillar[a.Pillar], av)
+	}
+	sort.Slice(rep.Areas, func(i, j int) bool { return rep.Areas[i].Area < rep.Areas[j].Area })
+
+	// Per-pillar verdict.
+	soft := map[string]bool{}
+	for _, p := range r.SoftGates {
+		soft[p] = true
+	}
+	overall := "PASS"
+	for _, p := range r.Pillars {
+		areas := areasByPillar[p.ID]
+		if len(areas) == 0 {
+			continue
+		}
+		floor := 5
+		var weakestArea, weakestAxis string
+		for _, av := range areas {
+			if av.Floor < floor {
+				floor = av.Floor
+				weakestArea = av.Area
+				if len(av.WeakestAxes) > 0 {
+					weakestAxis = av.WeakestAxes[0]
+				}
+			}
+		}
+		required := r.PillarFloors[p.ID]
+		status := "PASS"
+		if floor < required {
+			if soft[p.ID] {
+				status = "WARN"
+				if overall == "PASS" {
+					overall = "WARN"
+				}
+			} else {
+				status = "FAIL"
+				overall = "FAIL"
+			}
+		}
+		rep.Pillars = append(rep.Pillars, pillarVerdict{
+			Pillar:      p.ID,
+			Floor:       floor,
+			Required:    required,
+			Soft:        soft[p.ID],
+			Status:      status,
+			WeakestArea: weakestArea,
+			WeakestAxis: weakestAxis,
+		})
+	}
+	rep.OverallStatus = overall
+	return rep
+}
+
+func lowestCell(scores map[string]cellScore) (int, []string) {
+	floor := 5
+	for _, c := range scores {
+		if c.Score < floor {
+			floor = c.Score
+		}
+	}
+	var weakest []string
+	for axisID, c := range scores {
+		if c.Score == floor {
+			weakest = append(weakest, axisID)
+		}
+	}
+	sort.Strings(weakest)
+	return floor, weakest
+}
+
+// ── Output ───────────────────────────────────────────────────────────
+
+func emitJSON(w io.Writer, rep *report) {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(rep)
+}
+
+func emitFloorMap(w io.Writer, rep *report) {
+	fmt.Fprintln(w, "Per-pillar floor:")
+	for _, pv := range rep.Pillars {
+		marker := pv.Status
+		fmt.Fprintf(w, "  %-12s floor=%d required=%d  %s", pv.Pillar, pv.Floor, pv.Required, marker)
+		if pv.Soft && pv.Status == "WARN" {
+			fmt.Fprint(w, " (soft)")
+		}
+		if pv.Status != "PASS" && pv.WeakestArea != "" {
+			fmt.Fprintf(w, "  weakest=%s/%s", pv.WeakestArea, pv.WeakestAxis)
+		}
+		fmt.Fprintln(w)
+	}
+	fmt.Fprintf(w, "Overall: %s\n", rep.OverallStatus)
+}
+
+func emitMatrix(w io.Writer, r *rubric, s *scores, rep *report) {
+	fmt.Fprintln(w, "Terrain parity gate")
+	fmt.Fprintln(w, "===================")
+	fmt.Fprintf(w, "Captured: %s (commit %s)\n", rep.CapturedAt, rep.CapturedAgainstCommit)
+	fmt.Fprintln(w)
+
+	// Order axes for the column header: P1..P7, E1..E7, V1..V3.
+	var axisIDs []string
+	for _, a := range r.Axes {
+		axisIDs = append(axisIDs, a.ID)
+	}
+	sort.Slice(axisIDs, func(i, j int) bool {
+		return axisOrderKey(axisIDs[i]) < axisOrderKey(axisIDs[j])
+	})
+
+	// Group areas by pillar, and order pillars by priority.
+	pillarOrder := make([]string, len(r.Pillars))
+	for i, p := range r.Pillars {
+		pillarOrder[i] = p.ID
+	}
+	sort.SliceStable(pillarOrder, func(i, j int) bool {
+		var pi, pj int
+		for _, p := range r.Pillars {
+			if p.ID == pillarOrder[i] {
+				pi = p.Priority
+			}
+			if p.ID == pillarOrder[j] {
+				pj = p.Priority
+			}
+		}
+		return pi < pj
+	})
+
+	areaByID := map[string]area{}
+	for _, a := range r.Areas {
+		areaByID[a.ID] = a
+	}
+
+	// Header row.
+	fmt.Fprintf(w, "%-32s ", "Area")
+	for _, id := range axisIDs {
+		fmt.Fprintf(w, "%-3s ", id)
+	}
+	fmt.Fprintln(w, " floor")
+	fmt.Fprintln(w, repeatStr("-", 32+len(axisIDs)*4+8))
+
+	// Rows grouped by pillar.
+	for _, pillarID := range append(pillarOrder, "cross_cutting") {
+		var rowsInPillar []area
+		for _, a := range r.Areas {
+			if a.Pillar == pillarID {
+				rowsInPillar = append(rowsInPillar, a)
+			}
+		}
+		if len(rowsInPillar) == 0 {
+			continue
+		}
+		sort.Slice(rowsInPillar, func(i, j int) bool { return rowsInPillar[i].ID < rowsInPillar[j].ID })
+
+		// Pillar separator.
+		fmt.Fprintf(w, "[ %s ]\n", pillarLabel(r, pillarID))
+		for _, a := range rowsInPillar {
+			areaScores := s.Scores[a.ID]
+			fmt.Fprintf(w, "  %-30s ", truncate(a.Name, 30))
+			for _, axisID := range axisIDs {
+				c := areaScores[axisID]
+				marker := scoreMarker(c.Score)
+				fmt.Fprintf(w, "%s%d  ", marker, c.Score)
+			}
+			floor, _ := lowestCell(areaScores)
+			fmt.Fprintf(w, "  %d\n", floor)
+		}
+	}
+	fmt.Fprintln(w)
+
+	// Per-pillar verdict.
+	fmt.Fprintln(w, "Pillar verdict")
+	fmt.Fprintln(w, "--------------")
+	for _, pv := range rep.Pillars {
+		marker := pv.Status
+		if pv.Soft && pv.Status == "WARN" {
+			marker = "WARN (soft — does not block release)"
+		}
+		fmt.Fprintf(w, "  %-12s floor=%d / required=%d   %s\n", pv.Pillar, pv.Floor, pv.Required, marker)
+		if pv.Status != "PASS" && pv.WeakestArea != "" {
+			fmt.Fprintf(w, "                 weakest cell: %s / %s\n", pv.WeakestArea, pv.WeakestAxis)
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Overall: %s\n", rep.OverallStatus)
+}
+
+func exitCode(rep *report) int {
+	if rep.OverallStatus == "FAIL" {
+		return 1
+	}
+	return 0
+}
+
+// ── Small helpers ────────────────────────────────────────────────────
+
+func axisOrderKey(id string) int {
+	// P1..P7 → 100..107; E1..E7 → 200..207; V1..V3 → 300..302.
+	if len(id) < 2 {
+		return 999
+	}
+	base := 0
+	switch id[0] {
+	case 'P':
+		base = 100
+	case 'E':
+		base = 200
+	case 'V':
+		base = 300
+	default:
+		base = 900
+	}
+	n := 0
+	for _, c := range id[1:] {
+		if c < '0' || c > '9' {
+			break
+		}
+		n = n*10 + int(c-'0')
+	}
+	return base + n
+}
+
+func pillarLabel(r *rubric, id string) string {
+	for _, p := range r.Pillars {
+		if p.ID == id {
+			return p.Name
+		}
+	}
+	if id == "cross_cutting" {
+		return "Cross-cutting"
+	}
+	return id
+}
+
+func scoreMarker(score int) string {
+	// Three-state marker: ≥4 = strong, 3 = workable, ≤2 = below floor.
+	// When the design tokens land (Track 10.1), this becomes a token
+	// reference rather than ad-hoc characters.
+	switch {
+	case score >= 4:
+		return " "
+	case score == 3:
+		return "·"
+	default:
+		return "!"
+	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}
+
+func repeatStr(s string, n int) string {
+	out := make([]byte, 0, n*len(s))
+	for i := 0; i < n; i++ {
+		out = append(out, s...)
+	}
+	return string(out)
+}

--- a/cmd/terrain-parity-gate/main_test.go
+++ b/cmd/terrain-parity-gate/main_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate_RejectsMissingArea(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars: []pillar{{ID: "gate"}},
+		Areas: []area{
+			{ID: "alpha", Pillar: "gate"},
+			{ID: "beta", Pillar: "gate"},
+		},
+		Axes: []axis{{ID: "P1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {"P1": {Score: 3}},
+			// "beta" missing
+		},
+	}
+	err := validate(r, s)
+	if err == nil || !strings.Contains(err.Error(), "beta") {
+		t.Errorf("expected error mentioning missing area beta, got: %v", err)
+	}
+}
+
+func TestValidate_RejectsUnknownArea(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars: []pillar{{ID: "gate"}},
+		Areas:   []area{{ID: "alpha", Pillar: "gate"}},
+		Axes:    []axis{{ID: "P1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha":   {"P1": {Score: 3}},
+			"unknown": {"P1": {Score: 3}},
+		},
+	}
+	err := validate(r, s)
+	if err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("expected error mentioning unknown area, got: %v", err)
+	}
+}
+
+func TestValidate_RejectsMissingAxisInArea(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars: []pillar{{ID: "gate"}},
+		Areas:   []area{{ID: "alpha", Pillar: "gate"}},
+		Axes:    []axis{{ID: "P1"}, {ID: "P2"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {"P1": {Score: 3}}, // P2 missing
+		},
+	}
+	err := validate(r, s)
+	if err == nil || !strings.Contains(err.Error(), "P2") {
+		t.Errorf("expected error mentioning missing axis P2, got: %v", err)
+	}
+}
+
+func TestValidate_RejectsOutOfRangeScore(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars: []pillar{{ID: "gate"}},
+		Areas:   []area{{ID: "alpha", Pillar: "gate"}},
+		Axes:    []axis{{ID: "P1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {"P1": {Score: 7}}, // > 5
+		},
+	}
+	err := validate(r, s)
+	if err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("expected out-of-range error, got: %v", err)
+	}
+}
+
+func TestValidate_AllowsCrossCuttingPillar(t *testing.T) {
+	t.Parallel()
+	// The cross_cutting "pillar" isn't a numbered pillar but is allowed
+	// for the distribution area.
+	r := &rubric{
+		Pillars: []pillar{{ID: "gate"}},
+		Areas:   []area{{ID: "dist", Pillar: "cross_cutting"}},
+		Axes:    []axis{{ID: "P1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"dist": {"P1": {Score: 3}},
+		},
+	}
+	if err := validate(r, s); err != nil {
+		t.Errorf("expected cross_cutting to validate, got: %v", err)
+	}
+}
+
+func TestBuildReport_PassWhenAllAtFloor(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars:      []pillar{{ID: "gate", Name: "Gate", Priority: 1}},
+		PillarFloors: map[string]int{"gate": 4},
+		Areas:        []area{{ID: "alpha", Pillar: "gate"}},
+		Axes:         []axis{{ID: "P1"}, {ID: "E1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {
+				"P1": {Score: 4},
+				"E1": {Score: 5},
+			},
+		},
+	}
+	rep := buildReport(r, s)
+	if rep.OverallStatus != "PASS" {
+		t.Errorf("expected PASS, got %s", rep.OverallStatus)
+	}
+	if len(rep.Pillars) != 1 || rep.Pillars[0].Status != "PASS" {
+		t.Errorf("expected single pillar PASS, got %+v", rep.Pillars)
+	}
+}
+
+func TestBuildReport_FailWhenBelowHardFloor(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars:      []pillar{{ID: "gate", Name: "Gate", Priority: 1}},
+		PillarFloors: map[string]int{"gate": 4},
+		Areas:        []area{{ID: "alpha", Pillar: "gate"}},
+		Axes:         []axis{{ID: "P1"}, {ID: "E1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {
+				"P1": {Score: 4},
+				"E1": {Score: 2}, // below floor
+			},
+		},
+	}
+	rep := buildReport(r, s)
+	if rep.OverallStatus != "FAIL" {
+		t.Errorf("expected FAIL, got %s", rep.OverallStatus)
+	}
+	if rep.Pillars[0].Status != "FAIL" {
+		t.Errorf("expected pillar FAIL, got %s", rep.Pillars[0].Status)
+	}
+	if rep.Pillars[0].WeakestArea != "alpha" || rep.Pillars[0].WeakestAxis != "E1" {
+		t.Errorf("weakest pointer wrong: area=%s axis=%s", rep.Pillars[0].WeakestArea, rep.Pillars[0].WeakestAxis)
+	}
+	if exitCode(rep) != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode(rep))
+	}
+}
+
+func TestBuildReport_SoftGateWarns(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars:      []pillar{{ID: "align", Name: "Align", Priority: 3}},
+		PillarFloors: map[string]int{"align": 3},
+		SoftGates:    []string{"align"},
+		Areas:        []area{{ID: "alpha", Pillar: "align"}},
+		Axes:         []axis{{ID: "P1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {"P1": {Score: 2}}, // below soft floor
+		},
+	}
+	rep := buildReport(r, s)
+	if rep.OverallStatus != "WARN" {
+		t.Errorf("expected WARN, got %s", rep.OverallStatus)
+	}
+	if rep.Pillars[0].Status != "WARN" {
+		t.Errorf("expected pillar WARN, got %s", rep.Pillars[0].Status)
+	}
+	// Soft warn should not produce a non-zero exit code.
+	if exitCode(rep) != 0 {
+		t.Errorf("soft WARN should exit 0; got %d", exitCode(rep))
+	}
+}
+
+func TestBuildReport_MixedHardAndSoft(t *testing.T) {
+	t.Parallel()
+	r := &rubric{
+		Pillars: []pillar{
+			{ID: "gate", Name: "Gate", Priority: 1},
+			{ID: "align", Name: "Align", Priority: 3},
+		},
+		PillarFloors: map[string]int{"gate": 4, "align": 3},
+		SoftGates:    []string{"align"},
+		Areas: []area{
+			{ID: "alpha", Pillar: "gate"},
+			{ID: "beta", Pillar: "align"},
+		},
+		Axes: []axis{{ID: "P1"}},
+	}
+	s := &scores{
+		Scores: map[string]map[string]cellScore{
+			"alpha": {"P1": {Score: 2}}, // hard FAIL
+			"beta":  {"P1": {Score: 2}}, // soft WARN
+		},
+	}
+	rep := buildReport(r, s)
+	if rep.OverallStatus != "FAIL" {
+		t.Errorf("any FAIL should make overall FAIL; got %s", rep.OverallStatus)
+	}
+	if exitCode(rep) != 1 {
+		t.Errorf("expected exit 1 for hard FAIL, got %d", exitCode(rep))
+	}
+}
+
+func TestLowestCell(t *testing.T) {
+	t.Parallel()
+	scores := map[string]cellScore{
+		"P1": {Score: 4},
+		"P2": {Score: 2},
+		"P3": {Score: 3},
+		"E1": {Score: 2},
+	}
+	floor, weakest := lowestCell(scores)
+	if floor != 2 {
+		t.Errorf("expected floor=2, got %d", floor)
+	}
+	if len(weakest) != 2 {
+		t.Errorf("expected 2 weakest axes, got %v", weakest)
+	}
+	// Sorted ascending.
+	if weakest[0] != "E1" || weakest[1] != "P2" {
+		t.Errorf("weakest not sorted: %v", weakest)
+	}
+}
+
+func TestAxisOrderKey(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		id   string
+		want int
+	}{
+		{"P1", 101},
+		{"P7", 107},
+		{"E1", 201},
+		{"E7", 207},
+		{"V1", 301},
+		{"V3", 303},
+	}
+	for _, tc := range cases {
+		got := axisOrderKey(tc.id)
+		if got != tc.want {
+			t.Errorf("axisOrderKey(%q) = %d, want %d", tc.id, got, tc.want)
+		}
+	}
+}
+
+// TestRealRubricLoads verifies the shipped rubric.yaml + scores.yaml
+// in the repo parse, validate, and produce a plausible report. This
+// catches structural drift between the YAML and the Go types.
+func TestRealRubricLoads(t *testing.T) {
+	t.Parallel()
+	r, err := loadRubric("../../docs/release/parity/rubric.yaml")
+	if err != nil {
+		t.Fatalf("load rubric: %v", err)
+	}
+	s, err := loadScores("../../docs/release/parity/scores.yaml")
+	if err != nil {
+		t.Fatalf("load scores: %v", err)
+	}
+	if err := validate(r, s); err != nil {
+		t.Fatalf("validate real rubric/scores: %v", err)
+	}
+	rep := buildReport(r, s)
+	if len(rep.Pillars) == 0 {
+		t.Fatal("expected at least one pillar verdict")
+	}
+	// The shipped baseline is FAIL — that's the honest starting point.
+	// If this assertion ever passes (PASS), the rubric is being lifted
+	// without scores keeping up; investigate.
+	if rep.OverallStatus == "PASS" {
+		t.Logf("note: parity gate is now PASSing — confirm rubric and scores moved together")
+	}
+}

--- a/docs/release/parity/rubric.yaml
+++ b/docs/release/parity/rubric.yaml
@@ -1,0 +1,352 @@
+# Terrain parity rubric.
+#
+# This file is the *structural* source of truth for what the parity
+# dashboard measures. It defines:
+#
+#   - 12 functional areas (organized into 3 pillars)
+#   - 17 axes scored 1-5 (7 product + 7 engineering + 3 UI/visual)
+#   - per-pillar floor requirements (the release gate)
+#   - cross-cutting uniformity gates
+#
+# Per-cell scores live in `scores.yaml` (separate file) — that's what
+# moves PR-by-PR. This file changes only when we redefine the rubric
+# itself, which should be rare.
+#
+# See `docs/release/0.2.x-maturity-audit.md` for the human-readable
+# companion that explains the rubric in prose and shows the current
+# state.
+
+schema_version: "1"
+
+# Three pillars + cross-cutting "distribution" band.
+# Pillar priority for 0.2.0: Gate > Understand > Align (per plan).
+pillars:
+  - id: understand
+    name: "Understand"
+    job: "See the test universe as one thing"
+    external_framing: "See what's covered, what's missing, what's overlapping"
+    priority: 2
+  - id: align
+    name: "Align"
+    job: "Reduce drift between code, tests, and repos"
+    external_framing: "Standardize and reduce drift across test systems"
+    priority: 3
+  - id: gate
+    name: "Gate"
+    job: "One CI gate over the whole system"
+    external_framing: "Gate PR changes based on the system as a whole"
+    priority: 1
+
+# Per-pillar floor requirements for the 0.2.0 release gate.
+# Gate is publicly claimable (≥ 4); Understand is workable for adopters
+# (≥ 3); Align is soft (warn-only at 3). See `pillar_priority (0.2.0)`
+# section in the plan.
+pillar_floors:
+  understand: 3
+  align: 3
+  gate: 4
+
+# Soft gates print a warning banner but do not fail CI. The Align
+# pillar is soft for 0.2.0 because multi-repo aggregation is genuinely
+# emerging; partial shipping is acceptable.
+soft_gates:
+  - align
+
+# 12 functional areas. Tier proposals match the capability map in the
+# plan; they're scored separately and may diverge in the audit.
+areas:
+  - id: core_analyze
+    name: "Core analyze pipeline"
+    pillar: understand
+    tier: 1
+    surface: "terrain analyze, snapshot, signal manifest"
+    description: "The foundation every other area builds on."
+
+  - id: insights_impact_explain
+    name: "Insights / impact / explain"
+    pillar: understand
+    tier: 1
+    surface: "report insights/impact/explain (and legacy bare forms)"
+    description: "Read-side queries over the snapshot."
+
+  - id: summary_posture_metrics_focus
+    name: "Summary / posture / metrics / focus"
+    pillar: understand
+    tier: 1
+    surface: "report summary/posture/metrics/focus (and legacy bare forms)"
+    description: "Aggregation views over signals; closest area to the alignment narrative."
+
+  - id: pr_change_scoped
+    name: "PR / change-scoped"
+    pillar: gate
+    tier: 1
+    surface: "report pr, report select-tests, compare"
+    description: "Workflow-scoped gating — where adopters meet Terrain."
+
+  - id: ai_risk_inventory
+    name: "AI risk + inventory"
+    pillar: understand
+    tier: 1
+    surface: "aiSurface* detectors, AI surface inference, AI inventory in analyze output"
+    description: "Heuristic detectors; inventory is reliable, hygiene/regression are Tier-2 in 0.2.0."
+
+  - id: ai_eval_ingestion
+    name: "AI eval ingestion"
+    pillar: gate
+    tier: 1
+    surface: "Promptfoo / DeepEval / Ragas adapters; terrain ai run --baseline"
+    description: "Different code path from runtime ingestion; integration-testing target."
+
+  - id: ai_execution_gating
+    name: "AI execution + gating"
+    pillar: gate
+    tier: 2
+    surface: "terrain ai run, ai gate (planned)"
+    description: "Sandbox + secrets concerns; trust-boundary doc is a 0.2.0 deliverable."
+
+  - id: migration_conversion
+    name: "Migration / conversion"
+    pillar: align
+    tier: 1
+    surface: "migrate / convert namespace, framework-pair converters"
+    description: "Used in service of repo alignment; framing pivot to alignment-first in 0.2.0."
+
+  - id: portfolio
+    name: "Portfolio"
+    pillar: align
+    tier: 2
+    surface: "terrain portfolio (multi-repo)"
+    description: "Multi-repo aggregation; partial-ship acceptable in 0.2.0."
+
+  - id: policy_governance
+    name: "Policy / governance"
+    pillar: gate
+    tier: 1
+    surface: "policy check, ownership"
+    description: "Operational risk dimension; needs onboarding lift."
+
+  - id: server
+    name: "Server"
+    pillar: understand
+    tier: 2
+    surface: "terrain serve (local HTTP)"
+    description: "Local development tool; no auth, localhost-only."
+
+  - id: distribution_install
+    name: "Distribution / install"
+    pillar: cross_cutting
+    tier: 1
+    surface: "npm / brew / cosign / postinstall"
+    description: "Pre-first-run trust surface; cross-cutting prerequisite for every pillar."
+
+# 17 axes. Levels 1, 3, 5 are anchor points; 2 and 4 are intermediate
+# (between adjacent anchors).
+axes:
+  # ── Product axes (7) ─────────────────────────────────────────
+  - id: P1
+    name: "Feature completeness"
+    lens: product
+    description: "Does the area cover the user's actual workflow?"
+    levels:
+      "1": "Skeleton; common flows missing"
+      "3": "Common flows work end-to-end; rough edges remain"
+      "5": "Every documented flow works including edge cases"
+
+  - id: P2
+    name: "Output trust"
+    lens: product
+    description: "Can a senior engineer rely on the output without checking?"
+    levels:
+      "1": "Anecdotal / heuristic only"
+      "3": "Calibrated on synthetic fixtures (recall-anchored)"
+      "5": "Calibrated against labeled real-repo corpus with published precision/recall"
+
+  - id: P3
+    name: "Documentation"
+    lens: product
+    description: "Are docs accurate, honest, and complete?"
+    levels:
+      "1": "README mentions exist"
+      "3": "Per-feature doc with caveats; rule pages auto-generated"
+      "5": "Worked example + known false positives + suppression guidance per detector/feature"
+
+  - id: P4
+    name: "Onboarding"
+    lens: product
+    description: "Can a new user get to first value quickly?"
+    levels:
+      "1": "Requires reading source"
+      "3": "Quickstart works on a sample repo"
+      "5": "Quickstart works on an unfamiliar real repo in <15 minutes"
+
+  - id: P5
+    name: "Error UX"
+    lens: product
+    description: "When things go wrong, is the message actionable?"
+    levels:
+      "1": "Stack traces / opaque"
+      "3": "Actionable but inconsistent across commands"
+      "5": "Every error has a remediation pointer; standard template"
+
+  - id: P6
+    name: "Examples"
+    lens: product
+    description: "Are there real, reproducible examples per surface?"
+    levels:
+      "1": "One in README"
+      "3": "Examples per command"
+      "5": "Reproducible per-platform examples in CI"
+
+  - id: P7
+    name: "Use-case fit"
+    lens: product
+    description: "Does this area serve the headline job, or sit adjacent?"
+    levels:
+      "1": "Solves a fraction of the user's actual job"
+      "3": "Solves the headline job for this area"
+      "5": "Solves the job and composes with neighbouring tools cleanly"
+
+  # ── Engineering axes (7) ─────────────────────────────────────
+  - id: E1
+    name: "Test coverage"
+    lens: engineering
+    description: "Unit + integration + golden uniformly across packages."
+    levels:
+      "1": "Unit only, sparse"
+      "3": "Unit + integration"
+      "5": "Unit + integration + golden + property/fuzz"
+
+  - id: E2
+    name: "Calibration"
+    lens: engineering
+    description: "Recall and precision evidence for detectors and parsers."
+    levels:
+      "1": "None"
+      "3": "Recall-anchor fixtures"
+      "5": "Precision floor against real-repo corpus"
+
+  - id: E3
+    name: "Observability"
+    lens: engineering
+    description: "Can the user see how/why a result was produced?"
+    levels:
+      "1": "None"
+      "3": "Logs on demand (--log-level=debug)"
+      "5": "Per-component timing + completeness score in normal output"
+
+  - id: E4
+    name: "Stability"
+    lens: engineering
+    description: "Are output schemas versioned and field tiers documented?"
+    levels:
+      "1": "Schema unversioned"
+      "3": "Schema versioned, fields can move"
+      "5": "Stable/beta/internal field tiers documented"
+
+  - id: E5
+    name: "Performance"
+    lens: engineering
+    description: "Bounded memory + time budgets per repo size class."
+    levels:
+      "1": "Unbounded"
+      "3": "Walks complete on Terrain self-scan"
+      "5": "Memory + time budgets documented per repo size class"
+
+  - id: E6
+    name: "Determinism"
+    lens: engineering
+    description: "Repeatable output under SOURCE_DATE_EPOCH."
+    levels:
+      "1": "None"
+      "3": "SOURCE_DATE_EPOCH honored"
+      "5": "Byte-identical output gate in CI"
+
+  - id: E7
+    name: "Cancellation"
+    lens: engineering
+    description: "context.Context wired through inner loops."
+    levels:
+      "1": "context.Background()"
+      "3": "Context plumbed at top level"
+      "5": "Context honored in inner loops; verified by deliberately-slow tests"
+
+  # ── UI/visual axes (3, new in this plan) ─────────────────────
+  - id: V1
+    name: "Visual consistency"
+    lens: visual
+    description: "Renderers consume from shared design tokens."
+    levels:
+      "1": "Ad-hoc styling per command"
+      "3": "Most user-visible output goes through shared tokens"
+      "5": "Every renderer (terminal, HTML, markdown) uses the same token set; CI catches drift"
+
+  - id: V2
+    name: "Information rhythm"
+    lens: visual
+    description: "Output reads cleanly; signal-to-noise calibrated."
+    levels:
+      "1": "Wall-of-text or scattered output"
+      "3": "Sections are scanned in <5 seconds; signal-to-noise calibrated"
+      "5": "Output reads like a designed document; user knows where to look without instruction"
+
+  - id: V3
+    name: "Fun-to-use polish"
+    lens: visual
+    description: "Empty states, errors, progress, and tone of voice."
+    levels:
+      "1": "Errors are jargon; empty states are blank; first-run is silent"
+      "3": "Error messages have remediation; empty states suggest a next move; first-run greets the user"
+      "5": "Every empty state, error, and progress moment is designed; tone of voice is confident and idiomatic; small delights don't feel out of place"
+
+# Cross-cutting uniformity gates. The parity-gate tool runs each gate
+# in addition to the per-cell floor checks. A uniformity failure blocks
+# the release even when every cell is at its floor.
+uniformity_gates:
+  - id: detector_shape
+    name: "Detector shape uniformity"
+    description: "Every detector has all 8 required fields: stable ID, title, summary, severity rationale, evidence sources, calibration anchor, known false positives, suppression guidance."
+    applies_to: "All shipping detectors (manifest)"
+    verified_by: "cmd/terrain-docs-gen manifest validator"
+    blocking: true
+
+  - id: framework_depth
+    name: "Framework depth uniformity"
+    description: "Every Tier-1 framework hits the same axis floor across all axes — no asymmetry between Jest/pytest/Go test."
+    applies_to: "Tier-1 frameworks: Jest, Vitest, Mocha, Playwright, Cypress, pytest, Go test"
+    verified_by: "Per-framework cell scores in the parity dashboard"
+    blocking: true
+
+  - id: command_shape
+    name: "Command shape uniformity"
+    description: "Every command has the same shape: pillar marker, tier badge, journey question, --help structure, --json envelope, exit-code semantics, error template, suppression respect."
+    applies_to: "Every shipping command"
+    verified_by: "Help-shape golden tests; JSON-envelope schema validation"
+    blocking: true
+
+  - id: doc_scaffold
+    name: "Doc scaffold uniformity"
+    description: "Every per-detector / per-framework page follows the eight-section scaffold: title → status → summary → remediation → promotion plan → evidence sources → known false positives → suppression guidance → calibration status."
+    applies_to: "All docs/rules/* and docs/migration/* pages"
+    verified_by: "make docs-verify (extended)"
+    blocking: true
+
+  - id: renderer_tokens
+    name: "Renderer token uniformity"
+    description: "Terminal, HTML report, and PR-comment markdown all consume from internal/uitokens. No raw color codes or ad-hoc symbols outside that package."
+    applies_to: "Every user-visible code path"
+    verified_by: "Lint / vet rule that flags raw ANSI codes / ad-hoc symbols"
+    blocking: true
+
+  - id: empty_state_coverage
+    name: "Empty-state coverage"
+    description: "Every command that produces a list of findings has a designed empty-state path: zero findings, no AI surfaces, no policy file, first-run."
+    applies_to: "Every list-producing command"
+    verified_by: "Empty-state golden tests on a clean fixture"
+    blocking: true
+
+  - id: voice_and_tone
+    name: "Voice & tone uniformity"
+    description: "No hedging, no jargon-only phrases, plain English, no British spellings."
+    applies_to: "Every user-visible string"
+    verified_by: "Style-lint pass over user-visible strings (custom linter or manual review pass)"
+    blocking: false  # Subjective; advisory in 0.2.0, enforced in 0.2.x.

--- a/docs/release/parity/scores.yaml
+++ b/docs/release/parity/scores.yaml
@@ -1,0 +1,249 @@
+# Per-cell parity scores for the 12 functional areas × 17 axes rubric.
+#
+# Each cell is scored 1-5 with one-line evidence (file:line, test name,
+# or "no evidence found"). When a PR lifts a cell, this file is updated
+# alongside the code change. The parity-gate tool reads this file and
+# compares against the floors defined in rubric.yaml.
+#
+# Snapshot taken: 2026-05-02 against `main` at commit 8545f03.
+# This reflects the state captured in the 0.2.x maturity audit doc.
+#
+# When this file is in conflict with the audit doc (during a parity-
+# lift PR), the audit doc is the human-readable record and this file
+# is the machine-readable enforcement. Both update together.
+
+schema_version: "1"
+captured_at: "2026-05-02"
+captured_against_commit: "8545f03"
+
+# Per-area, per-axis score with evidence pointer.
+# The V-axes (V1, V2, V3) are baseline-scored from the current state;
+# they will be the largest area of lift in the 0.2.0 work.
+scores:
+  core_analyze:
+    P1: { score: 4, evidence: "Snapshot covers test files / frameworks / signals / code units / coverage / runtime / ownership / AI surfaces / eval scenarios. Edge case gaps: dynamic test generation heuristic; no first-class monorepo workspace support." }
+    P2: { score: 3, evidence: "27-fixture calibration corpus pins recall at 1.00 across 33 detectors (internal/engine/calibration_integration_test.go). Precision floor against labeled real repos deferred to 0.3." }
+    P3: { score: 4, evidence: "docs/rules/ has per-detector pages auto-regenerated from manifest. Gap: no per-detector 'known false positives' section yet." }
+    P4: { score: 4, evidence: "terrain init + terrain analyze work on any directory. Gap: no terrain init --emit-ci-workflow." }
+    P5: { score: 3, evidence: "validateCommandInputs catches obvious arg issues. Gap: mid-pipeline parse failure surfaces as 'analysis failed: <wrapped>' without remediation." }
+    P6: { score: 3, evidence: "README has illustrative report; docs/examples/ has end-to-end fixtures. Gap: no per-platform reproducible smoke." }
+    P7: { score: 4, evidence: "Maps directly to alignment use case (where do tests cover code? where don't they?)." }
+    E1: { score: 4, evidence: "internal/engine/, internal/analysis/, internal/signals/ all have unit + integration tests. Gap: no fuzz tests on parser entry points." }
+    E2: { score: 3, evidence: "Recall gate locked in (calibration_integration_test.go:166). Synthetic-corpus precision is 1.00 but only labeled signals participate." }
+    E3: { score: 3, evidence: "result.DiscoveryMessages, OnProgress callback, --log-level=debug. Gap: no per-detector timing in normal output; no completeness score surfaced." }
+    E4: { score: 4, evidence: "models.SnapshotSchemaVersion = '1.1.0'; SignalV2 fields are omitempty. Gap: no published 'stable / beta / internal' tier markers per JSON field." }
+    E5: { score: 3, evidence: "Self-scan ~99s on the Terrain repo (per feature-status.md); make bench-gate infrastructure exists but no benchmarks/baseline.txt yet. Tree-sitter parser pool added in 0.2." }
+    E6: { score: 4, evidence: "make test-determinism enforces SOURCE_DATE_EPOCH byte-identical output. sortSignals uses sort.SliceStable with Symbol tiebreaker." }
+    E7: { score: 3, evidence: "RunPipelineContext exists; top-level callsites use runPipelineWithSignals. Gap: untested whether file-reading detectors check ctx.Err() in inner loops; deliberately-slow detector cancel test does not exist." }
+    V1: { score: 2, evidence: "Mostly ad-hoc styling. Some shared helpers in internal/reporting (e.g. plural.go) but no token package. Track 10.1 lifts to 3+." }
+    V2: { score: 3, evidence: "PR #130 polish closed several rhythm issues (pluralization, dimension labels, measurement totals). Sections scan reasonably; some commands still emit wall-of-text." }
+    V3: { score: 2, evidence: "Errors are mostly bare wrapping; some commands have empty states but inconsistently; first-run has no greeting. Track 10.6 + 10.7 lift this." }
+
+  insights_impact_explain:
+    P1: { score: 3, evidence: "All three render reports against the snapshot. impact does git-diff-based selection. Gap: explain doesn't accept a finding ID as a target; needs Phase 3.1 stable IDs." }
+    P2: { score: 3, evidence: "Output derives from the snapshot; trust inherits from area 1." }
+    P3: { score: 3, evidence: "docs/examples/{insights,impact,explain}-report.md exist. Gap: per-command 'how confidence is computed' pages don't exist." }
+    P4: { score: 3, evidence: "Quickstart shows the four canonical commands with one-liner descriptions." }
+    P5: { score: 3, evidence: "exitNotFound = 5 distinguishes missing-entity from analysis-failed. Gap: explain 'couldn't find target' messages don't suggest similar known IDs." }
+    P6: { score: 3, evidence: "Per-command example doc files." }
+    P7: { score: 4, evidence: "PR-risk-report use case maps directly to impact + pr." }
+    E1: { score: 4, evidence: "internal/insights/, internal/impact/, internal/explain/ have unit + integration tests. cmd_explain.go integration-tested via cmd/terrain/cmd_explain_test.go." }
+    E2: { score: 3, evidence: "Inherits area 1's calibration. Impact selection is heuristic; no precision benchmark on labeled real-repo PRs." }
+    E3: { score: 2, evidence: "--show <view> switches drill-downs but no per-stage timing. No 'why these tests, why not others' view despite the data being in the snapshot." }
+    E4: { score: 3, evidence: "JSON output schemas exist. Gap: no documented field tiers." }
+    E5: { score: 3, evidence: "All three are read-side over the snapshot — fast." }
+    E6: { score: 4, evidence: "Inherits the snapshot determinism gate." }
+    E7: { score: 3, evidence: "All callsites use runPipelineWithSignals." }
+    V1: { score: 2, evidence: "Inherits area 1 styling state. No token consumption yet." }
+    V2: { score: 3, evidence: "Reports scan reasonably; impact view is dense and could use more rhythm." }
+    V3: { score: 2, evidence: "explain target-not-found error is bare; no empty states for impact when nothing is selected." }
+
+  summary_posture_metrics_focus:
+    P1: { score: 4, evidence: "summary aggregates posture/risk/trends/recommendations; posture shows per-dimension evidence; metrics is a one-page scorecard; focus ranks next actions. PR #130 polished the visual surface." }
+    P2: { score: 3, evidence: "Posture bands computed by internal/measurement/registry.go from per-detector results; recall-anchored. Polarity-aware band rendering (PR #130) closed a misleading-output bug." }
+    P3: { score: 4, evidence: "docs/product/posture-model.md describes dimensions + questions. Per-measurement explanations in code (buildPostureExplanation)." }
+    P4: { score: 4, evidence: "summary is the recommended first read after analyze." }
+    P5: { score: 3, evidence: "Falls back gracefully when posture is unknown." }
+    P6: { score: 3, evidence: "README + quickstart have summary outputs." }
+    P7: { score: 5, evidence: "Closest area to the headline alignment story: posture dimensions describe how aligned the test surface is with the code surface." }
+    E1: { score: 4, evidence: "internal/summary/, internal/measurement/, internal/reporting/ all tested. Polarity-translation tests added in PR #130." }
+    E2: { score: 3, evidence: "Band thresholds (ratioToBand(.05, .15, .30) etc.) are author-tuned, not corpus-tuned. Scoring v2 band re-anchoring deferred to 0.3." }
+    E3: { score: 3, evidence: "posture --verbose shows measurement evidence." }
+    E4: { score: 4, evidence: "MeasurementResult schema is versioned; KeyMeasurement (PR #130) is omitempty." }
+    E5: { score: 4, evidence: "All read-side; fast." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 3, evidence: "Inherits." }
+    V1: { score: 3, evidence: "PR #130 introduced consistent dimension labels and polarity-aware band rendering. No token package yet but the rhythm is uniform." }
+    V2: { score: 4, evidence: "summary output reads as a designed document; concrete measurements alongside band labels (PR #130)." }
+    V3: { score: 3, evidence: "Empty states exist for some scenarios; first-time analysis shows a baseline-establishing message." }
+
+  pr_change_scoped:
+    P1: { score: 3, evidence: "terrain pr builds change-scoped report with PR-comment markdown. Gap: no --fail-on on pr (PR #134 only added it to analyze); no --new-findings-only." }
+    P2: { score: 3, evidence: "Inherits area 1. Gap: PR comments may show signals against unchanged files when fan-out detection fires." }
+    P3: { score: 3, evidence: "docs/examples/pr-report.md exists. Gap: no documented suppression workflow (suppressions don't ship until 0.3 in earlier plan; pulled forward to 0.2.0 here)." }
+    P4: { score: 3, evidence: ".github/workflows/terrain-pr.yml template exists. Gap: no zero-config 'drop this snippet in your CI' path with --new-findings-only baked in." }
+    P5: { score: 3, evidence: "Standard error wrapping." }
+    P6: { score: 3, evidence: "Per-command examples. Gap: no recorded video / animated GIF of a real PR-comment cycle." }
+    P7: { score: 4, evidence: "PR risk report without running tests is the right framing. Gap: no 'established repos with debt' mode." }
+    E1: { score: 4, evidence: "internal/changescope/ thoroughly tested; PR #131 updated tests for the AI-Risk-Review rename." }
+    E2: { score: 2, evidence: "No corpus of labeled PR diffs to measure impact-selection precision against." }
+    E3: { score: 2, evidence: "No 'why these tests, why not others' view; no confidence histogram." }
+    E4: { score: 3, evidence: "JSON shape exists." }
+    E5: { score: 3, evidence: "Bounded by area 1." }
+    E6: { score: 3, evidence: "Inherits." }
+    E7: { score: 3, evidence: "Inherits." }
+    V1: { score: 2, evidence: "PR comment uses ad-hoc markdown. Tokens not consumed yet." }
+    V2: { score: 3, evidence: "PR comment is reasonably scannable but no hero verdict block; severity badges inconsistent." }
+    V3: { score: 2, evidence: "Empty PR (no findings) renders blandly; no recommendation for next step." }
+
+  ai_risk_inventory:
+    P1: { score: 3, evidence: "12 detectors registered. RAG structured parser + AI surface detection." }
+    P2: { score: 2, evidence: "Recall-anchored on 27 fixtures; no labeled-real-repo precision floor. Multiple known-gap items per detector." }
+    P3: { score: 3, evidence: "Each detector has docs/rules/ai/ page with summary + remediation + promotion plan + known limitations." }
+    P4: { score: 3, evidence: "AI surfaces appear in normal analyze output without special flags. terrain ai list/run/doctor available." }
+    P5: { score: 3, evidence: "Detectors needing missing data emit informative no-op signals." }
+    P6: { score: 2, evidence: "Calibration fixtures exist as test data, but no public end-to-end demonstration." }
+    P7: { score: 3, evidence: "AI inventory IS distinctive. AI risk findings read like security scanning but trust model is much weaker than that framing implies." }
+    E1: { score: 4, evidence: "internal/aidetect/ extensively tested; calibration corpus integration." }
+    E2: { score: 2, evidence: "Synthetic-fixture recall only. Per 0.2-known-gaps.md: substring matches in aiToolWithoutSandbox, naive 40-char in aiFewShotContamination, closed-class English keywords in aiHallucinationRate." }
+    E3: { score: 3, evidence: "Detectors emit explanations and inputs lists." }
+    E4: { score: 3, evidence: "Manifest-versioned. Gap: aiHallucinationRate name implies model judgment; rename in Track 5.2." }
+    E5: { score: 3, evidence: "File-scan based; bounded." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 2, evidence: "File-reading detectors haven't been audited for ctx.Err() checks in inner loops." }
+    V1: { score: 2, evidence: "AI Risk Review section in PR comments was renamed in PR #131 but visual treatment is uniform across all detectors regardless of trust tier." }
+    V2: { score: 2, evidence: "Inventory / hygiene / regression all rendered together with no visual distinction; user can't tell which findings are reliable vs heuristic." }
+    V3: { score: 2, evidence: "AI risk findings emit but provide no remediation pointers tailored to the LLM context (e.g. 'check if your prompt template uses {{ variable }} substitution')." }
+
+  ai_eval_ingestion:
+    P1: { score: 3, evidence: "Three adapters parse v3 + v4 (Promptfoo), 1.x shape (DeepEval), modern + legacy (Ragas). Baseline-snapshot regression mechanism exists." }
+    P2: { score: 3, evidence: "Strong-evidence results when adapters parse correctly. Edge cases (provider-crash rows, missing cost fields) handled in PR #128's polish." }
+    P3: { score: 4, evidence: "docs/integrations/{promptfoo,deepeval,ragas}.md per-framework guides; 0.2-known-gaps.md lists open issues." }
+    P4: { score: 3, evidence: "--promptfoo-results <path> documented. Gap: no 'here's a five-line CI snippet' example." }
+    P5: { score: 3, evidence: "0.2-known-gaps.md calls out: 'empty results: [] raises misleading error'. 0.2.x fix planned." }
+    P6: { score: 2, evidence: "Calibration fixtures exist as test data; no public adapter conformance smoke." }
+    P7: { score: 4, evidence: "Eval-artifact ingestion is a real differentiator vs. tools that only do static analysis." }
+    E1: { score: 4, evidence: "internal/airun/*_test.go covers shape variants." }
+    E2: { score: 2, evidence: "No 'adapter conformance fixtures' that lock in each adapter's parse semantics. Adapter version detection deferred." }
+    E3: { score: 2, evidence: "Aggregates emit, but no 'which fields fell back to defaults' warnings." }
+    E4: { score: 3, evidence: "Aggregates schema versioned via models.EvalAggregates. Gap: each adapter consumes its upstream's shape; we won't notice when upstream changes." }
+    E5: { score: 4, evidence: "JSON parsing; fast." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 3, evidence: "Top-level honored; reads are bounded so inner-loop checks aren't critical." }
+    V1: { score: 2, evidence: "No specific token consumption for eval rendering." }
+    V2: { score: 3, evidence: "Aggregate output is structured; per-adapter rendering is consistent." }
+    V3: { score: 2, evidence: "Errors when adapter fails (missing field, wrong shape) are technical, not conversational." }
+
+  ai_execution_gating:
+    P1: { score: 2, evidence: "terrain ai run ingests eval artifacts and emits a baseline-aware decision. Gap: docs unclear about which frameworks Terrain executes vs only parses; sandboxing 0.3; ai gate standalone doesn't ship." }
+    P2: { score: 3, evidence: "Decisions match what the artifact data supports; we're not making model claims." }
+    P3: { score: 2, evidence: "The trust boundary 'Terrain parses; the eval framework executes' is not stated clearly." }
+    P4: { score: 2, evidence: "Users new to AI evals don't know whether to run Promptfoo first or just point Terrain at it." }
+    P5: { score: 3, evidence: "Reasonable; baseline missing → graceful no-op." }
+    P6: { score: 2, evidence: "No end-to-end 'configure Promptfoo + Terrain in CI' example doc." }
+    P7: { score: 3, evidence: "Right framing: gating on AI evals before merge." }
+    E1: { score: 3, evidence: "Unit tests on the decision logic; integration tests on the parsers." }
+    E2: { score: 2, evidence: "No labeled-PR corpus for the gating decision specifically." }
+    E3: { score: 2, evidence: "'Reason' string exists; no per-input-artifact diagnostic." }
+    E4: { score: 3, evidence: "Decision shape is small and versioned." }
+    E5: { score: 4, evidence: "Trivial." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 3, evidence: "Inherits." }
+    V1: { score: 2, evidence: "Decision output uses ad-hoc styling." }
+    V2: { score: 2, evidence: "No hero verdict block; reason string buried." }
+    V3: { score: 2, evidence: "No empty states for 'no AI surfaces detected'; no remediation for gate-blocked decisions." }
+
+  migration_conversion:
+    P1: { score: 4, evidence: "migrate run/config/list/detect/shorthands/estimate/status/checklist/readiness/blockers/preview namespace; per-file converters; preview LCS-diff." }
+    P2: { score: 3, evidence: "Conversion confidence per file. Gap: A-grade ratings for top-3 fixture corpora deferred to 0.3." }
+    P3: { score: 4, evidence: "Per-direction docs exist. docs/migration/* covers framework pairs." }
+    P4: { score: 3, evidence: "terrain migrate readiness is a useful entry point. Gap: no 'alignment-first' framing in user-facing docs." }
+    P5: { score: 4, evidence: "Per-file confidence + preview-before-apply is a strong UX." }
+    P6: { score: 4, evidence: "Multiple per-direction example fixtures." }
+    P7: { score: 3, evidence: "Capability is solid; framing is misaligned with the actual job. Today's docs lead with 'convert this file' rather than 'your repo has framework drift'." }
+    E1: { score: 4, evidence: "internal/convert/, internal/migration/ extensively tested." }
+    E2: { score: 2, evidence: "Top-3 fixture corpora to A-grade with 95% post-conversion pass rate deferred to 0.3." }
+    E3: { score: 4, evidence: ".terrain/conversion-history/ JSONL audit trail." }
+    E4: { score: 3, evidence: "Per-direction shapes exist. Gap: no documented 'stable / experimental' tier per direction." }
+    E5: { score: 4, evidence: "LCS diff is bounded; per-file." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 3, evidence: "Inherits." }
+    V1: { score: 3, evidence: "Migration output has consistent rhythm; preview rendering is structured." }
+    V2: { score: 4, evidence: "Per-file confidence + preview reads cleanly." }
+    V3: { score: 3, evidence: "Estimate/readiness has reasonable empty-state ('no conversions detected')." }
+
+  portfolio:
+    P1: { score: 2, evidence: "Top-level command works on a single repo. Multi-repo aggregation is asserted in marketing but no shipping rollup workflow." }
+    P2: { score: 2, evidence: "Single-repo numbers are correct. Multi-repo is not actually implemented as advertised." }
+    P3: { score: 3, evidence: "docs/personas/sdet.md mentions portfolio." }
+    P4: { score: 2, evidence: "Discoverable via help; no 'here's the multi-repo flow' doc." }
+    P5: { score: 3, evidence: "Standard." }
+    P6: { score: 2, evidence: "No multi-repo example." }
+    P7: { score: 3, evidence: "Cross-repo alignment is a real job. Capability gap is acute." }
+    E1: { score: 3, evidence: "Unit tests on the per-repo aggregator." }
+    E2: { score: 2, evidence: "No multi-repo corpus." }
+    E3: { score: 3, evidence: "Inherits." }
+    E4: { score: 2, evidence: "Schema for portfolio output not documented." }
+    E5: { score: 3, evidence: "Per-repo." }
+    E6: { score: 3, evidence: "Inherits." }
+    E7: { score: 3, evidence: "Inherits." }
+    V1: { score: 2, evidence: "Single-repo portfolio rendering uses ad-hoc styling." }
+    V2: { score: 2, evidence: "Output is dense; no per-pillar drift visualization." }
+    V3: { score: 2, evidence: "No designed multi-repo empty state." }
+
+  policy_governance:
+    P1: { score: 3, evidence: "Policy file format exists; rule evaluation works. Gap: no rule-authoring UI; rules written by hand." }
+    P2: { score: 4, evidence: "Policy results are deterministic boolean checks against the snapshot." }
+    P3: { score: 3, evidence: "internal/policy/config.go documents the schema in code; docs/release/0.2.md mentions policy. Gap: no top-level 'writing a policy' doc." }
+    P4: { score: 2, evidence: "No terrain init --emit-policy-template flow." }
+    P5: { score: 3, evidence: "Standard." }
+    P6: { score: 2, evidence: "One policy example in test fixtures." }
+    P7: { score: 4, evidence: "Policy enforcement is a real adopter need." }
+    E1: { score: 4, evidence: "internal/policy/ tested." }
+    E2: { score: 4, evidence: "Boolean checks; no calibration concept." }
+    E3: { score: 3, evidence: "Standard." }
+    E4: { score: 3, evidence: "YAML schema versioned." }
+    E5: { score: 4, evidence: "Trivial." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 4, evidence: "Trivial." }
+    V1: { score: 2, evidence: "Policy check output uses ad-hoc styling." }
+    V2: { score: 3, evidence: "Reasonable rhythm; one finding per line." }
+    V3: { score: 2, evidence: "No 'no policy file' guided next-step ('terrain init will create one')." }
+
+  server:
+    P1: { score: 3, evidence: "Renders HTML report at /; /api/health, /api/analyze. Read-only flag enforces 405." }
+    P2: { score: 3, evidence: "Output trust inherits area 1." }
+    P3: { score: 3, evidence: "cmd/terrain/cmd_serve.go flag docstring; internal/server/server.go security-posture comment block. PR #131 brought these up to date." }
+    P4: { score: 3, evidence: "One-line invocation; opens locally." }
+    P5: { score: 3, evidence: "Standard 5xx; PR #132 adds context-cancel-friendly handler returns." }
+    P6: { score: 2, evidence: "No 'use this for local dev' example doc." }
+    P7: { score: 3, evidence: "Honest scope: local dev preview, not a team dashboard. Should never be marketed otherwise." }
+    E1: { score: 4, evidence: "internal/server/server_test.go covers handlers, security middleware, origin checks, cache + cancellation (PR #132)." }
+    E2: { score: 4, evidence: "N/A." }
+    E3: { score: 3, evidence: "Stderr startup banner; per-request logging is minimal." }
+    E4: { score: 3, evidence: "API endpoints documented in code; no public schema." }
+    E5: { score: 3, evidence: "Singleflight + RWMutex (PR #132) fix the original mutex-blocking bug." }
+    E6: { score: 4, evidence: "Inherits." }
+    E7: { score: 2, evidence: "Pre-#132: handlers ignore r.Context(). With #132 merged: 4 (per-caller cancel via select)." }
+    V1: { score: 2, evidence: "HTML report uses ad-hoc CSS; needs design system pass (Track 10.4)." }
+    V2: { score: 2, evidence: "HTML report is dense; no card-based layout, no sticky navigation." }
+    V3: { score: 2, evidence: "No empty states; localhost warning could be more guided." }
+
+  distribution_install:
+    P1: { score: 4, evidence: "All three install paths work; cosign signing + npm provenance + SLSA attestations on release archives." }
+    P2: { score: 4, evidence: "Mandatory cosign verify (with documented opt-out env vars)." }
+    P3: { score: 3, evidence: "PR #131 adds Prerequisites section + opt-out env vars to getting-started. With #131: 4." }
+    P4: { score: 2, evidence: "Node ≥22 requirement is hidden friction; many CI images are Node 20 LTS. Cosign install step adds friction for casual users." }
+    P5: { score: 2, evidence: "Pre-#133: postinstall swallows failure silently. With #133: 4 (marker file + framed banner)." }
+    P6: { score: 3, evidence: "Install snippets in README + getting-started." }
+    P7: { score: 4, evidence: "Three install paths cover the audience." }
+    E1: { score: 3, evidence: "scripts/verify-pack.js smoke. PR #133 adds node --test unit tests for the marker round-trip. With #133: 4." }
+    E2: { score: 4, evidence: "N/A." }
+    E3: { score: 3, evidence: "Postinstall stderr; release-smoke job. Gap: only Linux/amd64 release-smoke." }
+    E4: { score: 4, evidence: "npm package shape is simple." }
+    E5: { score: 4, evidence: "Install bounded by GitHub release download." }
+    E6: { score: 4, evidence: "Tarball contents reproducible." }
+    E7: { score: 4, evidence: "Trivial." }
+    V1: { score: 3, evidence: "PR #133 banner uses framed multi-line warning; first design-tokens consumer." }
+    V2: { score: 3, evidence: "Postinstall warning is well-structured; install errors readable." }
+    V3: { score: 3, evidence: "PR #133 marker-file + remediation block lifts P5/V3." }


### PR DESCRIPTION
## Summary

Track 0.1 from the 0.2.0 parity-gated release plan. Encodes the 12-area × 17-axis maturity rubric as data so Track 0.2 (the \`parity-gate\` Go binary) can consume it.

Two files, both pure data:

- **\`docs/release/parity/rubric.yaml\`** — structural source of truth
- **\`docs/release/parity/scores.yaml\`** — current per-cell scores (204 cells, one-line evidence each)

## What's in the rubric

- **3 pillars** with priorities for 0.2.0: Gate (1°), Understand (2°), Align (3° soft)
- **12 functional areas** with pillar + tier + surface
- **17 axes** — 7 product (P1-P7), 7 engineering (E1-E7), 3 UI/visual (V1-V3) — each with anchored level definitions for 1, 3, 5
- **Per-pillar floors**: Gate ≥ 4, Understand ≥ 3, Align ≥ 3 (soft warn-only)
- **7 cross-cutting uniformity gates** that catch unevenness across detectors, frameworks, commands, and outputs

## Baseline reality check

The current scores are honest about the floor: every pillar has at least one cell at score 2, which matches the launch-readiness review's "uneven product" critique. The 0.2.0 work (Tracks 1–10) lifts those cells to clear the gate.

The V-axes (UI/visual) baseline as the lowest-scoring cluster across the codebase — most output uses ad-hoc styling. Track 10 (Visual & design system) is the cross-cutting lift that addresses this.

## What's next

- **Track 0.2** — \`cmd/terrain-parity-gate\` Go binary that reads both files, emits the matrix + floor map, and exits non-zero when any cell drops below its pillar floor
- **Track 0.4** — wire \`make pillar-parity\` into CI as a hard gate

Both follow in separate PRs.

## Test plan

- [x] Both YAMLs are syntactically valid (parses with stdlib yaml.v3 in Track 0.2's tool)
- [x] 12 areas × 17 axes = 204 cells, every cell has a score and evidence
- [x] Every area in scores.yaml has a corresponding rubric.yaml entry
- [x] Floor map matches the audit doc (\`docs/release/0.2.x-maturity-audit.md\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
