### PR TITLE
feat(0.2): Align pillar foundation — repos.yaml + alignment-first migration + tier badges (Tracks 6.1/6.5/6.6)

### DIFF
--- a/cmd/terrain/cmd_convert.go
+++ b/cmd/terrain/cmd_convert.go
@@ -399,11 +399,12 @@ func runListConversions(jsonOutput bool) error {
 				direction.From,
 				direction.To,
 				strings.Join(direction.Shorthands, ", "),
-				humanizeGoNativeState(direction.GoNativeState),
+				tierLabelForState(direction.GoNativeState),
 			)
 		}
 		fmt.Println()
 	}
+	fmt.Println("Tiers: Stable = conversion-corpus calibrated; Experimental = end-to-end but expect hand cleanup; Preview = next up for implementation; Cataloged = metadata only.")
 	fmt.Println("Use `terrain convert <source> --from <framework> --to <framework>` to run a Go-native conversion, or add `--plan` to preview.")
 	return nil
 }
@@ -420,10 +421,10 @@ func runShorthands(jsonOutput bool) error {
 
 	fmt.Println("Shorthand command aliases")
 	fmt.Println()
-	fmt.Printf("  %-18s %-14s %-14s %s\n", "Alias", "From", "To", "State")
-	fmt.Printf("  %-18s %-14s %-14s %s\n", strings.Repeat("-", 18), strings.Repeat("-", 14), strings.Repeat("-", 14), strings.Repeat("-", 11))
+	fmt.Printf("  %-18s %-14s %-14s %s\n", "Alias", "From", "To", "Tier")
+	fmt.Printf("  %-18s %-14s %-14s %s\n", strings.Repeat("-", 18), strings.Repeat("-", 14), strings.Repeat("-", 14), strings.Repeat("-", 12))
 	for _, entry := range entries {
-		fmt.Printf("  %-18s %-14s %-14s %s\n", entry.Alias, entry.From, entry.To, humanizeGoNativeState(entry.GoNativeState))
+		fmt.Printf("  %-18s %-14s %-14s %s\n", entry.Alias, entry.From, entry.To, tierLabelForState(entry.GoNativeState))
 	}
 	fmt.Println()
 	fmt.Println("Use a shorthand directly to run the Go-native converter, or add `--plan`/`--dry-run` to preview.")
@@ -602,6 +603,33 @@ func humanizeGoNativeState(state conv.GoNativeState) string {
 		return "prioritized"
 	default:
 		return "cataloged"
+	}
+}
+
+// tierLabelForState renders a conversion direction's GoNativeState as
+// the Tier-badge vocabulary used elsewhere in 0.2 (Stable /
+// Experimental / Preview / Cataloged). Track 6.6 of the parity plan
+// surfaces this in `terrain migrate list` so adopters see the trust
+// posture per direction at a glance, not just the raw state name.
+//
+// The mapping:
+//   - implemented → "Stable"      (top-3 + conversion-corpus calibrated)
+//   - experimental → "Experimental" (works end-to-end; hand cleanup expected)
+//   - prioritized → "Preview"     (next in line for implementation)
+//   - cataloged   → "Cataloged"    (metadata only; no converter today)
+//
+// Returned without surrounding brackets so callers can wrap as needed
+// (the list renderer adds `[ ]`; JSON consumers get the bare label).
+func tierLabelForState(state conv.GoNativeState) string {
+	switch state {
+	case conv.GoNativeStateImplemented:
+		return "Stable"
+	case conv.GoNativeStateExperimental:
+		return "Experimental"
+	case conv.GoNativeStatePrioritized:
+		return "Preview"
+	default:
+		return "Cataloged"
 	}
 }
 

--- a/cmd/terrain/cmd_convert_tier_test.go
+++ b/cmd/terrain/cmd_convert_tier_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	conv "github.com/pmclSF/terrain/internal/convert"
+)
+
+// TestTierLabelForState locks the GoNativeState → Tier-label mapping
+// that surfaces in `terrain migrate list` output. Track 6.6 of the
+// 0.2.0 release plan defines this as the canonical user-facing
+// vocabulary; renaming a label here is a public-facing change and
+// requires updating docs/product/alignment-first-migration.md too.
+func TestTierLabelForState(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state conv.GoNativeState
+		want  string
+	}{
+		{conv.GoNativeStateImplemented, "Stable"},
+		{conv.GoNativeStateExperimental, "Experimental"},
+		{conv.GoNativeStatePrioritized, "Preview"},
+		{conv.GoNativeStateCataloged, "Cataloged"},
+		{conv.GoNativeState("unknown"), "Cataloged"},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			t.Parallel()
+			if got := tierLabelForState(tt.state); got != tt.want {
+				t.Errorf("tierLabelForState(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/product/alignment-first-migration.md
+++ b/docs/product/alignment-first-migration.md
@@ -1,0 +1,173 @@
+# Migration is alignment-first, not conversion-first
+
+How Terrain frames test framework migration in 0.2 — and why
+"converge on a framework of record" is a more useful question than
+"convert N files from framework A to framework B."
+
+## The framing shift
+
+Pre-0.2 Terrain talked about framework migration as conversion: a
+mechanical transform from Mocha to Jest, from unittest to pytest,
+from JUnit 4 to JUnit 5. That framing is correct but incomplete. It
+optimizes for the engineer running a single conversion, not for the
+team trying to bring a 50-repo portfolio into a coherent shape.
+
+The 0.2 launch-readiness review surfaced the disconnect: most teams
+care less about *converting* and more about *aligning*. They have
+six different test frameworks across twelve services, the new hires
+don't know which one their team uses, the CI templates fork along
+framework lines, and the cost of the inconsistency dwarfs the cost
+of any individual conversion.
+
+So 0.2's migration framing leads with alignment:
+
+> **Step 1: declare a framework of record per repo.**
+> **Step 2: see where each repo drifts from its declared framework.**
+> **Step 3: converge gradually — Terrain helps you sequence the work.**
+
+Conversion (the mechanical transform side) is one of the tools you
+use *during* convergence. It's not the headline; the headline is
+the convergence itself.
+
+## What this looks like in practice
+
+### Single repo
+
+```bash
+# Declare what this repo officially uses:
+cat > .terrain/frameworks.yaml <<EOF
+frameworksOfRecord:
+  - jest        # primary unit
+  - playwright  # primary e2e
+EOF
+
+# Run analyze. The output now includes a Framework Drift section:
+terrain analyze
+```
+
+```
+Framework Drift
+------------------------------------------------------------
+  Of-record:  jest, playwright
+  Detected:   jest (842 files), mocha (47 files), cypress (12 files)
+
+  ⚠ 47 mocha test files (5.4% of suite) drift from of-record framework
+  ⚠ 12 cypress test files in e2e/ — possibly intentional but undeclared
+
+  See: terrain migrate convergence-plan --target jest --source mocha
+```
+
+The drift section is alignment-first: it answers "where am I
+inconsistent" before it answers "what conversion do I run."
+
+### Multi-repo
+
+```bash
+# Declare the portfolio:
+cat > .terrain/repos.yaml <<EOF
+version: 1
+description: Acme engineering test alignment
+repos:
+  - name: web-app
+    path: ../web-app
+    frameworksOfRecord: [jest, playwright]
+  - name: api-service
+    path: ../api-service
+    frameworksOfRecord: [pytest]
+  - name: legacy-portal
+    path: ../legacy-portal
+    frameworksOfRecord: [mocha, cypress]    # legacy stack, not migrating yet
+EOF
+
+# Run portfolio over the manifest:
+terrain portfolio --from .terrain/repos.yaml
+```
+
+The portfolio output ranks repos by drift magnitude, surfaces
+shared blockers, and proposes a convergence sequence. The single-
+file converters are still there — they're step three, not step one.
+
+## Why this matters for tier framing
+
+Each conversion direction (Mocha → Jest, unittest → pytest, etc.)
+ships with tier metadata indicating how confident the conversion
+is in 0.2.0:
+
+| Conversion direction       | Tier in 0.2.0 | Notes |
+|----------------------------|---------------|-------|
+| Mocha → Jest               | Stable        | Top-3; conversion-corpus calibrated |
+| Jasmine → Jest             | Stable        | Top-3; conversion-corpus calibrated |
+| Vitest → Jest              | Stable        | Top-3; near-trivial transform |
+| unittest → pytest          | Experimental  | Common case works; class-based fixtures partial |
+| JUnit 4 → JUnit 5          | Experimental  | `@Test` swap solid; `@RunWith` cases partial |
+| Mocha → Vitest             | Experimental  | Lower demand; smaller corpus |
+| Cypress → Playwright       | Experimental  | E2E selectors don't transform 1:1 |
+| Other                      | Tier 3 / preview | Use at your own risk; preview only |
+
+`terrain migrate list` surfaces the tier per direction so adopters
+see the trust posture before they start a convergence run.
+
+## What changes in CLI output
+
+Two surfaces gain alignment-first framing:
+
+### `terrain analyze`
+
+The Framework section now includes a "Drift" subsection when a
+`frameworksOfRecord` declaration is present in the repo. Without
+the declaration, the legacy framework-distribution section
+unchanged.
+
+### `terrain migrate list`
+
+Each conversion direction prints with a tier badge:
+
+```
+Available conversions
+  jest ← mocha       [Stable]      conversion-corpus calibrated
+  jest ← jasmine     [Stable]      conversion-corpus calibrated
+  jest ← vitest      [Stable]      near-trivial transform
+  pytest ← unittest  [Experimental] class-based fixtures partial
+  junit5 ← junit4    [Experimental] @RunWith cases partial
+  vitest ← mocha     [Experimental] lower demand, smaller corpus
+  ...
+```
+
+## What's still in flight (0.2.x and 0.3)
+
+- **Per-direction conversion-corpus calibration to A-grade** for
+  the top-3 stable directions (Track 6.7 of the parity plan)
+- **`terrain portfolio --from <manifest>`** end-to-end aggregation
+  of multi-repo drift — manifest format ships in 0.2 (Track 6.1);
+  the aggregator lands in 0.2.x (Track 6.2/6.3)
+- **Cross-repo policy aggregation** — apply one policy to N repos
+  via the portfolio manifest. 0.3 work.
+
+Until those land, the alignment-first reframing is a **doc and CLI
+output change**, not a brand-new aggregator. The single-repo
+framework-drift section ships in 0.2; the multi-repo aggregator
+that consumes the manifest ships when it ships.
+
+## Anti-goals
+
+- We do not auto-convert files in 0.2. `terrain migrate run` is
+  preview-by-default; users review the diff and apply manually
+  (or with their own tooling).
+- We do not declare a "best" framework. The framework-of-record is
+  a per-team declaration; Terrain doesn't have an opinion about
+  Jest vs. Vitest vs. Mocha. We surface drift relative to your
+  declaration, not relative to ours.
+- We do not block convergence on calibration. Adopters can run
+  experimental-tier conversions today; the tier badge is honest
+  signaling, not a gate.
+
+## Related reading
+
+- [`docs/product/vision.md`](vision.md) — full pillar narrative
+  (Align is the secondary pillar in 0.2)
+- [`docs/release/feature-status.md`](../release/feature-status.md) —
+  per-capability tier matrix
+- [`internal/portfolio/manifest.go`](../../internal/portfolio/manifest.go) —
+  the multi-repo manifest schema
+- [`docs/architecture/27-go-native-conversion-migration.md`](../architecture/27-go-native-conversion-migration.md) —
+  conversion engine architecture (the mechanical transform side)

--- a/internal/portfolio/manifest.go
+++ b/internal/portfolio/manifest.go
@@ -1,0 +1,195 @@
+package portfolio
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RepoManifest is the shape of `.terrain/repos.yaml` — the multi-repo
+// declaration that Track 6 of the 0.2.0 release plan introduces. The
+// manifest enumerates each repo Terrain should aggregate over, plus
+// per-repo metadata that the cross-repo aggregator (when it lands)
+// will use to compute portfolio-level posture.
+//
+// Status in 0.2.0: **Tier 3 / experimental.** The schema is locked
+// for this release, but the cross-repo aggregation engine is partial
+// and the public claim ("multi-repo control plane") is explicitly
+// marked emerging in the README + feature-status doc. Adopters who
+// hand-roll a `repos.yaml` today get the file format they'll keep
+// using when 0.2.x ships the aggregator; the file written today is
+// forward-compatible.
+//
+// Per the parity plan's pillar-priority rule: Align is secondary in
+// 0.2.0 with floor ≥ 3 soft (warn-only). Shipping the manifest format
+// without the full aggregator is acceptable provided the marketing
+// reflects that — which `docs/release/feature-status.md` does.
+type RepoManifest struct {
+	// Version is the manifest schema version. 0.2 ships v1; later
+	// schema changes that aren't strictly additive will bump this.
+	// A loader that finds an unrecognized version refuses to load
+	// rather than guessing.
+	Version int `yaml:"version" json:"version"`
+
+	// Description is a free-form human-readable label for the
+	// manifest (e.g. "Acme Corp engineering portfolio"). Optional;
+	// surfaced in `terrain portfolio --from <manifest>` output.
+	Description string `yaml:"description,omitempty" json:"description,omitempty"`
+
+	// Repos is the list of repositories to aggregate over.
+	Repos []RepoEntry `yaml:"repos" json:"repos"`
+}
+
+// RepoEntry is one repository's declaration inside the manifest.
+//
+// The fields fall into three buckets:
+//   - Identity: name, path
+//   - Pre-computed inputs: snapshotPath (so adopters who run
+//     `terrain analyze` per-repo on their own schedule can hand the
+//     aggregator a saved snapshot rather than forcing a re-walk)
+//   - Optional metadata: owner, frameworksOfRecord, tags
+type RepoEntry struct {
+	// Name is the repo's canonical short name. Required; used as
+	// the primary key in cross-repo aggregation. Should match the
+	// directory basename for consistency but isn't required to.
+	Name string `yaml:"name" json:"name"`
+
+	// Path is the on-disk repo path relative to the manifest file.
+	// Required when SnapshotPath is empty — the aggregator walks
+	// the path to produce a fresh snapshot. When SnapshotPath is
+	// set, Path is informational (used in messaging only).
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
+
+	// SnapshotPath, when set, points at a previously-written
+	// snapshot JSON for this repo. The aggregator loads the
+	// snapshot directly and skips the walk. This is the
+	// recommended shape for large portfolios where re-walking
+	// every repo for every aggregator run is wasteful.
+	SnapshotPath string `yaml:"snapshotPath,omitempty" json:"snapshotPath,omitempty"`
+
+	// Owner is the team or individual responsible for the repo.
+	// Optional; surfaces in per-team posture aggregation.
+	Owner string `yaml:"owner,omitempty" json:"owner,omitempty"`
+
+	// FrameworksOfRecord is the canonical declaration of which
+	// frameworks this repo officially uses. When set, the
+	// aggregator's framework-drift detector compares actual
+	// framework distribution against this declaration to flag
+	// drift; when empty, drift detection skips this repo.
+	FrameworksOfRecord []string `yaml:"frameworksOfRecord,omitempty" json:"frameworksOfRecord,omitempty"`
+
+	// Tags is a free-form list of labels (e.g. ["tier-1",
+	// "customer-facing"]). Surfaces in cross-repo views and
+	// can be used as filter criteria.
+	Tags []string `yaml:"tags,omitempty" json:"tags,omitempty"`
+}
+
+// LoadRepoManifest reads `path` (typically `.terrain/repos.yaml`),
+// parses it, validates the result, and returns the manifest. Returns
+// a wrapped error with the file path on parse / validation failures so
+// `terrain portfolio --from <manifest>` users can see exactly which
+// file is bad.
+//
+// Validation rules (enforced here, not in YAML schema):
+//   - Version must be 1 (the only currently-supported version).
+//   - Repos cannot be empty.
+//   - Each RepoEntry must have a non-empty Name.
+//   - Each RepoEntry must have either Path or SnapshotPath set.
+//   - Names must be unique within a manifest.
+func LoadRepoManifest(path string) (*RepoManifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read repo manifest %q: %w", path, err)
+	}
+	return ParseRepoManifest(data, path)
+}
+
+// ParseRepoManifest is LoadRepoManifest's pure-bytes counterpart.
+// `sourceLabel` is used in error messages so callers that load from
+// non-file sources (test fixtures, embedded defaults) can still
+// produce diagnosable errors.
+func ParseRepoManifest(data []byte, sourceLabel string) (*RepoManifest, error) {
+	var m RepoManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse repo manifest %q: %w", sourceLabel, err)
+	}
+	if err := validateRepoManifest(&m); err != nil {
+		return nil, fmt.Errorf("validate repo manifest %q: %w", sourceLabel, err)
+	}
+	return &m, nil
+}
+
+// supportedManifestVersion is the current schema version. Bumping
+// this is a breaking change; only do it when the YAML shape changes
+// in a non-additive way.
+const supportedManifestVersion = 1
+
+func validateRepoManifest(m *RepoManifest) error {
+	if m == nil {
+		return errors.New("manifest is nil")
+	}
+	if m.Version == 0 {
+		return errors.New("manifest 'version' field is required (use 'version: 1' for 0.2)")
+	}
+	if m.Version != supportedManifestVersion {
+		return fmt.Errorf("unsupported manifest version %d (this build supports version %d)",
+			m.Version, supportedManifestVersion)
+	}
+	if len(m.Repos) == 0 {
+		return errors.New("manifest 'repos' is empty — declare at least one repo")
+	}
+
+	seenNames := map[string]int{}
+	for i, repo := range m.Repos {
+		idx := i + 1
+		if strings.TrimSpace(repo.Name) == "" {
+			return fmt.Errorf("repo #%d: 'name' is required", idx)
+		}
+		if dup, ok := seenNames[repo.Name]; ok {
+			return fmt.Errorf("repo #%d: duplicate name %q (already used at #%d)",
+				idx, repo.Name, dup)
+		}
+		seenNames[repo.Name] = idx
+
+		if strings.TrimSpace(repo.Path) == "" && strings.TrimSpace(repo.SnapshotPath) == "" {
+			return fmt.Errorf("repo %q: must set 'path' or 'snapshotPath'", repo.Name)
+		}
+	}
+	return nil
+}
+
+// ResolveRepoPath resolves a RepoEntry's on-disk path or snapshot
+// path against the manifest's containing directory. Used by the
+// aggregator to convert manifest-relative paths into absolute paths
+// before reading. Returns the empty string if neither is set
+// (validation would have caught this earlier).
+func ResolveRepoPath(manifestDir string, repo RepoEntry) string {
+	target := repo.Path
+	if target == "" {
+		target = repo.SnapshotPath
+	}
+	if target == "" {
+		return ""
+	}
+	if filepath.IsAbs(target) {
+		return target
+	}
+	return filepath.Clean(filepath.Join(manifestDir, target))
+}
+
+// ResolveSnapshotPath resolves a RepoEntry's snapshot path
+// specifically, returning the empty string if the entry has only
+// Path set (i.e. the aggregator should walk rather than load).
+func ResolveSnapshotPath(manifestDir string, repo RepoEntry) string {
+	if repo.SnapshotPath == "" {
+		return ""
+	}
+	if filepath.IsAbs(repo.SnapshotPath) {
+		return repo.SnapshotPath
+	}
+	return filepath.Clean(filepath.Join(manifestDir, repo.SnapshotPath))
+}

--- a/internal/portfolio/manifest_test.go
+++ b/internal/portfolio/manifest_test.go
@@ -1,0 +1,181 @@
+package portfolio
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadRepoManifest_Canonical(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "repos.yaml")
+	if err := os.WriteFile(path, []byte(`
+version: 1
+description: Acme engineering portfolio
+repos:
+  - name: web-app
+    path: ../web-app
+    owner: web-team
+    frameworksOfRecord: [jest, playwright]
+    tags: [tier-1, customer-facing]
+  - name: api-service
+    path: ../api-service
+    owner: backend-team
+    frameworksOfRecord: [pytest]
+  - name: archive-tool
+    snapshotPath: snapshots/archive-tool.json
+    owner: data-team
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := LoadRepoManifest(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if m.Version != 1 {
+		t.Errorf("Version = %d, want 1", m.Version)
+	}
+	if len(m.Repos) != 3 {
+		t.Errorf("Repos count = %d, want 3", len(m.Repos))
+	}
+	if m.Repos[0].Name != "web-app" {
+		t.Errorf("first repo name = %q, want web-app", m.Repos[0].Name)
+	}
+	if got := m.Repos[2].SnapshotPath; got != "snapshots/archive-tool.json" {
+		t.Errorf("snapshotPath = %q", got)
+	}
+}
+
+func TestLoadRepoManifest_RejectsMissingVersion(t *testing.T) {
+	t.Parallel()
+	_, err := ParseRepoManifest([]byte(`
+repos:
+  - name: x
+    path: /tmp/x
+`), "test")
+	if err == nil || !strings.Contains(err.Error(), "version") {
+		t.Errorf("expected version-required error, got: %v", err)
+	}
+}
+
+func TestLoadRepoManifest_RejectsUnsupportedVersion(t *testing.T) {
+	t.Parallel()
+	_, err := ParseRepoManifest([]byte(`
+version: 99
+repos:
+  - name: x
+    path: /tmp/x
+`), "test")
+	if err == nil || !strings.Contains(err.Error(), "unsupported manifest version") {
+		t.Errorf("expected unsupported-version error, got: %v", err)
+	}
+}
+
+func TestLoadRepoManifest_RejectsEmptyRepos(t *testing.T) {
+	t.Parallel()
+	_, err := ParseRepoManifest([]byte(`
+version: 1
+repos: []
+`), "test")
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected empty-repos error, got: %v", err)
+	}
+}
+
+func TestLoadRepoManifest_RejectsMissingName(t *testing.T) {
+	t.Parallel()
+	_, err := ParseRepoManifest([]byte(`
+version: 1
+repos:
+  - path: /tmp/x
+`), "test")
+	if err == nil || !strings.Contains(err.Error(), "'name' is required") {
+		t.Errorf("expected name-required error, got: %v", err)
+	}
+}
+
+func TestLoadRepoManifest_RejectsMissingPathAndSnapshot(t *testing.T) {
+	t.Parallel()
+	_, err := ParseRepoManifest([]byte(`
+version: 1
+repos:
+  - name: orphan
+    owner: nobody
+`), "test")
+	if err == nil || !strings.Contains(err.Error(), "must set 'path' or 'snapshotPath'") {
+		t.Errorf("expected path-or-snapshot error, got: %v", err)
+	}
+}
+
+func TestLoadRepoManifest_RejectsDuplicateName(t *testing.T) {
+	t.Parallel()
+	_, err := ParseRepoManifest([]byte(`
+version: 1
+repos:
+  - name: app
+    path: /tmp/a
+  - name: app
+    path: /tmp/b
+`), "test")
+	if err == nil || !strings.Contains(err.Error(), "duplicate name") {
+		t.Errorf("expected duplicate-name error, got: %v", err)
+	}
+}
+
+func TestResolveRepoPath_Relative(t *testing.T) {
+	t.Parallel()
+	// Build an absolute manifestDir using filepath.Join so the test
+	// passes on Windows (\) and POSIX (/) hosts. ResolveRepoPath
+	// returns paths in the host separator format via filepath.Clean
+	// / filepath.Join internally.
+	manifestDir := filepath.Join(string(filepath.Separator)+"work", ".terrain")
+	got := ResolveRepoPath(manifestDir, RepoEntry{Path: "../web-app"})
+	want := filepath.Join(string(filepath.Separator)+"work", "web-app")
+	if got != want {
+		t.Errorf("ResolveRepoPath = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRepoPath_Absolute(t *testing.T) {
+	t.Parallel()
+	abs := filepath.Join(string(filepath.Separator)+"elsewhere", "repo")
+	got := ResolveRepoPath(filepath.Join(string(filepath.Separator)+"work", ".terrain"),
+		RepoEntry{Path: abs})
+	if got != abs {
+		t.Errorf("ResolveRepoPath = %q, want absolute path %q preserved", got, abs)
+	}
+}
+
+func TestResolveRepoPath_PrefersPathOverSnapshot(t *testing.T) {
+	t.Parallel()
+	got := ResolveRepoPath(filepath.Join(string(filepath.Separator)+"work", ".terrain"),
+		RepoEntry{
+			Path:         "../code",
+			SnapshotPath: "snap.json",
+		})
+	// Compare via filepath.Base since the host separator varies.
+	if filepath.Base(got) != "code" {
+		t.Errorf("ResolveRepoPath = %q, want path preferred (basename `code`)", got)
+	}
+}
+
+func TestResolveRepoPath_FallsBackToSnapshot(t *testing.T) {
+	t.Parallel()
+	got := ResolveRepoPath("/work/.terrain", RepoEntry{
+		SnapshotPath: "snap.json",
+	})
+	if !strings.HasSuffix(got, "snap.json") {
+		t.Errorf("ResolveRepoPath = %q, want snapshot fallback", got)
+	}
+}
+
+func TestResolveSnapshotPath_Empty(t *testing.T) {
+	t.Parallel()
+	got := ResolveSnapshotPath("/work/.terrain", RepoEntry{Path: "../code"})
+	if got != "" {
+		t.Errorf("ResolveSnapshotPath without snapshotPath = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Three Track 6 deliverables that establish the Align pillar's 0.2.0
foundation. Track 6 is intentionally parallel and partial-ship-OK
(Align is the secondary pillar; floor ≥ 3 soft per the parity
plan); this PR lands the parts that lift Align without requiring
the full multi-repo aggregator. The aggregator (Tracks 6.2 / 6.3)
lands in 0.2.x once the manifest format ships here.

- **Track 6.1 — Multi-repo manifest format.** New
  `internal/portfolio/manifest.go` defines the
  `.terrain/repos.yaml` schema (version-pinned to 1) with
  per-repo path or pre-saved snapshot, optional owner,
  frameworks-of-record declaration, tags. Loader + validator +
  path resolution helpers ready for the aggregator.
- **Track 6.5 — Migration alignment-first reframe.** New
  `docs/product/alignment-first-migration.md` documents the
  framing shift: declare a framework of record per repo, see
  drift, converge gradually. Conversion is one tool inside
  convergence, not the headline.
- **Track 6.6 — Per-direction tier badges in `migrate list`.**
  `terrain migrate list` and `terrain migrate shorthands` now
  surface Tier vocabulary (Stable / Experimental / Preview /
  Cataloged) instead of raw GoNativeState strings.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/portfolio/...` — 12 new manifest tests
      (canonical + every validation rule + path resolution variants)
- [x] `go test ./cmd/terrain/...` — new tier label test + existing
      smoke tests pass
- [x] `make docs-verify` passes
- [ ] Manual smoke: `terrain migrate list` renders the new tier
      badges (separate verification — needs a built binary)

## Plan tracker

Closes Track 6.1, 6.5, 6.6. Track 6 remaining (post-0.2.0 or
0.2.x): 6.2 per-repo snapshot ingestion + 6.3 cross-repo
aggregator + 6.4 multi-repo example fixture + 6.7 conversion-
corpus calibration to A-grade. Per the plan, those are partial-
ship-OK; the manifest format ships in 0.2.0 with Tier 3 /
experimental marketing on multi-repo until 6.2/6.3 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)