### PR TITLE
feat(0.2): docs-linkcheck binary + schema field tiers (Tracks 9.8/9.12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 LDFLAGS := -s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 GO_OWNED_PKGS := ./cmd/... ./internal/...
 
-.PHONY: build test lint clean demo benchmark-fetch benchmark-smoke benchmark-full benchmark-stress benchmark-summary benchmark-convert install \
+.PHONY: build test lint clean demo benchmark-fetch benchmark-smoke benchmark-full benchmark-stress benchmark-summary benchmark-convert install docs-linkcheck \
        test-golden test-determinism test-schema test-adversarial test-e2e test-cli test-bench golden-update pr-gate release-gate \
        sbom sbom-cyclonedx sbom-spdx release-dry-run go-release-verify js-release-verify extension-verify release-verify \
        docs-gen docs-verify calibrate bench-baseline bench-gate memory-bench
@@ -161,6 +161,15 @@ pillar-parity-json:
 # Compact form: per-area + per-pillar floor map only.
 pillar-parity-floor:
 	@go run ./cmd/terrain-parity-gate --floor-map
+
+# `docs-linkcheck` walks docs/ and verifies that every intra-repo
+# markdown link resolves to a real file. Skips docs/internal/ and
+# docs/legacy/ by default — those subtrees hold planning notes whose
+# link discipline is inherited debt; run with -include-internal to
+# also scan them. External links (http/https/mailto) are out of
+# scope. Track 9.8 deliverable for the 0.2.0 parity plan.
+docs-linkcheck:
+	@go run ./cmd/terrain-docs-linkcheck
 
 # ── Calibration corpus ──────────────────────────────────────
 # Runs the engine pipeline against every fixture under tests/calibration/

--- a/cmd/terrain-docs-linkcheck/main.go
+++ b/cmd/terrain-docs-linkcheck/main.go
@@ -1,0 +1,247 @@
+// Command terrain-docs-linkcheck scans docs/ for broken intra-repo
+// markdown links. It is a Track 9.8 deliverable for the parity-gated
+// 0.2.0 release plan: docs that promise the user a path to a related
+// page should not break that promise silently.
+//
+// What it checks:
+//
+//	[text](relative/path.md)         — target file must exist
+//	[text](../other/path.md)         — same; resolved relative to source
+//	[text](relative/path.md#anchor)  — file must exist; anchor not validated
+//
+// What it skips:
+//
+//	[text](https://...)              — external; out of scope
+//	[text](http://...)               — external; out of scope
+//	[text](mailto:...)               — non-document
+//	[text](#anchor-only)             — same-page anchor; out of scope today
+//	<img src="..." />                — HTML; out of scope today
+//
+// Exit codes:
+//
+//	0 — all links resolve
+//	1 — one or more broken links (output names every offender + source)
+//	2 — invocation error (bad flags, can't read filesystem)
+//
+// Wired into the release-readiness pipeline via `make docs-linkcheck`.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// markdownLinkPattern matches `[label](target)` outside of code spans /
+// fences. Code-span / fence stripping happens before this pattern runs
+// so backtick-wrapped link literals don't false-positive.
+//
+// Tolerates nested parens inside the label (rare but valid) by using
+// a lazy match on the label and a non-greedy match on the target. The
+// target is captured between the first paren after `]` and the
+// matching close-paren — markdown disallows whitespace inside the
+// target so the "no whitespace, no inner paren" assumption holds for
+// the link shapes we actually emit in the docs tree.
+var markdownLinkPattern = regexp.MustCompile(`\[([^\]]*)\]\(([^)\s]+)\)`)
+
+// codeFencePattern matches a triple-backtick fence (open or close).
+// Used to skip everything between fences before link extraction.
+var codeFencePattern = regexp.MustCompile("^```")
+
+// inlineCodeSpanPattern matches `code` spans within a line. Stripped
+// before link extraction so that something like `[a](b)` inside a
+// code span is not flagged.
+var inlineCodeSpanPattern = regexp.MustCompile("`[^`]+`")
+
+type brokenLink struct {
+	source string
+	line   int
+	target string
+	reason string
+}
+
+// defaultSkipPrefixes is the set of doc subtrees the linkchecker
+// ignores by default. These contain planning notes, internal-eng
+// scratch, and legacy material whose link discipline is not part of
+// the user-facing 0.2.0 contract. Override with -include-internal
+// to scan them too — useful before doing the cleanup pass that
+// retires the inherited debt in those directories.
+var defaultSkipPrefixes = []string{
+	"docs/internal/",
+	"docs/legacy/",
+}
+
+func main() {
+	root := flag.String("root", "docs", "directory to scan")
+	includeInternal := flag.Bool("include-internal", false,
+		"also check docs/internal/ and docs/legacy/ (otherwise skipped — they hold planning notes whose links are inherited debt)")
+	flag.Parse()
+
+	if _, err := os.Stat(*root); err != nil {
+		fmt.Fprintf(os.Stderr, "linkcheck: cannot read root %q: %v\n", *root, err)
+		os.Exit(2)
+	}
+
+	skipPrefixes := defaultSkipPrefixes
+	if *includeInternal {
+		skipPrefixes = nil
+	}
+
+	broken, err := scan(*root, skipPrefixes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "linkcheck: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(broken) == 0 {
+		fmt.Printf("linkcheck: scanned %s, all intra-repo links resolve.\n", *root)
+		return
+	}
+
+	sort.SliceStable(broken, func(i, j int) bool {
+		if broken[i].source != broken[j].source {
+			return broken[i].source < broken[j].source
+		}
+		return broken[i].line < broken[j].line
+	})
+
+	fmt.Fprintf(os.Stderr, "::error::%d broken intra-repo link(s) under %s:\n", len(broken), *root)
+	for _, b := range broken {
+		fmt.Fprintf(os.Stderr, "  %s:%d  →  %s    (%s)\n",
+			b.source, b.line, b.target, b.reason)
+	}
+	os.Exit(1)
+}
+
+func scan(root string, skipPrefixes []string) ([]brokenLink, error) {
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(strings.ToLower(d.Name()), ".md") {
+			return nil
+		}
+		for _, p := range skipPrefixes {
+			if strings.HasPrefix(path, p) {
+				return nil
+			}
+		}
+		files = append(files, path)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	var broken []brokenLink
+	for _, f := range files {
+		hits, err := checkFile(f)
+		if err != nil {
+			return nil, fmt.Errorf("scan %s: %w", f, err)
+		}
+		broken = append(broken, hits...)
+	}
+	return broken, nil
+}
+
+func checkFile(path string) ([]brokenLink, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var broken []brokenLink
+
+	// Walk lines so we can produce per-line diagnostics, and so the
+	// fence-tracker can toggle in/out of code blocks. Splitting on
+	// "\n" rather than using bufio.Scanner because we want to keep
+	// trailing-newline behavior simple for a small docs corpus.
+	lines := strings.Split(string(data), "\n")
+	inFence := false
+	for i, line := range lines {
+		if codeFencePattern.MatchString(strings.TrimSpace(line)) {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+
+		// Strip inline code spans before link extraction.
+		stripped := inlineCodeSpanPattern.ReplaceAllString(line, "")
+
+		matches := markdownLinkPattern.FindAllStringSubmatch(stripped, -1)
+		for _, m := range matches {
+			target := m[2]
+			if shouldSkip(target) {
+				continue
+			}
+			if reason := resolveTarget(path, target); reason != "" {
+				broken = append(broken, brokenLink{
+					source: path,
+					line:   i + 1,
+					target: target,
+					reason: reason,
+				})
+			}
+		}
+	}
+	return broken, nil
+}
+
+func shouldSkip(target string) bool {
+	switch {
+	case strings.HasPrefix(target, "http://"),
+		strings.HasPrefix(target, "https://"),
+		strings.HasPrefix(target, "mailto:"),
+		strings.HasPrefix(target, "tel:"):
+		return true
+	case strings.HasPrefix(target, "#"):
+		// Same-page anchors. Verifying these would require parsing
+		// every heading + slugifying — out of scope today.
+		return true
+	}
+	return false
+}
+
+func resolveTarget(source, target string) string {
+	// Strip anchor and query if present — we only verify the file.
+	clean := target
+	if i := strings.IndexAny(clean, "#?"); i >= 0 {
+		clean = clean[:i]
+	}
+	if clean == "" {
+		// Pure anchor link — already handled by shouldSkip, but
+		// guard against `?` only.
+		return ""
+	}
+
+	// Resolve relative to the source file's directory.
+	resolved := filepath.Join(filepath.Dir(source), clean)
+	resolved = filepath.Clean(resolved)
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "no such file"
+		}
+		return fmt.Sprintf("stat error: %v", err)
+	}
+	if info.IsDir() {
+		// Some docs link to a directory expecting an implicit
+		// README. Accept if README.md exists.
+		if _, err := os.Stat(filepath.Join(resolved, "README.md")); err == nil {
+			return ""
+		}
+		return "directory link with no README.md"
+	}
+	return ""
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@
 - **The current engine** is signal-led: a test intelligence platform that surfaces risk, quality, migration readiness, and governance from static and runtime analysis.
 - **Migration remains the acquisition wedge** — the pain of framework migration is what brings teams to Terrain. The current engine turns that pain into broader test intelligence.
 
-The legacy converter docs are kept as historical records from the retired JavaScript runtime. The supported product runtime is now Go-native; see [legacy/](legacy/) only for background and migration history.
+The legacy converter docs are kept as historical records from the retired JavaScript runtime. The supported product runtime is now Go-native; see the [Legacy Notes](legacy/legacy-notes.md) only for background and migration history.
 
 ## Start Here
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -234,5 +234,5 @@ All commands support `--json` for machine-readable output and `--root PATH` to t
 
 - [CLI Reference](cli-spec.md) -- all commands and flags
 - [Signal Catalog](signal-catalog.md) -- the signal types Terrain detects
-- [Example Reports](examples/) -- sample output for each command
+- [Example Reports](examples/analyze-report.md) -- sample output for each command
 - [Contributing](contributing/adding-a-measurement.md) -- how to extend Terrain

--- a/docs/release/release-notes.md
+++ b/docs/release/release-notes.md
@@ -13,5 +13,6 @@ For release-specific design docs, see:
 - **Feature status (current release)** — [`docs/release/feature-status.md`](feature-status.md)
 
 The historical 0.1.0 ground-up-rewrite framing that lived in this file
-has been retired; the architectural narrative is consolidated under
-[`docs/architecture/`](../architecture/).
+has been retired; the architectural narrative is consolidated in
+[`docs/architecture/00-overview.md`](../architecture/00-overview.md)
+and the per-topic chapters alongside it.

--- a/docs/schema/FIELD_TIERS.md
+++ b/docs/schema/FIELD_TIERS.md
@@ -1,0 +1,130 @@
+# Schema field tiers
+
+Every field in Terrain's JSON output sits in one of three stability
+tiers. The tier tells adopters whether they can build long-lived
+tooling against the field, accept temporary brittleness, or treat
+the field as Terrain's internal scratch space.
+
+This is the Track 9.12 deliverable for the 0.2.0 release plan. The
+parity-plan rationale: adopters integrating Terrain into CI / IDE /
+dashboard tooling need to know which fields are safe to depend on
+and which can churn between minor releases.
+
+## The three tiers
+
+### Stable
+
+**Contract:** the field name, JSON type, and semantics will not
+change without a major schema version bump. Adopters can build
+long-lived tooling against stable fields with confidence.
+
+**Examples:**
+
+- `snapshotMeta.schemaVersion`
+- `repository.rootPath`, `repository.language`
+- `frameworks[].name`, `frameworks[].type`, `frameworks[].fileCount`
+- `testFiles[].path`, `testFiles[].framework`,
+  `testFiles[].testCount`, `testFiles[].assertionCount`
+- `codeUnits[].name`, `codeUnits[].path`, `codeUnits[].kind`,
+  `codeUnits[].exported`, `codeUnits[].unitID`
+- `signals[].type`, `signals[].severity`, `signals[].path`
+- `findingId` on every signal (Track 4.4)
+- `aggregates.successRate` on EvalRunResult
+
+Stable fields are claimed publicly. Removing one is a major-version
+breaking change with deprecation lead time.
+
+### Beta
+
+**Contract:** the field name and type are unlikely to change in
+the next minor release, but the *semantics* (what value Terrain
+puts into the field, when, with what precision) may evolve as
+calibration corpora arrive.
+
+**Examples:**
+
+- `signals[].confidence` — will be calibrated against the 0.3
+  precision corpus; today's confidence values are detector self-
+  reports, not measured against ground truth
+- `signals[].evidence[]` — the field shape is stable; the set
+  of evidence sources cited may grow per detector
+- `aiSubdomain` (Track 5.1) — vocabulary is stable for 0.2; new
+  AI signal types may add entries
+- `testTypeConfidence`, `testTypeEvidence` — same shape; rule
+  set may expand
+- `metadata.compatibilityNotes` — populated by the snapshot
+  migrator; messages may be reworded
+
+Beta fields are safe to read. Building features that branch on a
+specific *value* (e.g. "show this UI when confidence > 0.85")
+should track changes between Terrain releases.
+
+### Internal
+
+**Contract:** the field exists for Terrain's own diagnostics or
+debugging and may be renamed, restructured, or removed without
+notice. Treat as Terrain's scratch space.
+
+**Examples:**
+
+- `metadata.diagnostics.*` (when emitted by `--collect-diagnostics`)
+- Per-detector implementation hints embedded in
+  `signals[].evidence[]` strings (the user-facing line is beta;
+  detector-internal sub-strings are not)
+- Anything under `internalDebug.*` (when emitted)
+- `_internal*` prefixed fields anywhere
+
+Internal fields are visible in JSON output for debuggability but
+are explicitly outside the schema contract.
+
+## How to tell a field's tier
+
+In order of precedence:
+
+1. **Field name pattern.** Anything prefixed `_internal`, named
+   `internalDebug`, or under a `metadata.diagnostics.*` path is
+   internal. Anything under `metadata.compatibilityNotes` is beta.
+2. **JSON Schema annotation.** Where the schema is hand-curated
+   (`docs/schema/analysis.schema.json` and
+   `docs/schema/conversion.schema.json`), look for the
+   `x-terrain-tier` extension keyword on the property. Values:
+   `stable` / `beta` / `internal`. Absence defaults to *beta*
+   for any field shipped post-0.2.
+3. **This page.** When in doubt, the explicit examples above are
+   authoritative. Fields not listed default to beta.
+
+## Promotion path
+
+Fields move from internal → beta → stable as evidence accumulates
+that the contract is sustainable.
+
+| From → To | Trigger |
+|-----------|---------|
+| internal → beta | Field is read by at least one external integration; Terrain commits to a name + type for the next minor |
+| beta → stable | Calibration evidence + adopter usage demonstrate the semantic contract is durable; field is named in the schema's `required` block when applicable |
+| stable → demoted | Never within a major version. A stable field that's wrong stays through the major and changes at the next major bump. |
+
+## What this means for `terrain analyze --json`
+
+A typical adopter integrating against Terrain JSON should:
+
+1. **Pin a `snapshotMeta.schemaVersion` they tested against** —
+   not because Terrain breaks compatibility freely, but because
+   beta-tier semantic shifts are the most common change shape.
+2. **Defensively read beta fields with a fallback** — e.g.
+   "if `signals[i].confidence` is below 0.7 OR absent, treat as
+   low-confidence."
+3. **Never branch on internal fields** — anything not listed
+   above as stable or beta. Internal field reads should be
+   limited to debugging.
+
+## Related reading
+
+- [`docs/schema/COMPAT.md`](COMPAT.md) — schema versioning policy
+- [`docs/schema/analysis.schema.json`](analysis.schema.json) —
+  current analyze JSON schema
+- [`docs/schema/conversion.schema.json`](conversion.schema.json) —
+  current convert JSON schema
+- [`docs/release/feature-status.md`](../release/feature-status.md) —
+  per-capability tier matrix (different "tier" axis — capability
+  publicly-claimable status)

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -9,6 +9,13 @@ This directory contains JSON Schema definitions for Terrain's machine-readable o
 | `analysis.schema.json` | `terrain analyze --json` | Framework detection and project scan results |
 | `conversion.schema.json` | `terrain convert --report-json <file>` | Structured conversion run report |
 
+## Field stability tiers
+
+Every field falls in one of three tiers — Stable, Beta, or Internal —
+indicating whether adopters can build long-lived tooling against it.
+See [`FIELD_TIERS.md`](FIELD_TIERS.md) for the full contract per
+tier and examples of each.
+
 ## Versioning
 
 Each schema includes a `schemaVersion` field (e.g., `"1.0.0"`).


### PR DESCRIPTION
## Summary

Two release-readiness deliverables that lift the contract Terrain
makes with adopters:

- **Track 9.8 — Make docs-linkcheck.** New
  `cmd/terrain-docs-linkcheck` binary + `make docs-linkcheck`
  Makefile target. Walks docs/ and verifies every intra-repo
  markdown link resolves. Caught + fixed 3 broken links in the
  public docs surface.
- **Track 9.12 — Schema field stability tiers.** New
  `docs/schema/FIELD_TIERS.md` defines Stable / Beta / Internal
  tiers per JSON field, with concrete examples and a promotion
  path. Linked from `docs/schema/README.md`.

## What changed

**New code:**
- `cmd/terrain-docs-linkcheck/main.go` — link checker (~210 lines,
  zero deps)

**New docs:**
- `docs/schema/FIELD_TIERS.md` — three-tier contract per JSON field

**Edited:**
- `Makefile` — `docs-linkcheck` target wired
- `docs/README.md` — fixed legacy/ → legacy/legacy-notes.md
- `docs/quickstart.md` — fixed examples/ → examples/analyze-report.md
- `docs/release/release-notes.md` — fixed ../architecture/ → 00-overview.md
- `docs/schema/README.md` — added pointer to FIELD_TIERS.md

## Why these together

Both close release-readiness gaps the parity plan flagged: 9.8
gives CI a way to catch link rot before adopters do; 9.12 gives
adopters a clear contract for what they can build long-lived
tooling against. Both are docs/infra additions with no behavior
change.

## Test plan

- [x] `go build ./...` clean
- [x] `make docs-linkcheck` passes — all public-surface links
      resolve
- [x] `make docs-verify` clean — manifest unchanged
- [x] `go test ./...` clean — no test impact

## What's NOT covered (intentional)

- **Anchor verification** (`#section-name`) — out of scope today;
  would need slug-aware heading parsing per markdown flavor
- **External link reachability** (http/https) — out of scope;
  adds CI-time network dependency for diminishing returns
- **docs/internal/ + docs/legacy/ link cleanup** — 39 inherited
  broken links there are skipped by default; cleanup is its own
  PR. Run `make docs-linkcheck` with `-include-internal` (via
  the binary directly) to see them.

## Plan tracker

Closes Track 9.8 + 9.12 from the parity plan. Track 9 remaining:
9.1-9.6 + 9.7 (truth-verify) + 9.10 (memory bench). All
explicitly post-0.2.0-blocking but safe to land in either window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)