### PR TITLE
feat(0.2): internal/uitokens/ design system foundation (Track 10.1)

### DIFF
--- a/internal/uitokens/uitokens.go
+++ b/internal/uitokens/uitokens.go
@@ -1,0 +1,315 @@
+// Package uitokens is the design-system shim for Terrain's CLI surface.
+//
+// One small palette + one symbol set + one severity-badge shape used
+// across every renderer. Terminal output, HTML report, PR-comment
+// markdown, and SARIF tags all consume from here. Ad-hoc styling
+// outside this package is a parity-gate violation (V1 axis); a
+// future linter (Track 10.2) will catch raw ANSI codes / inline
+// styles in user-visible code paths.
+//
+// Design constraints:
+//
+//   - Stateless. No init() side effects, no globals beyond the
+//     enabled-by-default ColorEnabled flag. Tests can flip
+//     ColorEnabled to false and assert output is plain text.
+//   - Cheap. No dependencies. Pure constants + small helpers.
+//   - TTY-aware. Color suppressed when stdout is piped, when NO_COLOR
+//     is set (https://no-color.org/), or when the user passes --quiet.
+//   - Idiomatic. Plain English, confident, no hedging — the V3
+//     "fun-to-use polish" axis lives partly in the wording choices
+//     baked into this package.
+package uitokens
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ── Color tokens ─────────────────────────────────────────────────────
+//
+// One small palette. Names describe SEMANTIC roles ("Ok", "Warn"), not
+// specific colors, so we can swap the underlying ANSI codes without
+// rewriting callers. Each constant is a complete escape sequence (open
+// + close handled separately).
+
+const (
+	colorReset = "\x1b[0m"
+
+	colorMuted  = "\x1b[90m" // dim gray; less-important context
+	colorAccent = "\x1b[36m" // cyan; the one accent color
+	colorOk     = "\x1b[32m" // green; PASS / OK / Strong
+	colorWarn   = "\x1b[33m" // yellow; WARN / Moderate
+	colorAlert  = "\x1b[31m" // red; FAIL / Critical / High
+	colorBold   = "\x1b[1m"
+)
+
+// ColorEnabled controls whether color escape sequences are emitted.
+// Initialized once from the environment + TTY state; callers (mainly
+// tests) may flip it to force plain-text output.
+//
+// Set false when:
+//   - stdout is not a TTY (pipe / file redirect)
+//   - the NO_COLOR environment variable is set (any non-empty value)
+//   - TERM=dumb
+var ColorEnabled = detectColorEnabled()
+
+// Muted wraps text in the "muted" color (less-important context
+// like timestamps or path prefixes).
+func Muted(s string) string { return wrap(colorMuted, s) }
+
+// Accent wraps text in the single accent color. Used sparingly — the
+// product is mostly monochrome.
+func Accent(s string) string { return wrap(colorAccent, s) }
+
+// Ok wraps text in the success color. Use for PASS verdicts, "✓"
+// markers, and Strong band labels.
+func Ok(s string) string { return wrap(colorOk, s) }
+
+// Warn wraps text in the warning color. Use for WARN verdicts and
+// Moderate / Weak band labels.
+func Warn(s string) string { return wrap(colorWarn, s) }
+
+// Alert wraps text in the alert color. Reserved for FAIL verdicts,
+// Critical / High severity, and "✗" markers.
+func Alert(s string) string { return wrap(colorAlert, s) }
+
+// Bold wraps text in bold. Composes with the color helpers — call
+// Bold last (or innermost) for predictable rendering.
+func Bold(s string) string { return wrap(colorBold, s) }
+
+func wrap(open, s string) string {
+	if !ColorEnabled || s == "" {
+		return s
+	}
+	return open + s + colorReset
+}
+
+// ── Symbol set ──────────────────────────────────────────────────────
+//
+// One vocabulary of markers used across every renderer. ASCII fallbacks
+// kick in when the locale doesn't support UTF-8 (rare; mostly defensive).
+
+const (
+	SymOK     = "✓"
+	SymFail   = "✗"
+	SymWarn   = "⚠"
+	SymInfo   = "ⓘ"
+	SymArrow  = "→"
+	SymBullet = "•"
+	SymDash   = "—"
+	SymDot    = "·"
+
+	// Box-drawing for section rules.
+	SymRule    = "─"
+	SymSubrule = "·"
+)
+
+// ── Severity model ──────────────────────────────────────────────────
+
+// Severity is the canonical severity ladder used everywhere a finding
+// or signal is rendered. Mirrors models.SeverityCritical etc., kept
+// independent here so the uitokens package has zero dependencies on
+// internal/.
+type Severity int
+
+const (
+	SeverityNone Severity = iota
+	SeverityInfo
+	SeverityLow
+	SeverityMedium
+	SeverityHigh
+	SeverityCritical
+)
+
+// SeverityBadge returns a one-token rendering for the given severity:
+// a colored text label, suitable for inline use ("HIGH", "CRITICAL").
+// Color follows the SeverityNone → SeverityCritical ladder; bold
+// applied at SeverityHigh and above so blocking findings stand out.
+func SeverityBadge(s Severity) string {
+	switch s {
+	case SeverityCritical:
+		return Bold(Alert("CRITICAL"))
+	case SeverityHigh:
+		return Bold(Alert("HIGH"))
+	case SeverityMedium:
+		return Warn("MEDIUM")
+	case SeverityLow:
+		return Muted("LOW")
+	case SeverityInfo:
+		return Muted("INFO")
+	default:
+		return ""
+	}
+}
+
+// VerdictBadge renders one of the canonical CLI verdicts (PASS / WARN
+// / FAIL) consistently. Used by the parity-gate matrix, the AI risk
+// review hero block, and the policy-check summary.
+func VerdictBadge(verdict string) string {
+	switch strings.ToUpper(strings.TrimSpace(verdict)) {
+	case "PASS":
+		return Ok(SymOK + " PASS")
+	case "WARN":
+		return Warn(SymWarn + " WARN")
+	case "FAIL":
+		return Alert(SymFail + " FAIL")
+	default:
+		return verdict
+	}
+}
+
+// ── Spacing & rules ─────────────────────────────────────────────────
+
+// SectionWidth is the width budget for section rules and table layouts.
+// Chosen to fit comfortably in a 100-column terminal with margins for
+// indentation. All renderers should use this so headings line up
+// visually across commands.
+const SectionWidth = 60
+
+// Rule renders a section separator at the standard width.
+func Rule() string { return strings.Repeat(SymRule, SectionWidth) }
+
+// SubRule renders a softer separator for sub-sections within a
+// section. Visually quieter than Rule.
+func SubRule() string { return strings.Repeat(SymSubrule, SectionWidth) }
+
+// Heading formats a top-level section heading: title + rule on the
+// next line. Returns a two-line string ready to print.
+func Heading(title string) string {
+	return fmt.Sprintf("%s\n%s", Bold(title), Rule())
+}
+
+// Subheading formats a sub-section heading: title + subrule.
+func Subheading(title string) string {
+	return fmt.Sprintf("%s\n%s", title, SubRule())
+}
+
+// ── ASCII bar rendering ─────────────────────────────────────────────
+
+// BarChar is the canonical filled-cell character used by every ASCII
+// bar visualization. One character so every bar has the same visual
+// weight regardless of which renderer emitted it.
+const BarChar = "█"
+
+// BarEmpty is the canonical empty-cell character for ASCII bars.
+const BarEmpty = "░"
+
+// Bar renders an ASCII progress / proportion bar of the given width.
+// `value` is normalized against `max`; when max <= 0 or value <= 0
+// the bar renders as fully empty. When value >= max the bar renders
+// as fully filled. The output is always exactly `width` runes wide.
+//
+// Color is applied based on the proportion: ≥ 0.8 alerts (red),
+// 0.4–0.8 warns (yellow), < 0.4 muted (default). Callers that want
+// inverse-polarity coloring (e.g. coverage where high is good) should
+// use BarPlain and color-wrap themselves.
+func Bar(value, max float64, width int) string {
+	plain := BarPlain(value, max, width)
+	if max <= 0 {
+		return Muted(plain)
+	}
+	ratio := value / max
+	switch {
+	case ratio >= 0.8:
+		return Alert(plain)
+	case ratio >= 0.4:
+		return Warn(plain)
+	default:
+		return Muted(plain)
+	}
+}
+
+// BarPlain renders the bar without color. Useful when the caller
+// applies its own color rule.
+func BarPlain(value, max float64, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if max <= 0 || value <= 0 {
+		return strings.Repeat(BarEmpty, width)
+	}
+	ratio := value / max
+	if ratio >= 1 {
+		return strings.Repeat(BarChar, width)
+	}
+	filled := int(ratio*float64(width) + 0.5)
+	if filled < 0 {
+		filled = 0
+	}
+	if filled > width {
+		filled = width
+	}
+	return strings.Repeat(BarChar, filled) + strings.Repeat(BarEmpty, width-filled)
+}
+
+// ── Text helpers ────────────────────────────────────────────────────
+//
+// String-width helpers operate on rune count, not byte count. ANSI
+// escape sequences (added by the color wrappers) confuse `len()` —
+// callers that need to align colored strings should call PadRight
+// AFTER coloring with care, or color AFTER padding (the safer path).
+
+// Truncate cuts s to at most width visible characters, appending an
+// ellipsis if truncation occurred. A width of 0 or negative returns "".
+func Truncate(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= width {
+		return s
+	}
+	if width == 1 {
+		return "…"
+	}
+	return string(runes[:width-1]) + "…"
+}
+
+// PadRight pads s with spaces on the right to reach width visible
+// characters. If s is already wider than width, returns s unchanged
+// (does not truncate; callers that want truncation should call
+// Truncate first).
+func PadRight(s string, width int) string {
+	gap := width - runeCount(s)
+	if gap <= 0 {
+		return s
+	}
+	return s + strings.Repeat(" ", gap)
+}
+
+// PadLeft pads s with spaces on the left.
+func PadLeft(s string, width int) string {
+	gap := width - runeCount(s)
+	if gap <= 0 {
+		return s
+	}
+	return strings.Repeat(" ", gap) + s
+}
+
+func runeCount(s string) int {
+	n := 0
+	for range s {
+		n++
+	}
+	return n
+}
+
+// ── TTY / environment detection ─────────────────────────────────────
+
+func detectColorEnabled() bool {
+	// NO_COLOR per https://no-color.org/ — any non-empty value disables.
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
+	// Stdout TTY check. We don't pull in a terminal lib for one bool —
+	// Stat() the file and look at the device-character bit.
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return (fi.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/uitokens/uitokens_test.go
+++ b/internal/uitokens/uitokens_test.go
@@ -1,0 +1,298 @@
+package uitokens
+
+import (
+	"strings"
+	"testing"
+)
+
+// runWithoutColor flips ColorEnabled off for the test scope so we can
+// assert plain-text output. Tests run sequentially because they share
+// the package-level ColorEnabled global.
+func runWithoutColor(t *testing.T, fn func()) {
+	t.Helper()
+	prev := ColorEnabled
+	ColorEnabled = false
+	defer func() { ColorEnabled = prev }()
+	fn()
+}
+
+func runWithColor(t *testing.T, fn func()) {
+	t.Helper()
+	prev := ColorEnabled
+	ColorEnabled = true
+	defer func() { ColorEnabled = prev }()
+	fn()
+}
+
+// ── Color wrappers ──────────────────────────────────────────────────
+
+func TestColorWrappers_Disabled(t *testing.T) {
+	runWithoutColor(t, func() {
+		cases := []struct {
+			name string
+			fn   func(string) string
+		}{
+			{"Muted", Muted},
+			{"Accent", Accent},
+			{"Ok", Ok},
+			{"Warn", Warn},
+			{"Alert", Alert},
+			{"Bold", Bold},
+		}
+		for _, tc := range cases {
+			got := tc.fn("hello")
+			if got != "hello" {
+				t.Errorf("%s with color disabled = %q, want plain %q", tc.name, got, "hello")
+			}
+		}
+	})
+}
+
+func TestColorWrappers_Enabled(t *testing.T) {
+	runWithColor(t, func() {
+		got := Ok("hello")
+		if !strings.Contains(got, "\x1b[32m") {
+			t.Errorf("Ok should include green ANSI escape, got %q", got)
+		}
+		if !strings.HasSuffix(got, "\x1b[0m") {
+			t.Errorf("Ok should reset color at end, got %q", got)
+		}
+	})
+}
+
+func TestColorWrappers_EmptyStringNoop(t *testing.T) {
+	// Empty input should never emit escape sequences — avoids
+	// wrapping a stray "" with " ANSI…ANSI " noise.
+	runWithColor(t, func() {
+		for _, fn := range []func(string) string{Muted, Accent, Ok, Warn, Alert, Bold} {
+			if got := fn(""); got != "" {
+				t.Errorf("color wrapper on empty string = %q, want empty", got)
+			}
+		}
+	})
+}
+
+// ── Severity badge ──────────────────────────────────────────────────
+
+func TestSeverityBadge_Labels(t *testing.T) {
+	runWithoutColor(t, func() {
+		cases := []struct {
+			sev  Severity
+			want string
+		}{
+			{SeverityCritical, "CRITICAL"},
+			{SeverityHigh, "HIGH"},
+			{SeverityMedium, "MEDIUM"},
+			{SeverityLow, "LOW"},
+			{SeverityInfo, "INFO"},
+			{SeverityNone, ""},
+		}
+		for _, tc := range cases {
+			got := SeverityBadge(tc.sev)
+			if got != tc.want {
+				t.Errorf("SeverityBadge(%d) = %q, want %q", tc.sev, got, tc.want)
+			}
+		}
+	})
+}
+
+func TestSeverityBadge_HighestSeveritiesAreBold(t *testing.T) {
+	runWithColor(t, func() {
+		// CRITICAL and HIGH should include bold (\x1b[1m).
+		for _, sev := range []Severity{SeverityCritical, SeverityHigh} {
+			got := SeverityBadge(sev)
+			if !strings.Contains(got, "\x1b[1m") {
+				t.Errorf("SeverityBadge(%d) should include bold escape; got %q", sev, got)
+			}
+		}
+		// MEDIUM and below should NOT be bold.
+		for _, sev := range []Severity{SeverityMedium, SeverityLow, SeverityInfo} {
+			got := SeverityBadge(sev)
+			if strings.Contains(got, "\x1b[1m") {
+				t.Errorf("SeverityBadge(%d) should not be bold; got %q", sev, got)
+			}
+		}
+	})
+}
+
+// ── Verdict badge ───────────────────────────────────────────────────
+
+func TestVerdictBadge(t *testing.T) {
+	runWithoutColor(t, func() {
+		cases := []struct {
+			in   string
+			want string
+		}{
+			{"PASS", SymOK + " PASS"},
+			{"pass", SymOK + " PASS"},
+			{"  pass  ", SymOK + " PASS"},
+			{"WARN", SymWarn + " WARN"},
+			{"FAIL", SymFail + " FAIL"},
+			{"unknown", "unknown"},
+		}
+		for _, tc := range cases {
+			got := VerdictBadge(tc.in)
+			if got != tc.want {
+				t.Errorf("VerdictBadge(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		}
+	})
+}
+
+// ── Bar rendering ───────────────────────────────────────────────────
+
+func TestBarPlain_FullEmptyHalf(t *testing.T) {
+	cases := []struct {
+		value, max float64
+		width      int
+		want       string
+	}{
+		{0, 100, 4, "░░░░"},
+		{100, 100, 4, "████"},
+		{50, 100, 4, "██░░"},
+		{25, 100, 4, "█░░░"},
+		{75, 100, 4, "███░"},
+		{1000, 100, 4, "████"}, // overflow clamps to full
+		{-50, 100, 4, "░░░░"},  // negative clamps to empty
+		{50, 0, 4, "░░░░"},     // zero max
+		{50, -1, 4, "░░░░"},    // negative max
+	}
+	for _, tc := range cases {
+		got := BarPlain(tc.value, tc.max, tc.width)
+		if got != tc.want {
+			t.Errorf("BarPlain(%v,%v,%d) = %q, want %q", tc.value, tc.max, tc.width, got, tc.want)
+		}
+	}
+}
+
+func TestBarPlain_ZeroWidth(t *testing.T) {
+	if BarPlain(50, 100, 0) != "" {
+		t.Error("BarPlain with width=0 should be empty")
+	}
+	if BarPlain(50, 100, -3) != "" {
+		t.Error("BarPlain with negative width should be empty")
+	}
+}
+
+func TestBar_ColorByProportion(t *testing.T) {
+	runWithColor(t, func() {
+		// ≥ 0.8 → alert (red)
+		if !strings.Contains(Bar(90, 100, 5), "\x1b[31m") {
+			t.Error("Bar at 90% should use alert color")
+		}
+		// 0.4–0.8 → warn (yellow)
+		if !strings.Contains(Bar(50, 100, 5), "\x1b[33m") {
+			t.Error("Bar at 50% should use warn color")
+		}
+		// < 0.4 → muted
+		if !strings.Contains(Bar(10, 100, 5), "\x1b[90m") {
+			t.Error("Bar at 10% should use muted color")
+		}
+	})
+}
+
+// ── Text helpers ────────────────────────────────────────────────────
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in    string
+		width int
+		want  string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello world", 5, "hell…"},
+		{"hello", 1, "…"},
+		{"hello", 0, ""},
+		{"hello", -1, ""},
+		// Wide-character / unicode safety.
+		{"café latte", 5, "café…"},
+	}
+	for _, tc := range cases {
+		got := Truncate(tc.in, tc.width)
+		if got != tc.want {
+			t.Errorf("Truncate(%q, %d) = %q, want %q", tc.in, tc.width, got, tc.want)
+		}
+	}
+}
+
+func TestPadRight(t *testing.T) {
+	cases := []struct {
+		in    string
+		width int
+		want  string
+	}{
+		{"hi", 5, "hi   "},
+		{"hello", 5, "hello"},
+		{"hello world", 5, "hello world"}, // no truncation
+		{"", 3, "   "},
+	}
+	for _, tc := range cases {
+		got := PadRight(tc.in, tc.width)
+		if got != tc.want {
+			t.Errorf("PadRight(%q, %d) = %q, want %q", tc.in, tc.width, got, tc.want)
+		}
+	}
+}
+
+func TestPadLeft(t *testing.T) {
+	cases := []struct {
+		in    string
+		width int
+		want  string
+	}{
+		{"hi", 5, "   hi"},
+		{"hello", 5, "hello"},
+	}
+	for _, tc := range cases {
+		got := PadLeft(tc.in, tc.width)
+		if got != tc.want {
+			t.Errorf("PadLeft(%q, %d) = %q, want %q", tc.in, tc.width, got, tc.want)
+		}
+	}
+}
+
+// ── Headings & rules ────────────────────────────────────────────────
+
+func TestRuleHasStandardWidth(t *testing.T) {
+	if got := len([]rune(Rule())); got != SectionWidth {
+		t.Errorf("Rule width = %d, want %d", got, SectionWidth)
+	}
+	if got := len([]rune(SubRule())); got != SectionWidth {
+		t.Errorf("SubRule width = %d, want %d", got, SectionWidth)
+	}
+}
+
+func TestHeading_TwoLines(t *testing.T) {
+	runWithoutColor(t, func() {
+		got := Heading("Section title")
+		lines := strings.Split(got, "\n")
+		if len(lines) != 2 {
+			t.Errorf("Heading should be two lines, got %d", len(lines))
+		}
+		if lines[0] != "Section title" {
+			t.Errorf("line 1 = %q, want %q", lines[0], "Section title")
+		}
+		if !strings.HasPrefix(lines[1], SymRule) {
+			t.Errorf("line 2 should be a rule; got %q", lines[1])
+		}
+	})
+}
+
+// ── Composability ───────────────────────────────────────────────────
+
+func TestColorComposition_BoldOnTopOfColor(t *testing.T) {
+	runWithColor(t, func() {
+		// Bold(Alert("X")) — both escape sequences present, X visible
+		got := Bold(Alert("CRITICAL"))
+		if !strings.Contains(got, "\x1b[1m") {
+			t.Errorf("composed string missing bold; got %q", got)
+		}
+		if !strings.Contains(got, "\x1b[31m") {
+			t.Errorf("composed string missing alert color; got %q", got)
+		}
+		if !strings.Contains(got, "CRITICAL") {
+			t.Errorf("composed string missing payload; got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Foundational deliverable for **Track 10 (Visual & design system)** from the 0.2.0 parity-gated release plan. \`internal/uitokens/\` is the design-system shim every user-visible renderer in 0.2.0 will consume from — terminal output, HTML report, PR-comment markdown, SARIF tags.

After this lands, ad-hoc styling outside the package becomes a parity-gate violation on the V1 (visual consistency) axis. Track 10.2 follows: migrate existing renderers + add a vet rule that flags raw ANSI codes outside \`internal/uitokens/\`.

## What's in the package

- **Color tokens** — six semantic colors (muted / accent / ok / warn / alert / bold). Names describe roles, not shades.
- **TTY / NO_COLOR detection** — stdout TTY check + \`NO_COLOR\` env var + \`TERM=dumb\` fallback. Tests flip the flag to assert plain-text output.
- **Symbol vocabulary** — one vocabulary (✓ ✗ ⚠ ⓘ → • — · ─) used across every command.
- **Severity model + badges** — \`SeverityBadge()\` for the CRITICAL → INFO ladder; CRITICAL and HIGH bolded.
- **Verdict badges** — \`VerdictBadge("PASS"|"WARN"|"FAIL")\` returns the canonical glyph + label combo.
- **Spacing & rules** — \`SectionWidth = 60\`; \`Heading()\` / \`Subheading()\` return two-line blocks.
- **ASCII bar renderer** — \`Bar()\` auto-colors by proportion; \`BarPlain()\` for inverse-polarity callers (e.g. coverage).
- **Text helpers** — \`Truncate\` / \`PadRight\` / \`PadLeft\`; rune-aware.

Zero dependencies. Stateless. ~310 lines of code + ~280 lines of tests.

## Tests (15 total, all passing)

- Color wrappers respect \`ColorEnabled\` in both directions
- Color wrappers no-op on empty strings (avoid escape-sequence noise)
- Severity badges produce right labels and bold ≥ HIGH
- Verdict badges canonicalize case + whitespace
- Bar rendering: full / empty / half / overflow / negative / zero-max / zero-width
- Bar coloring threshold transitions at 0.4 and 0.8
- Truncate / PadRight / PadLeft handle unicode (e.g. \"café\" → \"café…\")
- Rule and SubRule render at \`SectionWidth\`
- \`Heading\` produces two lines (title + rule)
- Color composition (\`Bold(Alert(...))\`) preserves both escapes

## Test plan

- [x] \`go test ./internal/uitokens/ -count=1\` — all 15 tests pass
- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/uitokens/\` clean

## Next: Track 10.2

Renderer audit + migration. Existing \`internal/reporting/\` / \`internal/changescope/render.go\` / etc. switch to consuming from this package; a static check flags any \`\\x1b[\` outside \`internal/uitokens/\`. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
