### PR TITLE
docs(0.2): AI trust boundary + Node 22 prominence + release-smoke matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,45 +272,101 @@ jobs:
           --generate-notes \
           dist/*
 
-  # Post-release smoke test: download the just-published linux/amd64
-  # archive, extract, and verify `terrain version --json` reports the
-  # tagged version. Catches the class of "release published but
-  # archive contains a stale build / wrong version string" bugs that
-  # previously could only be caught by a user installing from the
-  # release after the fact. Runs after the GitHub release is created
-  # so the artifact URLs resolve.
+  # Post-release smoke test: download the just-published archive for
+  # each shipped target, extract, and verify `terrain version --json`
+  # reports the tagged version. Catches "release published but archive
+  # contains a stale build / wrong version string" bugs that
+  # previously could only surface after a user installed from the
+  # release. Runs after the GitHub release is created so artifact
+  # URLs resolve.
+  #
+  # Matrix covers the three primary platforms: linux/amd64 (the
+  # historical default), darwin/arm64 (the modern Mac default — Apple
+  # Silicon is the dominant developer hardware), and windows/amd64
+  # (the most likely Windows shape). linux/arm64 and darwin/amd64
+  # archives still ship; they just aren't smoke-tested per release —
+  # they share build infrastructure with the matrixed targets.
   release-smoke:
     needs: go-release-publish
-    runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux_amd64
+            runner: ubuntu-latest
+            archive_ext: tar.gz
+            binary: terrain
+          - name: darwin_arm64
+            runner: macos-14
+            archive_ext: tar.gz
+            binary: terrain
+          - name: windows_amd64
+            runner: windows-latest
+            archive_ext: zip
+            binary: terrain.exe
+    runs-on: ${{ matrix.runner }}
     steps:
-    - name: Download and verify linux/amd64 archive
+    - name: Download and verify ${{ matrix.name }} archive (POSIX)
+      if: matrix.archive_ext == 'tar.gz'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
         TAG="${GITHUB_REF_NAME}"
         VERSION="${TAG#v}"
-        ARCHIVE="terrain_${VERSION}_linux_amd64.tar.gz"
+        ARCHIVE="terrain_${VERSION}_${{ matrix.name }}.${{ matrix.archive_ext }}"
 
         echo "Downloading $ARCHIVE from release $TAG..."
         gh release download "$TAG" --pattern "$ARCHIVE" --clobber
 
         echo "Extracting..."
         tar -xzf "$ARCHIVE"
-        chmod +x ./terrain
+        chmod +x ./${{ matrix.binary }}
 
-        echo "Running ./terrain version --json:"
-        OUTPUT=$(./terrain version --json)
+        echo "Running ./${{ matrix.binary }} version --json:"
+        OUTPUT=$(./${{ matrix.binary }} version --json)
         echo "$OUTPUT"
 
-        # Parse the version field and assert it matches the tag.
         REPORTED=$(echo "$OUTPUT" | grep -oE '"version"\s*:\s*"[^"]+"' | head -1 | sed -E 's/.*"version"\s*:\s*"([^"]+)".*/\1/')
         if [ "$REPORTED" != "$VERSION" ]; then
           echo "❌ Version mismatch: archive reports '$REPORTED', expected '$VERSION'" >&2
           exit 1
         fi
-        echo "✅ Smoke test passed: published archive reports version $VERSION."
+        echo "✅ Smoke test passed (${{ matrix.name }}): published archive reports version $VERSION."
+
+    - name: Download and verify ${{ matrix.name }} archive (Windows)
+      if: matrix.archive_ext == 'zip'
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $TAG = $env:GITHUB_REF_NAME
+        $VERSION = $TAG.TrimStart('v')
+        $ARCHIVE = "terrain_${VERSION}_${{ matrix.name }}.${{ matrix.archive_ext }}"
+
+        Write-Host "Downloading $ARCHIVE from release $TAG..."
+        gh release download $TAG --pattern $ARCHIVE --clobber
+
+        Write-Host "Extracting..."
+        Expand-Archive -Path $ARCHIVE -DestinationPath . -Force
+
+        Write-Host "Running .\${{ matrix.binary }} version --json:"
+        $OUTPUT = & ".\${{ matrix.binary }}" version --json
+        Write-Host $OUTPUT
+
+        $match = $OUTPUT | Select-String -Pattern '"version"\s*:\s*"([^"]+)"' | Select-Object -First 1
+        if (-not $match) {
+            Write-Error "❌ No version field found in output"
+            exit 1
+        }
+        $REPORTED = $match.Matches[0].Groups[1].Value
+        if ($REPORTED -ne $VERSION) {
+            Write-Error "❌ Version mismatch: archive reports '$REPORTED', expected '$VERSION'"
+            exit 1
+        }
+        Write-Host "✅ Smoke test passed (${{ matrix.name }}): published archive reports version $VERSION."
 
   # Homebrew tap update is handled by the separate homebrew-update.yml
   # workflow, which fires on `release: published` (and on workflow_dispatch

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Everything else is a deeper view *off* this primary workflow.
 # Homebrew
 brew install pmclSF/terrain/mapterrain
 
-# npm — requires cosign on PATH for signed-binary verification.
+# npm — requires Node 22+ and cosign on PATH for signed-binary verification.
+# (CI on Node 20 LTS? Use the brew or `go install` path above.)
 # brew install cosign  (macOS / Linux)
 # scoop install cosign (Windows)
 # Set TERRAIN_INSTALLER_ALLOW_MISSING_COSIGN=1 to fall back to checksum-only,
@@ -364,6 +365,12 @@ brew install mapterrain
 ```bash
 npm install -g mapterrain
 ```
+
+> **Node 22 required.** The npm postinstall verifies signed binaries
+> with cosign and uses APIs (`fetch`, top-level await, modern stream
+> primitives) that landed in Node 22. CI images on Node 20 LTS
+> should use the Homebrew or `go install` path until 0.3 ships
+> Node-20 compat. Run `node --version` to check.
 
 ### Go install
 

--- a/docs/product/ai-trust-boundary.md
+++ b/docs/product/ai-trust-boundary.md
@@ -1,0 +1,129 @@
+# AI Trust Boundary
+
+What Terrain executes vs. what it parses, where AI processing
+happens, and what it doesn't do. This page exists because the
+launch-readiness review flagged the boundary as insufficiently
+documented — adopters were unsure whether `terrain ai run` invokes
+LLMs, ships secrets, or sandboxes anything.
+
+## TL;DR
+
+- **Terrain does not execute LLMs.** Eval frameworks (Promptfoo /
+  DeepEval / Ragas) execute prompts against models. Terrain reads
+  the artifacts they produce.
+- **Terrain does not ship secrets.** API keys live where they
+  always lived — your shell, your CI secrets, your `.env`. Terrain
+  doesn't read them, doesn't pass them anywhere, doesn't log them.
+- **Terrain does not phone home.** Local-first. The only network
+  I/O happens during installation (downloading signed binaries
+  from GitHub Releases) — analysis itself is offline.
+- **Terrain does not sandbox eval execution.** Sandboxing is 0.3
+  work. If the eval framework has tools that touch your system,
+  that surface is the framework's responsibility in 0.2.
+
+## Per-command boundary
+
+### `terrain analyze`
+
+**What it does:** static analysis of repo source + ingestion of
+artifacts (coverage / runtime / eval results when present).
+
+**What it doesn't do:** invoke any LLM. Read secrets. Make network
+requests for analysis purposes.
+
+**Filesystem access:** read-only walk of the repo root passed in
+(or `.` by default). No writes outside `.terrain/snapshots/`
+(only when `--write-snapshot` is set explicitly).
+
+### `terrain ai list` / `terrain ai doctor`
+
+**What it does:** scans the repo for AI surface declarations
+(prompts, tools, contexts, eval scenarios), reports on inventory
++ coverage.
+
+**What it doesn't do:** invoke any LLM. Make network requests.
+Touch the eval framework binaries.
+
+### `terrain ai run`
+
+**Important — this is the highest-trust-surface command in 0.2.**
+
+**What `terrain ai run` does:**
+1. Loads scenarios from your `terrain.yaml` config.
+2. Optionally invokes the eval framework binary (Promptfoo /
+   DeepEval / Ragas) as a child process when scenarios point at
+   one.
+3. Reads the framework's output JSON.
+4. Computes a baseline-aware decision (`pass` / `warn` / `block`)
+   and writes the result to `.terrain/artifacts/`.
+
+**Where the LLM call actually happens:** *inside* the eval
+framework, not inside Terrain. The framework decides how to call
+the model, what API key to use, what timeouts apply, whether to
+sandbox tool calls. Terrain is one layer above.
+
+**What this means for adopters:**
+- Your existing API key handling stays as-is. If Promptfoo
+  picked up `OPENAI_API_KEY` from your shell before, it still
+  does. Terrain doesn't proxy or wrap the key.
+- Your existing rate limiting / retry behavior stays as-is —
+  it's the framework's policy.
+- If the framework has tool-execution capabilities (file write,
+  shell command), the framework decides what's allowed. Terrain
+  does not add a sandbox layer in 0.2.
+
+### `terrain ai run --baseline <path>` / `--ingest-only`
+
+`--ingest-only` skips the framework invocation and only reads
+existing eval-output JSON files (via `--promptfoo-results`,
+`--deepeval-results`, `--ragas-results`). In this mode Terrain is
+fully passive — no child processes, no LLM calls.
+
+## Sandboxing roadmap
+
+| Capability | 0.2 | 0.3 |
+|------------|-----|-----|
+| Read-only filesystem access in `terrain analyze` | yes | yes |
+| Sandbox `terrain ai run` child processes | no | yes |
+| Tool-call allowlist for AI tool invocations | no (framework's job) | terrain-side allowlist |
+| Network egress controls during eval execution | no (framework's job) | optional terrain-side network policy |
+
+If you need 0.3-grade sandboxing in 0.2, run `terrain ai run` with
+`--ingest-only` and execute the eval framework yourself in your
+preferred sandbox (Docker, gVisor, Firecracker, etc.). Terrain
+will read the framework's output without invoking it.
+
+## Detector boundary (pure-static side)
+
+The 12 AI risk detectors that ship in 0.2 (`aiPromptInjectionRisk`,
+`aiHardcodedAPIKey`, `aiToolWithoutSandbox`, etc.) are all **pure
+static analysis** — they read source code on disk, never invoke an
+LLM. False positives are heuristic; AST-grade taint analysis lands
+in 0.3.
+
+## What Terrain doesn't promise about AI risk in 0.2
+
+The audit doc spells these out explicitly. Repeating here so
+nothing in this trust-boundary doc reads as a guarantee:
+
+- Terrain does NOT judge model truthfulness (`aiHallucinationRate`
+  reads the eval framework's hallucination metadata, not Terrain
+  judging hallucinations directly).
+- Terrain does NOT promise public-grade precision floors. Recall is
+  calibration-anchored on a 27-fixture corpus; precision against
+  labeled real-repo corpora is 0.3 work.
+- Terrain does NOT replace dedicated AI safety services. Lakera /
+  Guardrails / similar runtime guards solve a different problem
+  (request-time protection); Terrain solves the structural /
+  pre-deploy / inventory side.
+
+## Related reading
+
+- [`docs/product/vision.md`](vision.md) — full product narrative
+- [`docs/product/trust-ladder.md`](trust-ladder.md) — adoption ramp
+- [`docs/release/feature-status.md`](../release/feature-status.md) —
+  per-capability tier (which AI surfaces are publicly claimable)
+- [`docs/release/0.2-known-gaps.md`](../release/0.2-known-gaps.md) —
+  honest carryovers, including AI-specific ones
+- [`docs/integrations/{promptfoo,deepeval,ragas}.md`](../integrations/) —
+  per-framework integration notes

--- a/docs/user-guides/getting-started.md
+++ b/docs/user-guides/getting-started.md
@@ -2,6 +2,32 @@
 
 ## Prerequisites
 
+### Node 22 (npm path only)
+
+The npm install path requires **Node 22 or later**. The postinstall
+script uses `fetch`, top-level await, and modern stream primitives
+that landed in Node 22 — earlier versions fail at install time, not
+run time.
+
+```bash
+node --version    # expect v22.x or higher
+```
+
+If your CI image is pinned to Node 20 LTS, two recommended
+alternatives keep working without a Node bump:
+
+```bash
+# Homebrew (macOS / Linux)
+brew install pmclSF/terrain/mapterrain
+
+# Go install (any platform with Go 1.23+)
+go install github.com/pmclSF/terrain/cmd/terrain@latest
+```
+
+Node-20 compat for the npm path is on the 0.3 roadmap.
+
+### Cosign (npm path only)
+
 The npm install path verifies signed binaries with cosign before
 extracting them. Cosign needs to be on `PATH` before you run `npm
 install`:


### PR DESCRIPTION
## Summary

Bundle of three Track 7 / Track 8 deliverables for the parity-gated
0.2.0 release plan. All three close items the launch-readiness
review flagged as insufficiently documented or insufficiently
verified.

- **Track 7.3 — AI execution trust-boundary doc.** New page
  `docs/product/ai-trust-boundary.md` explicitly documents what
  Terrain executes vs. parses, where the LLM call actually
  happens (inside the eval framework, not Terrain), per-command
  trust surface for `analyze`, `ai list/doctor`, `ai run`, and
  `ai run --ingest-only`, plus the 0.2 → 0.3 sandboxing roadmap.
- **Track 8.1 — Node 22 prominence.** README and
  `docs/user-guides/getting-started.md` now call out the Node 22
  npm-path requirement up front, with explicit brew / `go install`
  alternatives for CI on Node 20 LTS.
- **Track 8.2 — Release-smoke matrix expansion.** Post-publish
  smoke job goes from linux/amd64-only to also cover darwin/arm64
  (Apple Silicon) and windows/amd64. Matrix uses POSIX tar.gz on
  Linux/macOS and pwsh `Expand-Archive` on Windows; both verify
  `terrain version --json` reports the tagged version.

## Why these three together

They're independent in code but co-located in the plan: all three
are "honest about how this thing actually installs and runs"
items. Bundling minimizes review thrash on a doc-and-CI-config
PR. None changes Go code; the only Go-relevant change is the
release workflow.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `make docs-verify` passes
- [x] `actionlint .github/workflows/release.yml` reports no new
      issues (existing SC2035 info-level warnings on line 231
      are pre-existing and unrelated)
- [ ] Workflow matrix verified end-to-end on next tagged release
      (cannot exercise pre-merge — needs a real published archive)
- [ ] AI trust-boundary doc reviewed for accuracy of per-command
      claims against current code paths

## Plan tracker

Closes Track 7.3, 8.1, 8.2 from the parity-gated 0.2.0 plan.
Remaining 0.2.0 work (per plan): Track 3.3-3.5, 5.1, 5.3, 5.6, 6.x,
7.1-7.2/7.4-7.5, 9.x, 10.2-10.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)