### PR TITLE
docs(0.2): product vision + README/quickstart/feature-status/CHANGELOG anchored to pitch (Track 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,43 @@ All notable changes to Terrain are documented here. The format follows
 
 Post-0.2 work tracked separately.
 
-## [0.2.0] — 2026-05-02 — AI parity, calibration gate, CLI compression
+## [0.2.0] — Parity-gated release — control plane for your test system
 
-The release that turns Terrain's AI story into something testable. Twelve
-new AI detectors ship with calibration anchors at **100% recall on a
-27-fixture corpus** (the gate is a recall regression gate; per-detector
-*precision* floors against a labeled-repo corpus are deferred to 0.3 —
-see `docs/release/0.2-known-gaps.md`). The CLI surface compresses 35→11
-canonical commands while keeping every legacy alias working. The
-calibration runner becomes a load-bearing regression gate. Per
-`docs/release/0.2.md`.
+> **Terrain is the control plane for your test system.**
+> It maps how your unit, integration, e2e, and AI tests actually relate
+> to your code — and lets you gate changes based on that system as a
+> whole. See what's covered, what's missing, and what's overlapping.
+> See which tests matter for a PR — and why. Bring AI evals into the
+> same review pipeline as the rest of your tests.
+
+0.2.0 is the first release shipped under the [parity gate]
+(docs/release/0.2.x-maturity-audit.md): every functional area must
+clear its pillar floor (Gate ≥ 4, Understand ≥ 3, Align ≥ 3 soft) before
+the tag cuts. Source of truth for the full vision is
+[`docs/product/vision.md`](docs/product/vision.md); per-capability
+status with pillar + tier is [`docs/release/feature-status.md`]
+(docs/release/feature-status.md).
+
+The release groups deliverables by the three pillars:
+
+- **Understand** (Tier 1): full snapshot pipeline; `report
+  summary/posture/metrics/focus/insights/explain`; AI surface
+  inventory; cross-repo views.
+- **Align** (Tier 1): framework migration with per-file confidence;
+  alignment-first docs; multi-repo manifest format.
+- **Gate** (Tier 1): `report pr / impact` with `--fail-on /
+  --new-findings-only / --timeout`; suppressions
+  (`.terrain/suppressions.yaml`); stable finding IDs;
+  `terrain explain finding <id>`; one recommended GitHub Action
+  template.
+
+Twelve new AI detectors ship with calibration anchors at **100% recall
+on a 27-fixture corpus** (the gate is a recall regression gate;
+per-detector *precision* floors against a labeled-repo corpus are
+deferred to 0.3 — see `docs/release/0.2-known-gaps.md`). The CLI
+surface compresses 35→11 canonical commands while keeping every legacy
+alias working. The calibration runner becomes a load-bearing regression
+gate.
 
 ### What's stable in 0.2
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
 # Terrain
 
-**Map your test terrain.** Understand your test system in seconds — typical
-service repos in 5–15s, large monorepos take longer (the headline "30
-seconds" claim refers to repos ≤ 1,000 test files; see Performance below).
+> **Terrain is the control plane for your test system.**
+>
+> It maps how your unit, integration, e2e, and AI tests actually relate
+> to your code — and lets you gate changes based on that system as a whole.
+>
+> See what's covered, what's missing, and what's overlapping.
+> See which tests matter for a PR — and why.
+> Bring AI evals into the same review pipeline as the rest of your tests.
+
+*Map your test terrain.* Two commands an adopter learns first, in order:
+
+```bash
+terrain analyze         # Understand your test system
+terrain report pr       # Gate PR changes based on it
+```
+
+Everything else is a deeper view *off* this primary workflow.
+
+## Install
 
 ```bash
 # Homebrew
 brew install pmclSF/terrain/mapterrain
 
-# npm — note: requires cosign on PATH for signed-binary verification.
+# npm — requires cosign on PATH for signed-binary verification.
 # brew install cosign  (macOS / Linux)
 # scoop install cosign (Windows)
 # Set TERRAIN_INSTALLER_ALLOW_MISSING_COSIGN=1 to fall back to checksum-only,
@@ -24,13 +40,14 @@ findings (runtime health, eval regression, policy enforcement) are unlocked
 by optional artifacts; degrade gracefully when absent.
 
 > **New here?** Read the [Quickstart Guide](docs/quickstart.md) to understand your first report in 5 minutes.
-> **What ships in 0.2?** See [What 0.2 is and isn't](#what-02-is-and-isnt) below before adopting in CI.
+> **Going deeper?** [`docs/product/vision.md`](docs/product/vision.md) is the full product narrative.
+> **Adopting in CI?** See [What 0.2 is and isn't](#what-02-is-and-isnt) below first.
 
 ---
 
-Terrain is a test system intelligence platform. It reads your repository — test code, source structure, and (when available) coverage data, runtime artifacts, ownership files, and local policy — and builds a structural model of how your tests relate to your code. From that model it surfaces risk, quality gaps, redundancy, fragile dependencies, and migration readiness on a best-effort basis without running a single test.
+Terrain operates one layer above the test runners — the same architectural pattern as a Kubernetes control plane, but for the test system. Test runners (Jest / pytest / Go test / Playwright / Promptfoo) continue to execute; Terrain reads what they produce, models the system as one thing, and gates against it.
 
-The core idea: every codebase has a *test terrain* — the shape of its testing infrastructure, the density of coverage across areas, the hidden fault lines where a fixture change cascades into thousands of tests. Terrain makes that shape visible and navigable so you can make informed decisions about what to test, what to fix, and where to invest.
+When the testing surface drifts from the code surface — exports without tests, frameworks fragmenting across directories, AI surfaces shipping without scenarios, one team's posture diverging from another's — Terrain shows where the drift is and what convergence would take. That's the alignment side of the job. Conversion (migrating frameworks, e.g. Jest → Vitest) is one mode of alignment, not a separate product.
 
 ## What "Test Terrain" Means
 
@@ -229,39 +246,64 @@ If you're evaluating Terrain against another tool and the boundary isn't obvious
 
 ## What 0.2 Is and Isn't
 
-Read this before adopting in CI. Source of truth per-feature is
+Read this before adopting in CI. Source of truth per-capability is
 [`docs/release/feature-status.md`](docs/release/feature-status.md);
 this is the summary view.
 
-**Stable in 0.2** — covered by tests, documented behavior, won't change
-shape in 0.2.x:
+Capabilities are tiered:
 
-- repository scan + framework detection (Tier-1 frameworks)
-- snapshot generation + schema versioning
-- signal registry + manifest export
-- AI surface inventory (prompt / agent / tool / context / eval / model / scenario)
-- Promptfoo / DeepEval / Ragas eval-artifact ingestion
-- recall regression gate via the 27-fixture calibration corpus
-- 10 of the 12 new AI detectors marked `[stable]`
-- canonical 11-command CLI shape (legacy aliases still work; removal targets 0.3)
+- **Tier 1** — covered by tests, documented behavior, claimed publicly. Floor ≥ 4 on the parity rubric.
+- **Tier 2** — shipping but explicitly experimental; useful but not yet hardened. Floor ≥ 3.
+- **Tier 3** — in development, opt-in, no public claim. Wait for promotion.
 
-**Experimental** — useful but not yet hardened; expect signal/UX changes:
+### By pillar
 
-- `aiPromptInjectionRisk` and `aiFewShotContamination` detectors (regex-based; AST-grade taint is 0.3)
-- `terrain serve` local HTTP server (no auth, localhost-only, single-developer use)
-- `terrain portfolio` multi-repo analysis
-- portfolio-level scoring thresholds
-- AI surface inference *precision* (recall is calibration-anchored; precision against a labeled-repo corpus is 0.3)
+**Understand** (Tier 1 unless noted):
 
-**Planned for 0.3**:
+- `terrain analyze` — snapshot + signals + posture
+- `terrain report summary / posture / metrics / focus / insights / explain` — read-side queries
+- `terrain compare` — snapshots over time
+- AI surface inventory — what AI surfaces exist, where they are, what evals cover them
+- `terrain serve` (Tier 2) — local HTTP report; localhost-only, no auth
+- `terrain portfolio` (Tier 2, emerging) — multi-repo aggregation; partial in 0.2.0
+- `terrain debug *` (Tier 2) — diagnostic drill-downs
 
-- per-detector precision benchmarking against a labeled-repo corpus
+**Align** (Tier 1):
+
+- `terrain migrate` / `terrain convert` — framework migration with per-file confidence
+- `terrain report select-tests` (Tier 2) — recommended protective test set for a change
+- Alignment views in `posture` and `portfolio` — drift between code surface and test surface
+
+**Gate** (Tier 1 unless noted):
+
+- `terrain report pr` — change-scoped PR risk report
+- `terrain report impact` — impact selection with reason chains (`--explain-selection`)
+- `terrain analyze --fail-on / --timeout / --new-findings-only` — CI gating primitives
+- `terrain policy check` — policy enforcement
+- Eval artifact ingestion — Promptfoo / DeepEval / Ragas adapters
+- AI risk: **inventory** (Tier 1, reliable)
+- AI risk: **hygiene** + **regression** (Tier 2, visible but not gating-critical)
+- `terrain ai run --baseline` (Tier 2) — regression-aware AI gate
+
+### Anti-goals (0.2.x)
+
+These are explicit non-claims:
+
+- **Terrain does not guarantee safe test skipping.** It provides explainable selection and gating signals. The "see which tests matter — and why" pitch is a clarity claim, not a safe-skip claim.
+- **Terrain does not run your tests.** Test runners execute; Terrain reads what they produce.
+- **Terrain does not judge model truthfulness.** AI risk detectors surface heuristic structural patterns and ingest eval-framework metadata.
+- **Terrain does not promise public-grade precision floors in 0.2.x.** Recall-anchored calibration only; labeled-corpus precision floors are 0.3 work.
+
+### Planned for 0.3
+
+- Per-detector precision benchmarking against a labeled-repo corpus
 - AST-grade taint analysis for prompt injection
-- suppression model (`.terrain/suppressions.yaml`) and the false-positive workflow it enables
+- Suppression lifecycle (expiry, owner, audit) — basic suppressions ship in 0.2.0
 - `terrain ai gate` standalone command
-- plugin architecture for community adapters
-- sandboxing for eval execution
-- removal of the legacy CLI aliases (with a 0.2.x deprecation runway)
+- Plugin architecture for community adapters
+- Sandboxing for eval execution
+- Legacy CLI alias removal (with a 0.2.x deprecation runway)
+- AI-aware integration / e2e tests under the control plane (0.4 trajectory)
 
 ## Who Uses Terrain
 

--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -1,0 +1,267 @@
+# Terrain — Product Vision
+
+> **Terrain is the control plane for your test system.**
+>
+> It maps how your unit, integration, e2e, and AI tests actually relate
+> to your code — and lets you gate changes based on that system as a
+> whole.
+>
+> See what's covered, what's missing, and what's overlapping.
+> See which tests matter for a PR — and why.
+> Bring AI evals into the same review pipeline as the rest of your
+> tests.
+
+This document is the durable north-star for Terrain. Each release
+updates the trajectory section; the headline pitch and the three-pillar
+shape stay stable across releases.
+
+---
+
+## The user's actual job
+
+A staff engineer / platform engineer / tech lead inherits or grows a
+codebase. They need to answer:
+
+1. *Do I understand what testing exists across this codebase?*
+2. *Does the testing surface align with the code surface, or has it
+   drifted?*
+3. *When something changes, what does it actually put at risk?*
+4. *Are AI features in this system tested with the same rigor as the
+   rest, or are they a blind spot?*
+5. *Across our repos, is testing uniform, or is each team's posture
+   invisible to the others?*
+6. *Can I gate on all of that in CI without writing five different
+   integrations?*
+
+No single tool answers more than two of those questions today.
+**Terrain's job is unifying the answer.**
+
+## What Terrain is
+
+A typical product team's test universe lives across five different
+runners (Jest / pytest / Go test / Playwright / Promptfoo et al.),
+three different report formats, and zero unified gates. **Terrain
+is the layer above** — it doesn't execute tests, it understands them
+and gates against them.
+
+Two phrases doing real work:
+
+- **"Control plane"** — Terrain operates one layer above the test
+  runners. Same architectural pattern as a Kubernetes control plane,
+  but for the test system. Test runners continue to execute; Terrain
+  reads what they produce, models the system, and decides what's
+  blocking.
+- **"As one thing"** — the unification value. The PR risk-report
+  doesn't care whether a finding came from a flaky unit test, a
+  missing AI eval, or a coverage gap. It's all the same finding shape
+  with the same severity model and the same suppression workflow.
+
+## The three pillars
+
+Each pillar is *what you do with the model*. The pillars share a
+common substrate (snapshot, signal model, CI gate primitives) and a
+common surface (uniform exit codes, JSON contract, severity model,
+suppression file).
+
+| Pillar | Job | External framing |
+|--------|-----|------------------|
+| **Understand** | See the test universe as one thing | "See what's covered, what's missing, what's overlapping" |
+| **Align** | Reduce drift between code, tests, and repos | "Standardize and reduce drift across test systems" |
+| **Gate** | One CI gate over the whole system | "Gate PR changes based on the system as a whole" |
+
+### Understand — see the test universe as one thing
+
+Map every test, framework, code unit, AI surface, eval scenario,
+ownership boundary, coverage gap, and runtime metric into one
+structural model. Surface the alignment between what's tested and
+what matters: coverage relative to complexity, density relative to
+risk, AI surfaces relative to eval coverage. Diff the model over time
+to see what changed.
+
+Capabilities: `terrain analyze`, `terrain report
+summary/posture/metrics/focus/insights/explain`, `terrain compare`,
+AI surface inventory, `terrain serve` (local view), `terrain debug *`
+(diagnostics), `terrain portfolio` (cross-repo view).
+
+### Align — reduce drift between code, tests, and repos
+
+When the testing surface doesn't match the code surface — exports
+without tests, frameworks fragmenting across directories, AI surfaces
+shipping without scenarios, one team's posture diverging from
+another's — Terrain shows where the drift is and what it would take
+to converge. When convergence requires framework migration (Jest →
+Vitest, Mocha → Jest, JUnit 4 → 5, etc.), Terrain does that with
+per-file confidence and a preview-before-apply workflow.
+
+**Migration is a mode of alignment, not a separate product.** The
+docs lead with "your repo has framework drift; here's what it would
+take to converge", not "convert this file."
+
+Capabilities: `terrain migrate` namespace, `terrain convert` per-file,
+conversion-history audit trail, alignment views in `posture` /
+`portfolio`, `terrain report select-tests` (test-set alignment to a
+change).
+
+### Gate — bring everything under one CI gate
+
+Whether the underlying test is a unit test, an eval scenario, an AI
+risk signal, a policy violation, or a coverage threshold breach, the
+CI experience is the same: same `--fail-on`, same
+`--new-findings-only`, same suppression model, same exit codes, same
+JSON contract. The PR comment template is one template. The CI
+workflow is one workflow.
+
+Capabilities: `terrain report pr`, `terrain report impact`, `terrain
+ai run --baseline`, `terrain policy check`, `--fail-on` /
+`--timeout` / `--new-findings-only` flags, suppressions, stable
+finding IDs, per-finding remediation pointers.
+
+## The unifying thread
+
+The pillars feel like one product because they share **CI gate
+primitives**:
+
+| Primitive | Used by |
+|-----------|---------|
+| Exit-code conventions (0/1/2/4/5/6) | every command |
+| `--fail-on <severity>` | analyze, pr, impact, ai run |
+| `--new-findings-only --baseline <path>` | analyze, pr |
+| `.terrain/suppressions.yaml` | every detector |
+| Stable finding IDs | every signal |
+| `--format json/sarif/annotation` | every read-side command |
+| One PR-comment template (`changescope`) | impact, pr, ai run |
+
+A CI engineer who learns the gating model once doesn't relearn it
+for AI evals or for cross-repo alignment.
+
+## What's distinctive
+
+Compared to tools your audience already knows:
+
+| Compared to | Terrain's distinct position |
+|-------------|------------------------------|
+| Jest / Vitest / pytest / Go test / Playwright | Reads them, doesn't replace them — operates one layer above |
+| Coverage tools (Istanbul, gcov, coverage.py) | Ingests coverage as evidence; doesn't instrument code |
+| SonarQube / Semgrep / CodeQL | Source-side bug-finding is theirs; *test-system* quality is ours |
+| Promptfoo / DeepEval / Ragas | They run AI evals; we ingest the results into the same gate as everything else |
+| Test-impact tools (Bazel, Gradle test queries) | Cross-language structural impact, not single-toolchain |
+| AI safety / runtime guard tools (Lakera, Guardrails) | Structural / pre-deploy / inventory; they're runtime |
+| GitHub code scanning | We emit SARIF *into* it; we don't compete |
+
+**The unique claim:** the only tool that gives you one model of your
+test universe across test types, languages, and repos, with CI
+gating primitives.
+
+## What Terrain explicitly isn't
+
+- **Not a test runner.** Test runners continue to execute; Terrain
+  reads the artifacts they produce.
+- **Not a coverage tool.** Coverage data is ingested as evidence,
+  not computed.
+- **Not a static analyzer for application code.** Terrain inspects
+  *test* code structure (assertions, mocks, framework patterns,
+  scenario coverage). Source-side bug-finding stays with Sonar /
+  Semgrep / CodeQL.
+- **Not an LLM eval framework.** We ingest Promptfoo / DeepEval /
+  Ragas output; we don't run prompts against models.
+- **Not a developer-productivity dashboard.** No per-developer
+  metrics, no leaderboards. Ownership data routes work and doesn't
+  score people.
+- **Not a SaaS.** Local-first, CI-native, no account, no telemetry
+  off-host. (Note: `npm install -g mapterrain` and `brew install`
+  download signed binaries from GitHub Releases as part of
+  installation; analysis itself does not phone home.)
+- **Not an LLM safety service.** AI risk detectors are heuristic and
+  recall-anchored; precision floors against labeled corpora are 0.3
+  work.
+
+## Anti-goals (0.2.x)
+
+These are explicit non-claims for the 0.2 line. They exist to keep
+execution honest:
+
+- **Terrain does not guarantee safe test skipping.** It provides
+  *explainable* selection and gating signals. The "see which tests
+  matter — and why" pitch line is a clarity claim, not a safe-skip
+  claim.
+- **Terrain does not run your tests.** Bears repeating.
+- **Terrain does not judge model truthfulness.** AI risk detectors
+  surface heuristic structural patterns and ingest eval-framework
+  metadata.
+- **Terrain does not promise public-grade precision floors in 0.2.x.**
+  Recall-anchored calibration on the 27-fixture corpus is the only
+  honest claim until labeled-real-repo precision corpora ship in 0.3.
+
+## Trajectory
+
+Three releases, with the verb sharpening at each step:
+
+| Release | Verb | What ships |
+|---------|------|------------|
+| **0.2.0** | "See clearly + gate progressively" | Three pillars at parity floors (Gate ≥ 4, Understand ≥ 3, Align ≥ 3 soft); suppressions; finding IDs; `--new-findings-only`; AI risk subdivision into inventory/hygiene/regression; multi-repo manifest; alignment-first migration framing; per-area examples; design system; per-detector "known false positives" docs |
+| **0.3** | "Take control" | Labeled-corpus precision floors per detector; AST taint flow for prompt injection; suppression lifecycle (expiry, owner, audit); AI gate as standalone command; plugin architecture; sandboxing for eval execution; legacy CLI alias removal |
+| **0.4** | "Test the universe" | AI-aware integration / e2e tests under the control plane (define them, run them in CI, gate on them, suppress them); cross-repo alignment workflows; eval-test composition (unit + integration + eval as one feature) |
+
+**"Take control" only becomes a public claim at 0.3.** In 0.2.x,
+public copy stays at "see clearly + gate progressively." Marketing
+maturity tracks engineering maturity per the parity gate.
+
+## Capability map
+
+Every shipping capability has a pillar. Tier-1 capabilities are
+publicly claimable; Tier-2 is shipping but explicitly experimental;
+Tier-3 is in development, opt-in, no public claim.
+
+| Capability | Pillar | Tier (0.2.0) |
+|------------|--------|--------------|
+| `analyze` | Understand | Tier 1 |
+| `report insights / posture / summary / metrics / focus / explain` | Understand | Tier 1 |
+| `compare` | Understand (over time) | Tier 1 |
+| `terrain serve` | Understand (local view) | Tier 2 |
+| `terrain portfolio` | Understand (multi-repo) | Tier 2 (emerging) |
+| `terrain debug *` | Understand (diagnostics) | Tier 2 |
+| `migrate` / `convert` | Align | Tier 1 |
+| `report select-tests` | Align (test-set to change) | Tier 2 |
+| `report pr` | Gate | Tier 1 |
+| `report impact` | Gate (PR-scoped) | Tier 1 |
+| `analyze --fail-on / --timeout / --new-findings-only` | Gate | Tier 1 |
+| `policy check` | Gate (policy dimension) | Tier 1 |
+| AI surface inventory | Understand | Tier 1 (reliable) |
+| AI risk: hygiene + regression | Gate | Tier 2 (visible, not gating-critical) |
+| Eval artifact ingestion | Gate | Tier 1 |
+| `terrain ai run --baseline` | Gate (regression-aware) | Tier 2 |
+| `terrain init` | onboarding (cross-pillar) | Tier 1 |
+
+Nothing orphan, nothing hidden. The breadth stays; tiering is honest
+about which capabilities make public claims at this release.
+
+## Primary workflow
+
+Two commands an adopter learns first, in order:
+
+```bash
+terrain analyze         # Understand your test system
+terrain report pr       # Gate PR changes based on it
+```
+
+Everything else is a deeper view *off* this primary workflow. Docs,
+help text, and the recommended GitHub Action snippet all anchor to
+this two-step flow. Other commands (`migrate`, `portfolio`, `ai run`,
+`policy check`, `serve`, `debug *`) are reachable but discovered
+*through* this workflow, not as alternative entry points.
+
+## How this document evolves
+
+- The headline pitch and three-pillar shape are stable across
+  releases. Changing them needs a strategy decision, not a doc edit.
+- The trajectory table updates each release: today's verb moves
+  forward; the new release's verb takes its slot.
+- The capability map updates whenever a capability changes pillar or
+  tier. Updates happen in the same PR that lifts the capability.
+- The anti-goals stay until they're no longer true. Each anti-goal
+  has a definite "this becomes a goal in release X" trigger; that
+  trigger lives in the rubric (`docs/release/parity/rubric.yaml`).
+
+The pitch is the source of truth that the README, quickstart, and
+marketing copy point at. When this doc and the README disagree, this
+doc wins until the README is updated.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,18 @@
 # Terrain Quickstart
 
-Understand your test system in 5 minutes. No config, no setup, no test execution required.
+Five minutes from `npm install` to one actionable insight on your repo.
+The walkthrough is structured around the three insights that count toward
+the [first-user success gate](../docs/product/vision.md):
 
-Terrain reads your repository — test code, source structure, coverage data, runtime artifacts — and builds a structural model of how your tests relate to your code. From that model it surfaces risk, quality gaps, redundancy, fragile dependencies, and actionable recommendations.
+1. **PR risk explanation** — a finding tied to a changed file
+2. **Coverage gap with explanation** — a named uncovered export with a
+   remediation pointer
+3. **Test-selection explanation** — chosen tests + reason chains
+
+Terrain operates one layer above your test runners (Jest / pytest / Go
+test / Playwright / Promptfoo). It reads what they produce, models the
+test system as one thing, and gates against it. No config, no setup,
+no test execution required for the walkthrough.
 
 ## Install
 
@@ -21,15 +31,60 @@ git clone https://github.com/pmclSF/terrain.git
 cd terrain && go build -o terrain ./cmd/terrain
 ```
 
-## Your first analysis
+## Step 1 — Understand (90 seconds)
 
-Run this in any repository with test files:
+The primary workflow's first command. Run this in any repository with
+test files:
 
 ```bash
 terrain analyze
 ```
 
-That's it. No configuration, no setup. Terrain auto-detects your test frameworks (Jest, Vitest, Playwright, Cypress, pytest, JUnit, Go testing, and 10 more), builds a structural model, and produces a report.
+You should see a report with the repository profile, signal breakdown,
+risk posture, and key findings. **This is your "coverage gap with
+explanation" insight**: the report names specific uncovered exports
+with remediation pointers ("Add test coverage for 12 uncovered
+exported function(s) — see untestedExport signals for specific
+functions").
+
+That's the first of the three first-user insights. Two more to go.
+
+## Step 2 — Gate (90 seconds)
+
+The primary workflow's second command. On a feature branch with diff
+against main, run:
+
+```bash
+terrain report pr --base main
+```
+
+This emits a change-scoped PR risk report — what your diff actually
+puts at risk, ranked by confidence. **This is your "PR risk
+explanation" insight**: every blocking signal is tied to a specific
+changed file with a "what / why / what-to-do" line.
+
+Add `--fail-on critical` and the command exits non-zero (code 6) when
+any critical-severity finding is present. That's how you wire it
+into CI as a gate. See the [CI integration
+example](examples/gate/github-action.yml) for the recommended config.
+
+## Step 3 — See which tests matter (90 seconds)
+
+```bash
+terrain report impact --base main --explain-selection
+```
+
+This is the **test-selection explanation** insight: chosen tests plus
+the reason chain for why each was selected and why others were not.
+
+> **Note on safe-skip:** Terrain provides explainable selection. It does
+> not assert that any specific test is safe to skip. The "see which
+> tests matter — and why" pitch is a clarity claim, not a safe-skip
+> claim. Whether to skip the unselected tests is your call, with the
+> evidence Terrain hands you.
+
+That's the three first-user insights. From here, the rest of this
+guide goes deeper.
 
 ## Understanding the report
 

--- a/docs/release/feature-status.md
+++ b/docs/release/feature-status.md
@@ -1,8 +1,18 @@
 # Feature Status — 0.2.0
 
 Single source of truth for what ships in 0.2.0. Every claim in `README.md`,
-`DESIGN.md`, marketing material, and example outputs should map back to a
-status here. Drift is treated as a release blocker.
+`docs/product/vision.md`, marketing material, and example outputs should
+map back to a status here. Drift is treated as a release blocker.
+
+Each shipping capability has three tags:
+
+- **Pillar** — Understand, Align, or Gate (per `docs/product/vision.md`)
+- **Tier** — 1 (publicly claimable, parity floor ≥ 4), 2 (experimental, floor ≥ 3), 3 (in development, no public claim)
+- **Status** — stable / experimental / planned / deprecated
+
+The pillar + tier columns are new in 0.2.0. The pillar tells you which
+of the three workflow questions this capability answers; the tier tells
+you whether marketing claims back it.
 
 Statuses:
 
@@ -17,26 +27,33 @@ If a feature is **planned**, no detector emits its signals today.
 
 ## Workflows
 
-| Feature | Status | Notes |
-|---|---|---|
-| `terrain analyze` | stable | Full snapshot pipeline; `--baseline` flag added in 0.2. Now panics in detectors are recovered to a single `detectorPanic` signal — the rest of the pipeline isolates. |
-| `terrain init` | stable | Bootstrap a `.terrain/` config tree. |
-| `terrain report <verb>` | stable | New 0.2 namespace: 9 read-side verbs (summary, insights, metrics, explain, show, impact, pr, posture, select-tests). Routes to the same runners as the legacy top-level commands; output is byte-identical for the cases reviewed. |
-| `terrain migrate <verb>` | stable | New 0.2 namespace: 11 verbs covering the merged convert + migrate + migration commands. `terrain convert` retains its per-file fall-through (`terrain convert spec.cy.ts --to playwright` works). |
-| `terrain config <verb>` | stable | New 0.2 namespace: feedback, telemetry. |
-| `terrain doctor` | stable | Migration-readiness diagnostic. Test-file count is now restricted to direct test-dir parents (was over-counting fixture trees by ~4×). |
-| `terrain explain` | stable | Reason chains supported; per-detector evidence quality varies. Now also reachable as `terrain report explain`. |
-| `terrain debug <verb>` | stable | graph / coverage / fanout / duplicates / depgraph. |
-| `terrain serve` | experimental | HTTP API on 127.0.0.1 only; the dashboard "embedded charts" claim from earlier docs is **planned**, not shipped. |
-| `terrain ai list` | stable | Surface inventory + scenario detection. |
-| `terrain ai doctor` | stable | Diagnostic check on AI scenario configuration. |
-| `terrain ai run` | stable | Captures eval framework output to `.terrain/artifacts/`. AI-gate exit code is now `4` (was `1`) on `actionBlock` per the documented exit-code scheme. |
-| `terrain ai record` | stable | Record current scenario state as a baseline. |
-| `terrain ai baseline` | stable | List recorded baselines. |
-| `terrain ai replay` | stable | Replay a saved artifact. |
-| `terrain ai compare` | planned | Prompt-pair regression detection. | 0.3 |
-| `terrain ai gate` | planned | Standalone CI gate command. Today, gating goes through `terrain ai run` + `--baseline`. | 0.3 |
-| `terrain portfolio <verb>` | experimental | Multi-repo workspace. |
+| Feature | Pillar | Tier | Status | Notes |
+|---|---|---|---|---|
+| `terrain analyze` | Understand | 1 | stable | Full snapshot pipeline; `--baseline` flag added in 0.2. Detector panics recovered to a single `detectorPanic` signal. `--fail-on / --timeout / --new-findings-only` ship as Gate-pillar primitives. |
+| `terrain init` | cross-cutting | 1 | stable | Bootstrap a `.terrain/` config tree. |
+| `terrain report summary / posture / metrics / focus` | Understand | 1 | stable | Aggregation views over signals. |
+| `terrain report insights / explain` | Understand | 1 | stable | Read-side queries; reason chains supported. |
+| `terrain report impact` | Gate | 1 | stable | Change-scoped selection; `--explain-selection` lands in 0.2.0 (Track 3.2). |
+| `terrain report pr` | Gate | 1 | stable | PR-scoped report + comment template. `--fail-on / --new-findings-only` parity with `analyze` (Track 3.1). |
+| `terrain report select-tests` | Align | 2 | experimental | Recommended protective test set. |
+| `terrain report show <kind> <id>` | Understand | 1 | stable | Drill into test, unit, owner, or finding. |
+| `terrain compare` | Understand | 1 | stable | Snapshots over time. |
+| `terrain migrate <verb>` | Align | 1 | stable | Per-direction tier badges added in 0.2 (Track 6.6). `terrain convert` retains per-file fall-through. |
+| `terrain policy check` | Gate | 1 | stable | Local policy enforcement. `terrain init` emits a starter policy template (Track 7.6). |
+| `terrain config <verb>` | cross-cutting | 1 | stable | feedback, telemetry. |
+| `terrain doctor` | cross-cutting | 2 | stable | Migration-readiness diagnostic; per-pillar maturity view (Track 2.5). |
+| `terrain debug <verb>` | Understand | 2 | stable | graph / coverage / fanout / duplicates / depgraph. |
+| `terrain serve` | Understand | 2 | experimental | Local HTTP report; localhost-only, no auth. PR #132 wires request context + singleflight (Track 4.1). |
+| `terrain ai list` | Gate (inventory) | 1 | stable | AI surface inventory. |
+| `terrain ai doctor` | cross-cutting | 2 | stable | Diagnostic check on AI scenario configuration. |
+| `terrain ai run` | Gate | 2 | stable | Captures eval framework output. AI-gate exit code 4 on `actionBlock`. Trust-boundary doc (Track 7.3) clarifies parses-vs-executes. |
+| `terrain ai run --baseline` | Gate | 2 | stable | Regression-aware AI gate. |
+| `terrain ai record / baseline / replay` | Gate | 2 | stable | Baseline lifecycle. |
+| `terrain ai compare` | Gate | 3 | planned | Prompt-pair regression detection. 0.3. |
+| `terrain ai gate` | Gate | 3 | planned | Standalone CI gate command. Today, gating goes through `terrain ai run` + `--baseline`. 0.3. |
+| `terrain portfolio <verb>` | Align | 2 | experimental | Multi-repo workspace. Multi-repo manifest format + per-repo aggregation lands in 0.2 (Track 6.1–6.3); full closure in 0.2.x. |
+| `terrain explain finding <id>` | Gate | 1 | stable (0.2) | Resolve a stable finding ID back to its evidence. Track 4.6. |
+| `terrain suppress <id>` | Gate | 1 | stable (0.2) | Write a suppression entry. Track 4.7. |
 
 ## Detectors / signal types
 


### PR DESCRIPTION
## Summary

Bundles the doc-only Track 1 work from the 0.2.0 parity-gated release plan into one PR: every user-visible doc now leads with the unified pitch verbatim, and capabilities are tiered by pillar.

Bigger PR per request — Tracks 1.1, 1.2, 1.3, 1.4, 1.5, 1.8 in one merge. Tracks 1.6 (per-pillar reproducible examples) and 1.7 (per-detector "known false positives" sections) are larger and follow separately.

## What's in the PR

**Track 1.1 — \`docs/product/vision.md\`** (NEW, ~270 lines)
The durable north-star doc. Headline pitch verbatim, three pillars with internal job + external framing + anchored capabilities, capability → tier map, anti-goals (no safe-skip; doesn't run tests; doesn't judge model truthfulness), trajectory through 0.4.

**Track 1.2 + 1.3 — README rewrite**
- Headline replaced with the pitch verbatim
- Primary workflow (\`terrain analyze && terrain report pr\`) shown above the install snippet
- "What 0.2 Is and Isn't" rewritten as Pillar × Tier (Tier 1/2/3) instead of flat stable/experimental
- Anti-goals section called out
- "Map your test terrain" demoted to secondary tagline

**Track 1.4 — \`docs/quickstart.md\` anchored to first-user gate**
The walkthrough is now organized as the three insight types from the [first-user success gate](docs/product/vision.md): coverage gap → PR risk → test-selection. Each step ~90 seconds; total ≤ 5 min. Safe-skip caveat called out explicitly.

**Track 1.5 — \`docs/release/feature-status.md\` Pillar + Tier columns**
Every shipping capability tagged with Pillar (Understand / Align / Gate) and Tier (1 / 2 / 3). \`terrain explain finding <id>\` and \`terrain suppress <id>\` added (these ship in Tracks 4.6 / 4.7).

**Track 1.8 — \`CHANGELOG.md\` 0.2.0 entry restructure**
Pitch as the headline opener. New parity-gate framing paragraph explains Gate ≥ 4, Understand ≥ 3, Align ≥ 3 soft. Release deliverables grouped by pillar.

## Test plan

- [x] \`make docs-verify\` — passes (manifest/severity/rules in sync; rule docs unchanged this PR)
- [x] \`go test ./... ./internal/testdata/\` — green
- [x] Manual read-through: README + quickstart + vision doc all lead with the same pitch and tell the same story
- [x] Cross-references between docs (vision ↔ feature-status ↔ README ↔ audit) point at the right files

## Follow-ups

- Track 1.6 — per-pillar reproducible examples in \`docs/examples/{understand,align,gate}/\` (separate PR)
- Track 1.7 — per-detector "known false positives" sections in \`docs/rules/*\` (bulk regen via \`cmd/terrain-docs-gen\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
