### PR TITLE
feat(0.2): explain finding + suppress writer + --new-findings-only (Tracks 4.6/4.7/4.8)

### DIFF
--- a/cmd/terrain/cmd_analyze.go
+++ b/cmd/terrain/cmd_analyze.go
@@ -126,7 +126,46 @@ func relativeToRoot(path, root string) string {
 	return path
 }
 
-func runAnalyze(root string, jsonOutput bool, format string, verbose bool, writeSnap bool, coveragePath, coverageRunLabel string, runtimePaths string, gauntletPaths string, promptfooPaths string, deepevalPaths string, ragasPaths string, baselinePath string, slowThreshold float64, redactPaths bool) error {
+// analyzeRunOpts collects every input runAnalyze takes. Replaces a
+// fifteen-positional-argument signature with one struct so future
+// flag additions stop expanding the call site.
+type analyzeRunOpts struct {
+	Root             string
+	JSONOutput       bool
+	Format           string
+	Verbose          bool
+	WriteSnapshot    bool
+	CoveragePath     string
+	CoverageRunLabel string
+	RuntimePaths     string
+	GauntletPaths    string
+	PromptfooPaths   string
+	DeepEvalPaths    string
+	RagasPaths       string
+	BaselinePath     string
+	SlowThreshold    float64
+	RedactPaths      bool
+	SuppressionsPath string
+	NewFindingsOnly  bool
+}
+
+func runAnalyze(o analyzeRunOpts) error {
+	root := o.Root
+	jsonOutput := o.JSONOutput
+	format := o.Format
+	verbose := o.Verbose
+	writeSnap := o.WriteSnapshot
+	coveragePath := o.CoveragePath
+	coverageRunLabel := o.CoverageRunLabel
+	runtimePaths := o.RuntimePaths
+	gauntletPaths := o.GauntletPaths
+	promptfooPaths := o.PromptfooPaths
+	deepevalPaths := o.DeepEvalPaths
+	ragasPaths := o.RagasPaths
+	baselinePath := o.BaselinePath
+	slowThreshold := o.SlowThreshold
+	redactPaths := o.RedactPaths
+
 	parsedRuntime := parseRuntimePaths(runtimePaths)
 	parsedGauntlet := parseRuntimePaths(gauntletPaths)        // same comma-split logic
 	parsedPromptfoo := parseRuntimePaths(promptfooPaths)      // same comma-split logic
@@ -146,6 +185,11 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 	}
 	if baselinePath != "" {
 		if err := validateExistingPaths("--baseline", []string{baselinePath}); err != nil {
+			return err
+		}
+	}
+	if o.SuppressionsPath != "" {
+		if err := validateExistingPaths("--suppressions", []string{o.SuppressionsPath}); err != nil {
 			return err
 		}
 	}
@@ -174,6 +218,8 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 	opt.DeepEvalPaths = parsedDeepEval
 	opt.RagasPaths = parsedRagas
 	opt.BaselineSnapshotPath = baselinePath
+	opt.SuppressionsPath = o.SuppressionsPath
+	opt.NewFindingsOnly = o.NewFindingsOnly
 	opt.OnProgress = newProgressFunc(jsonOutput)
 	// Honour Ctrl-C: pre-0.2.x analyze exited abruptly on SIGINT with no
 	// cleanup. runPipelineWithSignals wraps RunPipelineContext with a

--- a/cmd/terrain/cmd_explain.go
+++ b/cmd/terrain/cmd_explain.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pmclSF/terrain/internal/explain"
+	"github.com/pmclSF/terrain/internal/identity"
 	"github.com/pmclSF/terrain/internal/impact"
 	"github.com/pmclSF/terrain/internal/models"
 	"github.com/pmclSF/terrain/internal/reporting"
@@ -184,9 +185,121 @@ func runExplain(target, root, baseRef string, jsonOutput, verbose bool) error {
 		}
 	}
 
+	// Try as a stable finding ID (e.g.
+	// "weakAssertion@internal/auth/login_test.go:TestLogin#a1b2c3d4").
+	// `terrain explain finding <id>` per Track 4.6 — round-trip a
+	// finding ID back to its evidence + suggest a suppression command.
+	if _, _, _, _, ok := identity.ParseFindingID(target); ok {
+		if sig, found := lookupSignalByFindingID(snap, target); found {
+			if jsonOutput {
+				return jsonOut(sig)
+			}
+			renderFindingExplanation(sig, target)
+			return nil
+		}
+		// Looks like a finding ID but not in this snapshot — distinct
+		// from "garbage input": tell the user it parsed correctly but
+		// didn't resolve. Common cause: stale ID after a refactor.
+		return cliExitError{
+			code: exitNotFound,
+			message: fmt.Sprintf(
+				"finding ID parses but is not in the current snapshot: %s\n\n"+
+					"Common causes:\n"+
+					"  - the underlying signal moved (file rename, symbol rename, line drift without symbol)\n"+
+					"  - the suppression file already drops it — check `.terrain/suppressions.yaml`\n"+
+					"  - the snapshot is from a different run — re-run `terrain analyze`",
+				target,
+			),
+		}
+	}
+
 	return cliExitError{
 		code:    exitNotFound,
-		message: fmt.Sprintf("entity not found: %s\n\nTry: a test file path, test ID, scenario ID, or 'selection'", target),
+		message: fmt.Sprintf("entity not found: %s\n\nTry: a test file path, test ID, scenario ID, finding ID, or 'selection'", target),
+	}
+}
+
+// lookupSignalByFindingID searches the snapshot for a signal with the
+// given FindingID. Returns the signal + ok=true on hit. Walks both
+// top-level Signals and per-test-file Signals so any emission path
+// resolves.
+func lookupSignalByFindingID(snap *models.TestSuiteSnapshot, id string) (models.Signal, bool) {
+	if snap == nil {
+		return models.Signal{}, false
+	}
+	for _, s := range snap.Signals {
+		if s.FindingID == id {
+			return s, true
+		}
+	}
+	for _, tf := range snap.TestFiles {
+		for _, s := range tf.Signals {
+			if s.FindingID == id {
+				return s, true
+			}
+		}
+	}
+	return models.Signal{}, false
+}
+
+// renderFindingExplanation prints a finding's evidence in human-
+// readable form. Mirrors the shape used by other explain renders:
+// section header → finding metadata → next-step pointers (including
+// the canonical `terrain suppress` invocation).
+func renderFindingExplanation(s models.Signal, id string) {
+	rule := strings.Repeat("─", 60)
+	fmt.Println("Terrain — finding explanation")
+	fmt.Println(rule)
+	fmt.Println()
+
+	fmt.Printf("Finding ID:  %s\n", id)
+	fmt.Printf("Detector:    %s\n", s.Type)
+	fmt.Printf("Severity:    %s\n", strings.ToUpper(string(s.Severity)))
+	if s.Category != "" {
+		fmt.Printf("Category:    %s\n", s.Category)
+	}
+	fmt.Println()
+
+	if s.Location.File != "" {
+		loc := s.Location.File
+		if s.Location.Symbol != "" {
+			loc += " :: " + s.Location.Symbol
+		}
+		if s.Location.Line > 0 {
+			loc += fmt.Sprintf(" (line %d)", s.Location.Line)
+		}
+		fmt.Printf("Location:    %s\n", loc)
+	}
+	if s.Owner != "" {
+		fmt.Printf("Owner:       %s\n", s.Owner)
+	}
+	if s.EvidenceStrength != "" {
+		fmt.Printf("Evidence:    %s", s.EvidenceStrength)
+		if s.EvidenceSource != "" {
+			fmt.Printf(" (%s)", s.EvidenceSource)
+		}
+		fmt.Println()
+	}
+	if s.RuleID != "" {
+		fmt.Printf("Rule:        %s\n", s.RuleID)
+	}
+	fmt.Println()
+
+	if s.Explanation != "" {
+		fmt.Println("Why it matters:")
+		fmt.Printf("  %s\n", s.Explanation)
+		fmt.Println()
+	}
+	if s.SuggestedAction != "" {
+		fmt.Println("What to do:")
+		fmt.Printf("  %s\n", s.SuggestedAction)
+		fmt.Println()
+	}
+
+	fmt.Println("Next steps:")
+	fmt.Printf("  terrain suppress %q --reason \"<why>\"   waive this finding (with a reason)\n", id)
+	if s.RuleURI != "" {
+		fmt.Printf("  see %s for the full detector reference\n", s.RuleURI)
 	}
 }
 

--- a/cmd/terrain/cmd_suppress.go
+++ b/cmd/terrain/cmd_suppress.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pmclSF/terrain/internal/identity"
+	"github.com/pmclSF/terrain/internal/suppression"
+)
+
+// runSuppress writes a new entry into `.terrain/suppressions.yaml`
+// for the given finding ID. The flow is:
+//
+//  1. Validate the finding ID parses (Track 4.4 format).
+//  2. Load the existing suppressions file (or create an empty one).
+//  3. Refuse to add a duplicate entry — if one already exists, print
+//     a helpful message pointing at the existing reason and exit.
+//  4. Append the new entry.
+//  5. Write back, preserving comments and ordering of existing
+//     entries via simple text-append (we deliberately don't round-trip
+//     through YAML because goccy/go-yaml's comment preservation is
+//     uneven; appending text is the safer 0.2.0 shape).
+//
+// Result: a suppression entry with reason + optional expires + owner,
+// ready for the next `terrain analyze` run to honor.
+func runSuppress(findingID, reason, expires, owner, root string) error {
+	if findingID == "" {
+		return fmt.Errorf("missing finding ID — usage: terrain suppress <finding-id> --reason \"why\"")
+	}
+	if _, _, _, _, ok := identity.ParseFindingID(findingID); !ok {
+		return fmt.Errorf("invalid finding ID format %q — expected detector@path:anchor#hash", findingID)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("--reason is required (every suppression must justify itself)")
+	}
+
+	// Light sanity-check on `expires` — if the user supplied something,
+	// it should at least look like an ISO date so a downstream parser
+	// doesn't trip silently. We don't enforce real-date validity here;
+	// the loader emits a non-fatal warning if it can't parse.
+	if expires != "" {
+		if !looksLikeISODate(expires) {
+			return fmt.Errorf("--expires %q does not look like YYYY-MM-DD", expires)
+		}
+	}
+
+	suppPath := filepath.Join(root, suppression.DefaultPath)
+
+	// Check for existing entry — refuse to add duplicates so users
+	// don't accidentally accumulate stale waivers.
+	existing, err := suppression.Load(suppPath)
+	if err != nil {
+		return fmt.Errorf("could not load existing %s: %w", suppression.DefaultPath, err)
+	}
+	if existing != nil {
+		for _, e := range existing.Entries {
+			if e.FindingID == findingID {
+				return cliExitError{
+					code: exitUsageError,
+					message: fmt.Sprintf(
+						"finding %s is already suppressed.\n"+
+							"Existing reason: %s\n"+
+							"Existing owner:  %s\n"+
+							"Existing expires: %s\n\n"+
+							"Edit %s directly to update the entry, or remove it first to re-add.",
+						findingID, e.Reason, e.Owner, e.Expires, suppPath,
+					),
+				}
+			}
+		}
+	}
+
+	// Build the entry as YAML text. Append to the existing file, or
+	// create a new file with the schema header if the file doesn't
+	// exist. We deliberately write text rather than re-marshaling —
+	// preserves any comments / ordering the user added by hand.
+	if err := os.MkdirAll(filepath.Dir(suppPath), 0o755); err != nil {
+		return fmt.Errorf("could not create %s parent dir: %w", suppression.DefaultPath, err)
+	}
+
+	header := ""
+	body, readErr := os.ReadFile(suppPath)
+	if readErr != nil {
+		if !os.IsNotExist(readErr) {
+			return fmt.Errorf("read %s: %w", suppPath, readErr)
+		}
+		// New file — emit the schema header.
+		header = "# Terrain suppressions — generated and edited by `terrain suppress`.\n" +
+			"# Schema: https://github.com/pmclSF/terrain/blob/main/internal/suppression/suppression.go\n\n" +
+			"schema_version: \"1\"\n" +
+			"suppressions:\n"
+	}
+
+	entry := buildSuppressionYAML(findingID, reason, expires, owner)
+
+	out := header
+	if len(body) > 0 {
+		out += string(body)
+		// Ensure separation before our append.
+		if !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+	}
+	// If the existing file doesn't yet have a `suppressions:` key, the
+	// loader (when it sees only schema_version + an entry) would still
+	// parse — but for hygiene, rewrite the whole file with normal shape
+	// when we're appending.
+	if header == "" && !strings.Contains(string(body), "\nsuppressions:") && !strings.HasPrefix(string(body), "suppressions:") {
+		out += "suppressions:\n"
+	}
+	out += entry
+
+	if err := os.WriteFile(suppPath, []byte(out), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", suppPath, err)
+	}
+
+	fmt.Printf("Suppressed %s\n", findingID)
+	fmt.Printf("  reason:  %s\n", reason)
+	if expires != "" {
+		fmt.Printf("  expires: %s\n", expires)
+	}
+	if owner != "" {
+		fmt.Printf("  owner:   %s\n", owner)
+	}
+	fmt.Printf("\nWritten to: %s\n", suppPath)
+	if expires == "" {
+		fmt.Println("\nTip: add --expires=YYYY-MM-DD so the suppression doesn't outlive its reason.")
+	}
+	return nil
+}
+
+func buildSuppressionYAML(findingID, reason, expires, owner string) string {
+	var b strings.Builder
+	b.WriteString("  - finding_id: ")
+	b.WriteString(findingID)
+	b.WriteString("\n")
+	b.WriteString("    reason: ")
+	b.WriteString(yamlInlineString(reason))
+	b.WriteString("\n")
+	if expires != "" {
+		b.WriteString("    expires: ")
+		b.WriteString(expires)
+		b.WriteString("\n")
+	}
+	if owner != "" {
+		b.WriteString("    owner: ")
+		b.WriteString(yamlInlineString(owner))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// yamlInlineString quotes a string for safe inline use in YAML.
+// We always double-quote so reasons containing special characters
+// (`:`, `#`, leading dashes, etc.) round-trip cleanly.
+func yamlInlineString(s string) string {
+	// Escape backslash + double-quote.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+func looksLikeISODate(s string) bool {
+	// Cheap shape check: 10 chars in YYYY-MM-DD layout.
+	if len(s) != 10 {
+		return false
+	}
+	if s[4] != '-' || s[7] != '-' {
+		return false
+	}
+	for i, r := range s {
+		if i == 4 || i == 7 {
+			continue
+		}
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/terrain/cmd_suppress_test.go
+++ b/cmd/terrain/cmd_suppress_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/identity"
+	"github.com/pmclSF/terrain/internal/suppression"
+)
+
+// TestRunSuppress_CreatesNewFile verifies the happy path: no existing
+// suppressions file, runSuppress writes a fresh one with the schema
+// header + one entry.
+func TestRunSuppress_CreatesNewFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	id := identity.BuildFindingID("weakAssertion", "internal/auth/login_test.go", "TestLogin", 42)
+
+	if err := runSuppress(id, "false positive — sanitized upstream", "2026-08-01", "@platform", root); err != nil {
+		t.Fatalf("runSuppress: %v", err)
+	}
+
+	// Verify the file shape via the loader: it should round-trip
+	// cleanly into one valid Entry.
+	res, err := suppression.Load(filepath.Join(root, suppression.DefaultPath))
+	if err != nil {
+		t.Fatalf("load written file: %v", err)
+	}
+	if len(res.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(res.Entries))
+	}
+	e := res.Entries[0]
+	if e.FindingID != id || !strings.Contains(e.Reason, "sanitized") || e.Owner != "@platform" {
+		t.Errorf("entry mismatch: %+v", e)
+	}
+}
+
+// TestRunSuppress_AppendsToExisting verifies that runSuppress appends
+// when the file already has entries (preserves prior ones).
+func TestRunSuppress_AppendsToExisting(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	idA := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	idB := identity.BuildFindingID("mockHeavyTest", "b.go", "Y", 2)
+
+	if err := runSuppress(idA, "first", "", "", root); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSuppress(idB, "second", "", "", root); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := suppression.Load(filepath.Join(root, suppression.DefaultPath))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(res.Entries))
+	}
+}
+
+// TestRunSuppress_RejectsDuplicate verifies the second call with the
+// same finding ID returns a usage error (not silently appending a
+// duplicate).
+func TestRunSuppress_RejectsDuplicate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+
+	if err := runSuppress(id, "first", "", "", root); err != nil {
+		t.Fatal(err)
+	}
+	err := runSuppress(id, "second", "", "", root)
+	if err == nil || !strings.Contains(err.Error(), "already suppressed") {
+		t.Errorf("expected 'already suppressed' error, got %v", err)
+	}
+}
+
+// TestRunSuppress_RejectsBadID verifies that a malformed finding ID
+// is rejected before any file is touched.
+func TestRunSuppress_RejectsBadID(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	err := runSuppress("not-a-finding-id", "ok", "", "", root)
+	if err == nil || !strings.Contains(err.Error(), "invalid finding ID") {
+		t.Errorf("expected invalid-ID error, got %v", err)
+	}
+	// Verify no file was created.
+	if _, err := os.Stat(filepath.Join(root, suppression.DefaultPath)); err == nil {
+		t.Error("file should not exist after a rejected call")
+	}
+}
+
+// TestRunSuppress_RequiresReason verifies the reason flag is enforced.
+func TestRunSuppress_RequiresReason(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	err := runSuppress(id, "", "", "", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "--reason is required") {
+		t.Errorf("expected reason-required error, got %v", err)
+	}
+}
+
+// TestRunSuppress_RejectsBadExpiryShape verifies that a non-ISO-shaped
+// expires fails fast.
+func TestRunSuppress_RejectsBadExpiryShape(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	err := runSuppress(id, "ok", "next-month", "", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Errorf("expected YYYY-MM-DD error, got %v", err)
+	}
+}
+
+// TestLooksLikeISODate covers the small validator.
+func TestLooksLikeISODate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"2026-08-01", true},
+		{"2099-12-31", true},
+		{"2026/08/01", false},
+		{"08-01-2026", false},
+		{"2026-8-1", false}, // not zero-padded
+		{"", false},
+		{"abc", false},
+	}
+	for _, tc := range cases {
+		got := looksLikeISODate(tc.in)
+		if got != tc.want {
+			t.Errorf("looksLikeISODate(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -123,12 +123,37 @@ func main() {
 		promptfooFlag := analyzeCmd.String("promptfoo-results", "", "path to Promptfoo --output result file(s); comma-separated for multiple")
 		deepevalFlag := analyzeCmd.String("deepeval-results", "", "path to DeepEval --export result file(s); comma-separated for multiple")
 		ragasFlag := analyzeCmd.String("ragas-results", "", "path to Ragas eval result file(s); comma-separated for multiple")
-		baselineFlag := analyzeCmd.String("baseline", "", "path to a previous snapshot JSON file; enables regression-aware detectors (aiCostRegression, aiRetrievalRegression)")
+		baselineFlag := analyzeCmd.String("baseline", "", "path to a previous snapshot JSON file; enables regression-aware detectors and --new-findings-only filtering")
 		slowThreshold := analyzeCmd.Float64("slow-threshold", defaultSlowThresholdMs, "slow test threshold in ms")
 		redactPathsFlag := analyzeCmd.Bool("redact-paths", false, "rewrite absolute paths in --format=sarif output to repo-relative form (or basename if outside repo)")
+		suppressionsFlag := analyzeCmd.String("suppressions", "", "path to .terrain/suppressions.yaml (default: $root/.terrain/suppressions.yaml; missing file is fine)")
+		newOnlyFlag := analyzeCmd.Bool("new-findings-only", false, "filter signals to those NOT present in --baseline (lets established repos with debt adopt --fail-on without bricking CI)")
 		_ = analyzeCmd.Parse(os.Args[2:])
 		mountPositionalAsRoot("analyze", analyzeCmd.Args(), rootFlag)
-		if err := runAnalyze(*rootFlag, *jsonFlag, *formatFlag, *verboseFlag, *writeSnapshot, *coverageFlag, *coverageRunLabelFlag, *runtimeFlag, *gauntletFlag, *promptfooFlag, *deepevalFlag, *ragasFlag, *baselineFlag, *slowThreshold, *redactPathsFlag); err != nil {
+		if *newOnlyFlag && *baselineFlag == "" {
+			fmt.Fprintln(os.Stderr, "error: --new-findings-only requires --baseline <path>")
+			os.Exit(exitUsageError)
+		}
+		analyzeOpts := analyzeRunOpts{
+			Root:               *rootFlag,
+			JSONOutput:         *jsonFlag,
+			Format:             *formatFlag,
+			Verbose:            *verboseFlag,
+			WriteSnapshot:      *writeSnapshot,
+			CoveragePath:       *coverageFlag,
+			CoverageRunLabel:   *coverageRunLabelFlag,
+			RuntimePaths:       *runtimeFlag,
+			GauntletPaths:      *gauntletFlag,
+			PromptfooPaths:     *promptfooFlag,
+			DeepEvalPaths:      *deepevalFlag,
+			RagasPaths:         *ragasFlag,
+			BaselinePath:       *baselineFlag,
+			SlowThreshold:      *slowThreshold,
+			RedactPaths:        *redactPathsFlag,
+			SuppressionsPath:   *suppressionsFlag,
+			NewFindingsOnly:    *newOnlyFlag,
+		}
+		if err := runAnalyze(analyzeOpts); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
@@ -326,6 +351,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  terrain explain <code-unit>     explain a code unit (path:name)")
 			fmt.Fprintln(os.Stderr, "  terrain explain <owner>         explain an owner's scope")
 			fmt.Fprintln(os.Stderr, "  terrain explain <scenario-id>   explain an AI/eval scenario")
+			fmt.Fprintln(os.Stderr, "  terrain explain <finding-id>    explain a finding (e.g. weakAssertion@path:Sym#hash)")
 			fmt.Fprintln(os.Stderr, "  terrain explain selection       explain overall test selection")
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(os.Stderr, "Flags:")
@@ -335,6 +361,30 @@ func main() {
 			os.Exit(2)
 		}
 		if err := runExplain(explainArgs[0], *rootFlag, *baseRef, *jsonFlag, *verboseFlag); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(exitCodeForCLIError(err))
+		}
+
+	case "suppress":
+		// `terrain suppress <finding-id> --reason "why" [--expires YYYY-MM-DD] [--owner @who]`
+		// Track 4.7 — appends a suppression entry to .terrain/suppressions.yaml.
+		// No legacy alias: this command is new in 0.2.0 and lives in the
+		// canonical surface as a Gate-pillar primitive.
+		suppressCmd := flag.NewFlagSet("suppress", flag.ExitOnError)
+		rootFlag := suppressCmd.String("root", ".", "repository root")
+		reasonFlag := suppressCmd.String("reason", "", "why this finding is being suppressed (required)")
+		expiresFlag := suppressCmd.String("expires", "", "ISO date YYYY-MM-DD when the suppression should expire (optional but recommended)")
+		ownerFlag := suppressCmd.String("owner", "", "owner pointer for review (optional)")
+		_ = suppressCmd.Parse(os.Args[2:])
+		args := suppressCmd.Args()
+		if len(args) < 1 {
+			fmt.Fprintln(os.Stderr, "Usage: terrain suppress <finding-id> --reason \"why\" [--expires YYYY-MM-DD] [--owner @who]")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Find a finding's ID with: terrain explain <finding-id>")
+			os.Exit(exitUsageError)
+		}
+		findingID := args[0]
+		if err := runSuppress(findingID, *reasonFlag, *expiresFlag, *ownerFlag, *rootFlag); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(exitCodeForCLIError(err))
 		}

--- a/internal/engine/new_findings_only.go
+++ b/internal/engine/new_findings_only.go
@@ -1,0 +1,103 @@
+package engine
+
+import (
+	"github.com/pmclSF/terrain/internal/logging"
+	"github.com/pmclSF/terrain/internal/models"
+)
+
+// applyNewFindingsOnly filters the snapshot to keep only signals whose
+// FindingID is NOT present in the baseline snapshot. Used by Track 4.8
+// (`--new-findings-only --baseline <path>`) so established repos with
+// existing debt can adopt strict CI gates on day one — the gate only
+// fires on findings introduced AFTER the baseline was captured.
+//
+// Behavior:
+//   - When `snapshot.Baseline` is nil (no `--baseline` was supplied),
+//     this function logs a warning and returns the snapshot unchanged.
+//     The user's `--new-findings-only` flag was inert; we tell them.
+//   - When the baseline is present but contains no signals (e.g.
+//     a fresh first-run baseline), every current signal counts as
+//     "new" — same as no filter applied.
+//   - When the baseline has signals, every (top-level + per-file)
+//     signal in the current snapshot is checked against the baseline
+//     FindingID set; matches are removed.
+//
+// Idempotent. No-op when snapshot is nil.
+func applyNewFindingsOnly(snapshot *models.TestSuiteSnapshot) {
+	if snapshot == nil {
+		return
+	}
+	if snapshot.Baseline == nil {
+		logging.L().Warn("--new-findings-only is inert: no --baseline supplied")
+		return
+	}
+
+	baselineIDs := collectBaselineFindingIDs(snapshot.Baseline)
+	if len(baselineIDs) == 0 {
+		// Empty baseline — nothing to subtract; every current signal
+		// is "new" by definition.
+		return
+	}
+
+	beforeTop := len(snapshot.Signals)
+	snapshot.Signals = filterByMissingID(snapshot.Signals, baselineIDs)
+	beforeFile := 0
+	afterFile := 0
+	for fi := range snapshot.TestFiles {
+		tf := &snapshot.TestFiles[fi]
+		beforeFile += len(tf.Signals)
+		tf.Signals = filterByMissingID(tf.Signals, baselineIDs)
+		afterFile += len(tf.Signals)
+	}
+
+	logging.L().Info("new-findings-only applied",
+		"baseline_findings", len(baselineIDs),
+		"top_level_dropped", beforeTop-len(snapshot.Signals),
+		"per_file_dropped", beforeFile-afterFile,
+	)
+}
+
+// collectBaselineFindingIDs reads every signal in the baseline (both
+// top-level Signals and per-test-file Signals) and returns the set
+// of populated FindingIDs. Older baselines without finding IDs return
+// an empty set — those signals can't participate in the comparison.
+func collectBaselineFindingIDs(baseline *models.TestSuiteSnapshot) map[string]bool {
+	if baseline == nil {
+		return nil
+	}
+	ids := make(map[string]bool)
+	for _, s := range baseline.Signals {
+		if s.FindingID != "" {
+			ids[s.FindingID] = true
+		}
+	}
+	for _, tf := range baseline.TestFiles {
+		for _, s := range tf.Signals {
+			if s.FindingID != "" {
+				ids[s.FindingID] = true
+			}
+		}
+	}
+	return ids
+}
+
+// filterByMissingID keeps signals whose FindingID is NOT in the set.
+// Signals with empty FindingID are kept (we can't compare them; better
+// to over-report than silently drop unidentifiable findings).
+func filterByMissingID(signals []models.Signal, baselineIDs map[string]bool) []models.Signal {
+	if len(signals) == 0 {
+		return signals
+	}
+	kept := signals[:0]
+	for _, s := range signals {
+		if s.FindingID == "" {
+			kept = append(kept, s)
+			continue
+		}
+		if baselineIDs[s.FindingID] {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept
+}

--- a/internal/engine/new_findings_only_test.go
+++ b/internal/engine/new_findings_only_test.go
@@ -1,0 +1,138 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/identity"
+	"github.com/pmclSF/terrain/internal/models"
+)
+
+func TestApplyNewFindingsOnly_DropsBaselineMatches(t *testing.T) {
+	t.Parallel()
+
+	// Two signals share an ID with the baseline; one is new.
+	id1 := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	id2 := identity.BuildFindingID("weakAssertion", "b.go", "Y", 2)
+	idNew := identity.BuildFindingID("mockHeavyTest", "c.go", "Z", 3)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id1},
+			{Type: "weakAssertion", FindingID: id2},
+			{Type: "mockHeavyTest", FindingID: idNew},
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{
+				{Type: "weakAssertion", FindingID: id1},
+				{Type: "weakAssertion", FindingID: id2},
+			},
+		},
+	}
+
+	applyNewFindingsOnly(snap)
+
+	if len(snap.Signals) != 1 {
+		t.Fatalf("expected 1 surviving signal (the new one), got %d", len(snap.Signals))
+	}
+	if snap.Signals[0].FindingID != idNew {
+		t.Errorf("wrong signal survived: %+v", snap.Signals[0])
+	}
+}
+
+func TestApplyNewFindingsOnly_NoBaselineLogsWarning(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id},
+		},
+		// Baseline intentionally nil — flag is inert.
+	}
+	applyNewFindingsOnly(snap)
+	// Without a baseline, every signal stays.
+	if len(snap.Signals) != 1 {
+		t.Errorf("no-baseline case should not filter; got %d signals", len(snap.Signals))
+	}
+}
+
+func TestApplyNewFindingsOnly_EmptyBaselineKeepsAll(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id},
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{}, // populated but empty
+		},
+	}
+	applyNewFindingsOnly(snap)
+	if len(snap.Signals) != 1 {
+		t.Errorf("empty baseline should not filter; got %d signals", len(snap.Signals))
+	}
+}
+
+func TestApplyNewFindingsOnly_PerFileSignals(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	idNew := identity.BuildFindingID("mockHeavyTest", "b.go", "Y", 2)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id},
+		},
+		TestFiles: []models.TestFile{
+			{
+				Path: "a.go",
+				Signals: []models.Signal{
+					{Type: "weakAssertion", FindingID: id},   // existing → drop
+					{Type: "mockHeavyTest", FindingID: idNew}, // new → keep
+				},
+			},
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{
+				{Type: "weakAssertion", FindingID: id},
+			},
+		},
+	}
+
+	applyNewFindingsOnly(snap)
+
+	if len(snap.Signals) != 0 {
+		t.Errorf("top-level matching baseline should be dropped; got %d", len(snap.Signals))
+	}
+	if len(snap.TestFiles[0].Signals) != 1 {
+		t.Fatalf("expected 1 surviving per-file signal, got %d", len(snap.TestFiles[0].Signals))
+	}
+	if snap.TestFiles[0].Signals[0].FindingID != idNew {
+		t.Errorf("wrong signal survived per-file: %+v", snap.TestFiles[0].Signals[0])
+	}
+}
+
+func TestApplyNewFindingsOnly_KeepsSignalsWithoutFindingID(t *testing.T) {
+	t.Parallel()
+	// Older or specially-emitted signals may not have a FindingID. The
+	// filter shouldn't silently drop them — over-report rather than
+	// under-report.
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion"}, // no FindingID
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{
+				{Type: "mockHeavyTest", FindingID: "something"},
+			},
+		},
+	}
+	applyNewFindingsOnly(snap)
+	if len(snap.Signals) != 1 {
+		t.Errorf("signals without FindingID should be kept; got %d", len(snap.Signals))
+	}
+}
+
+func TestApplyNewFindingsOnly_NilSafe(t *testing.T) {
+	t.Parallel()
+	applyNewFindingsOnly(nil)
+	applyNewFindingsOnly(&models.TestSuiteSnapshot{}) // no signals, no baseline
+}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -122,6 +122,19 @@ type PipelineOptions struct {
 	//
 	// See `internal/suppression` for the schema and matching semantics.
 	SuppressionsPath string
+
+	// NewFindingsOnly, when true, filters the snapshot to keep only
+	// signals whose FindingID is NOT present in the baseline snapshot
+	// (loaded via BaselineSnapshotPath). Used by
+	// `terrain analyze --fail-on critical --new-findings-only --baseline old.json`
+	// so established repos with existing debt don't brick CI on first
+	// adoption — the gate fires only on findings introduced AFTER the
+	// baseline was captured.
+	//
+	// No-op when BaselineSnapshotPath is empty (no baseline → nothing
+	// to subtract; pipeline emits a warning so the user notices their
+	// flag is inert).
+	NewFindingsOnly bool
 }
 
 // RunPipeline executes the full analysis pipeline:
@@ -737,6 +750,16 @@ func RunPipelineContext(ctx context.Context, root string, opts ...PipelineOption
 	// accumulate. Missing file is fine — most users won't have one
 	// in 0.2.0.
 	applySuppressions(snapshot, root, opt.SuppressionsPath, time.Now())
+
+	// Step 10d: optional --new-findings-only filter. When the user
+	// supplied both --baseline and --new-findings-only, drop every
+	// signal whose FindingID already existed in the baseline so the
+	// gate fires only on net-new findings. Established repos with
+	// existing debt rely on this to adopt --fail-on without bricking
+	// CI on day one.
+	if opt.NewFindingsOnly {
+		applyNewFindingsOnly(snapshot)
+	}
 
 	if err := models.ValidateSnapshot(snapshot); err != nil {
 		return nil, fmt.Errorf("invalid snapshot produced by pipeline: %w", err)


### PR DESCRIPTION
## Summary

Bundles Tracks 4.6, 4.7, and 4.8 from the 0.2.0 parity-gated release plan. With finding IDs (#138) and the suppression schema (#139) in flight, this PR makes the suppression workflow usable end-to-end.

**Base branch:** \`feat/0.2-suppressions\` (#139, which itself stacks on #138). Will rebase onto main after the chain merges.

## Track 4.6 — \`terrain explain <finding-id>\`

\`terrain explain\` recognizes stable finding IDs and prints a finding-detail block: detector + severity + location + evidence + explanation + suggested action + the canonical \`terrain suppress\` invocation. A finding ID that parses but isn't in the snapshot returns a distinct exit-5 (not-found) message that distinguishes "stale ID after refactor" from "garbage input."

## Track 4.7 — \`terrain suppress <id> --reason "..." [--expires] [--owner]\`

New top-level Gate-pillar primitive. Validates the ID format, refuses duplicates (existing entry → usage error pointing at the existing reason), appends a YAML entry to \`.terrain/suppressions.yaml\`. Writes text rather than re-marshaling so user comments / ordering are preserved. Schema header auto-emitted on first call.

## Track 4.8 — \`--new-findings-only --baseline <path>\`

The "established repos with debt" adoption flow. \`--fail-on critical\` alone would brick CI on day one against existing findings; combining with \`--new-findings-only --baseline old.json\` makes the gate fire only on findings introduced AFTER the baseline. \`--new-findings-only\` without \`--baseline\` is rejected at usage-error level so the user gets a clear message rather than a silent no-op.

## Refactor (small, helpful)

\`runAnalyze\` gets an \`analyzeRunOpts\` struct so the call site in \`main.go\` isn't a 17-positional-argument list. Future flag additions don't expand the signature.

## Test plan

- [x] \`go test ./cmd/terrain/ -run "TestRunSuppress|TestLooksLikeISODate"\` — 7 tests green (creates new file, appends to existing, rejects duplicate, rejects bad ID, requires reason, rejects bad expiry shape, ISO validator)
- [x] \`go test ./internal/engine/ -run "TestApplyNewFindingsOnly"\` — 6 tests green (drops baseline matches, no-baseline warning, empty baseline, per-file signals, keeps signals without ID, nil-safe)
- [x] \`go test ./...\` full suite green
- [x] \`go test ./internal/testdata/\` golden + CLI suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
