### PR TITLE
feat(0.2): detector capability metadata + missing-input diagnostics (Tracks 9.1/9.3)

### DIFF
--- a/docs/rules/engine/detector-missing-input.md
+++ b/docs/rules/engine/detector-missing-input.md
@@ -1,0 +1,26 @@
+# TER-ENGINE-003 — Detector Missing Input
+
+> Auto-generated stub. Edit anything below the marker; the generator preserves it.
+
+**Type:** `detectorMissingInput`  
+**Domain:** quality  
+**Default severity:** low  
+**Status:** stable
+
+## Summary
+
+A registered detector requires inputs (runtime artifacts, baseline snapshot, or eval-framework results) that the current snapshot doesn't carry. The detector was skipped; the rest of the pipeline ran normally.
+
+## Remediation
+
+The marker explanation lists the specific flag(s) to pass to `terrain analyze` to provide the missing inputs. If you don't need this detector's signals, leave the inputs absent — the marker is informational.
+
+## Evidence sources
+
+- `static`
+
+## Confidence range
+
+Detector confidence is bracketed at [1.00, 1.00] (heuristic in 0.2; calibration in 0.3).
+
+<!-- docs-gen: end stub. Hand-authored content below this line is preserved across regenerations. -->

--- a/docs/signals/manifest.json
+++ b/docs/signals/manifest.json
@@ -1215,6 +1215,23 @@
       ],
       "ruleId": "TER-ENGINE-002",
       "ruleUri": "docs/rules/engine/detector-budget.md"
+    },
+    {
+      "type": "detectorMissingInput",
+      "constName": "SignalDetectorMissingInput",
+      "domain": "quality",
+      "status": "stable",
+      "title": "Detector Missing Input",
+      "description": "A registered detector requires inputs (runtime artifacts, baseline snapshot, or eval-framework results) that the current snapshot doesn't carry. The detector was skipped; the rest of the pipeline ran normally.",
+      "remediation": "The marker explanation lists the specific flag(s) to pass to `terrain analyze` to provide the missing inputs. If you don't need this detector's signals, leave the inputs absent — the marker is informational.",
+      "defaultSeverity": "low",
+      "confidenceMin": 1,
+      "confidenceMax": 1,
+      "evidenceSources": [
+        "static"
+      ],
+      "ruleId": "TER-ENGINE-003",
+      "ruleUri": "docs/rules/engine/detector-missing-input.md"
     }
   ]
 }

--- a/internal/models/signal_catalog.go
+++ b/internal/models/signal_catalog.go
@@ -117,6 +117,12 @@ var SignalCatalog = map[SignalType]SignalCatalogEntry{
 	// snapshot whenever a detector hit its budget, defeating the
 	// timeout enforcement shipped in 0.2 (Track 9.4).
 	"detectorBudgetExceeded": {Source: SignalSourceStatic},
+	// detectorMissingInput is emitted by safeDetectChecked when a
+	// detector's RequiresRuntime / RequiresBaseline /
+	// RequiresEvalArtifact metadata is set but the snapshot lacks
+	// the corresponding input. Track 9.3 — surfaces input gaps as
+	// a single per-detector marker instead of silent zero-output.
+	"detectorMissingInput": {Source: SignalSourceStatic},
 }
 
 // KnownSignalTypes is the canonical signal vocabulary accepted by snapshot

--- a/internal/signals/detector_registry.go
+++ b/internal/signals/detector_registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -62,10 +63,7 @@ func safeDetect(reg DetectorRegistration, fn func() []models.Signal) (out []mode
 
 // safeDetectWithBudget wraps safeDetect with a per-detector wall-
 // clock timeout. Track 9.4 — the budget protects the pipeline from
-// any single hung detector blocking the rest. The detector still
-// runs in the calling goroutine (no extra goroutine cost on the
-// happy path); when it exceeds its budget we emit a budget-exceeded
-// marker and return.
+// any single hung detector blocking the rest.
 //
 // Note: a detector that ignores ctx and runs a tight CPU loop will
 // still complete its work after the budget elapses (Go has no
@@ -103,6 +101,97 @@ func safeDetectWithBudget(reg DetectorRegistration, fn func() []models.Signal) [
 				reg.Meta.ID, budget),
 			SuggestedAction: "If this detector is legitimately slow on your repo, raise its budget in DetectorMeta.Budget. If it should be fast, the runaway suggests a quadratic-or-worse code path or a hung I/O — re-run with --log-level=debug.",
 		}}
+	}
+}
+
+// signalTypeMissingInputDiagnostic is the marker emitted by the
+// registry when a detector's RequiresRuntime / RequiresBaseline /
+// RequiresEvalArtifact flag is set but the snapshot doesn't carry
+// the corresponding input. Track 9.3 — adopters running `terrain
+// analyze` without coverage / baseline / eval artifacts get a
+// single visible diagnostic per affected detector instead of
+// silent zero-output.
+const signalTypeMissingInputDiagnostic = SignalDetectorMissingInput
+
+// missingInputs returns a list of human-readable input-name strings
+// that the detector's metadata says it needs but the snapshot
+// doesn't provide. Empty list means the detector can run; non-empty
+// means the registry should emit a missingInputDiagnostic and skip
+// invocation. Each input name corresponds to a CLI flag the user
+// would set to provide the input.
+func missingInputs(meta DetectorMeta, snap *models.TestSuiteSnapshot) []string {
+	if snap == nil {
+		return nil
+	}
+	var missing []string
+	if meta.RequiresRuntime && !snapshotHasRuntime(snap) {
+		missing = append(missing, "runtime artifacts (--runtime path/to/junit.xml or jest.json)")
+	}
+	if meta.RequiresBaseline && snap.Baseline == nil {
+		missing = append(missing, "baseline snapshot (--baseline path/to/old-snapshot.json)")
+	}
+	if meta.RequiresEvalArtifact && len(snap.EvalRuns) == 0 {
+		missing = append(missing, "eval-framework artifact (--promptfoo-results / --deepeval-results / --ragas-results)")
+	}
+	return missing
+}
+
+// snapshotHasRuntime reports whether the snapshot carries any
+// runtime test result data. We look at the test-file inventory
+// rather than walking every signal — the runtime stats live on the
+// TestFile, not on signals.
+func snapshotHasRuntime(snap *models.TestSuiteSnapshot) bool {
+	for i := range snap.TestFiles {
+		if snap.TestFiles[i].RuntimeStats != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// missingInputDiagnostic builds the marker signal emitted when one
+// or more required inputs are absent. The explanation lists every
+// missing input so adopters can fix them all in one re-run rather
+// than playing whack-a-mole.
+func missingInputDiagnostic(meta DetectorMeta, missing []string) models.Signal {
+	return models.Signal{
+		Type:       signalTypeMissingInputDiagnostic,
+		Category:   models.CategoryQuality,
+		Severity:   models.SeverityLow,
+		Confidence: 1.0,
+		Explanation: fmt.Sprintf(
+			"detector %q requires inputs the current snapshot doesn't carry: %s",
+			meta.ID, joinInputNames(missing)),
+		SuggestedAction: "Re-run `terrain analyze` with the listed flags to enable this detector. If you don't need its signals, leave the inputs absent — this diagnostic surfaces the gap without blocking the rest of the pipeline.",
+	}
+}
+
+// safeDetectChecked is the registry's canonical detector-invocation
+// path. It composes Track 9.3 (missing-input check) with Track 9.4
+// (per-detector budget) over Track 9.2's panic recovery: input
+// gates first (skip detectors that can't fire), then budget-bounded
+// invocation that delegates to safeDetect for panic handling.
+// All call sites in Run / RunWithGraph route through here.
+func safeDetectChecked(reg DetectorRegistration, snap *models.TestSuiteSnapshot, fn func() []models.Signal) []models.Signal {
+	if missing := missingInputs(reg.Meta, snap); len(missing) > 0 {
+		return []models.Signal{missingInputDiagnostic(reg.Meta, missing)}
+	}
+	return safeDetectWithBudget(reg, fn)
+}
+
+func joinInputNames(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	default:
+		// Oxford comma, plain English: "a, b, c, and d".
+		// Join all but the last with ", " then append ", and <last>".
+		head := names[:len(names)-1]
+		return strings.Join(head, ", ") + ", and " + names[len(names)-1]
 	}
 }
 
@@ -181,6 +270,57 @@ type DetectorMeta struct {
 	// it; setting a tighter budget on simple structural detectors
 	// catches accidental quadratic-or-worse code paths.
 	Budget time.Duration
+
+	// --- Track 9.1 capability metadata ---
+	//
+	// The fields below describe what a detector consumes beyond the
+	// in-memory snapshot. They're descriptive (so docs / `terrain
+	// doctor` can surface "this detector needs runtime data") AND
+	// load-bearing (Track 9.3 — when a required input is missing
+	// the registry emits a single per-detector missingInputDiagnostic
+	// instead of silently running a detector that can't fire).
+	//
+	// All zero values mean "don't require this input", which keeps
+	// the existing detector roster behaving exactly as before. New
+	// detectors that genuinely need runtime / baseline / eval data
+	// should set the relevant flag so the diagnostic surfaces when
+	// inputs are absent.
+
+	// RequiresRuntime indicates the detector reads RuntimeStats from
+	// the snapshot (populated by JUnit XML / Jest JSON / Go test
+	// JSON ingestion). Without runtime artifacts the snapshot's
+	// runtime fields are empty and the detector cannot fire.
+	RequiresRuntime bool
+
+	// RequiresBaseline indicates the detector compares the current
+	// snapshot against a baseline snapshot (passed via
+	// `terrain analyze --baseline`). Without it, the regression
+	// detectors (aiCostRegression, aiHallucinationRate,
+	// aiRetrievalRegression) have no point of comparison.
+	RequiresBaseline bool
+
+	// RequiresEvalArtifact indicates the detector reads EvalRuns
+	// from the snapshot (populated by Promptfoo / DeepEval / Ragas
+	// adapter ingestion). Without an artifact path passed via the
+	// `--{promptfoo,deepeval,ragas}-results` flags, the snapshot's
+	// EvalRuns is empty and these detectors can't fire.
+	RequiresEvalArtifact bool
+
+	// ContextAware reports whether the detector honors ctx.Err() in
+	// its inner loops. Detectors that don't are still safe — they
+	// run inside safeDetectWithBudget and get abandoned at the
+	// budget cap — but ctx-aware detectors can react faster to
+	// pipeline cancellation. Surfaced in `terrain doctor` so
+	// reviewers can see the cancellation posture per-detector.
+	ContextAware bool
+
+	// Experimental marks the detector as not-yet-stable. Distinct
+	// from the manifest's Status field on individual signals: a
+	// stable signal type can still have an experimental detector
+	// (the type is locked, the detector implementation is not).
+	// Experimental detectors are excluded from the recommended
+	// `--fail-on critical` gate per the trust-tier framing.
+	Experimental bool
 }
 
 // DetectorRegistration pairs a Detector with its metadata.
@@ -277,7 +417,7 @@ func (r *DetectorRegistry) Run(snap *models.TestSuiteSnapshot) {
 		wg.Add(1)
 		go func(idx int, reg DetectorRegistration) {
 			defer wg.Done()
-			found := safeDetectWithBudget(reg, func() []models.Signal { return reg.Detector.Detect(snap) })
+			found := safeDetectChecked(reg, snap, func() []models.Signal { return reg.Detector.Detect(snap) })
 			mu.Lock()
 			results = append(results, result{idx: idx, signals: found})
 			mu.Unlock()
@@ -294,7 +434,7 @@ func (r *DetectorRegistry) Run(snap *models.TestSuiteSnapshot) {
 
 	// Dependent detectors run after independent outputs are available.
 	for _, reg := range dependents {
-		found := safeDetectWithBudget(reg, func() []models.Signal { return reg.Detector.Detect(snap) })
+		found := safeDetectChecked(reg, snap, func() []models.Signal { return reg.Detector.Detect(snap) })
 		snap.Signals = append(snap.Signals, found...)
 	}
 }
@@ -338,7 +478,7 @@ func (r *DetectorRegistry) RunWithGraph(snap *models.TestSuiteSnapshot, g *depgr
 		wg.Add(1)
 		go func(idx int, reg DetectorRegistration) {
 			defer wg.Done()
-			found := safeDetectWithBudget(reg, func() []models.Signal { return reg.Detector.Detect(snap) })
+			found := safeDetectChecked(reg, snap, func() []models.Signal { return reg.Detector.Detect(snap) })
 			mu.Lock()
 			results = append(results, result{idx: idx, signals: found})
 			mu.Unlock()
@@ -381,7 +521,7 @@ func (r *DetectorRegistry) RunWithGraph(snap *models.TestSuiteSnapshot, g *depgr
 			wg2.Add(1)
 			go func(idx int, reg DetectorRegistration, gd GraphDetector) {
 				defer wg2.Done()
-				found := safeDetectWithBudget(reg, func() []models.Signal { return gd.DetectWithGraph(snap, g) })
+				found := safeDetectChecked(reg, snap, func() []models.Signal { return gd.DetectWithGraph(snap, g) })
 				mu.Lock()
 				graphResults = append(graphResults, result{idx: idx, signals: found})
 				mu.Unlock()
@@ -399,7 +539,7 @@ func (r *DetectorRegistry) RunWithGraph(snap *models.TestSuiteSnapshot, g *depgr
 
 	// Phase 3: Signal-dependent detectors (sequential).
 	for _, reg := range dependents {
-		found := safeDetectWithBudget(reg, func() []models.Signal { return reg.Detector.Detect(snap) })
+		found := safeDetectChecked(reg, snap, func() []models.Signal { return reg.Detector.Detect(snap) })
 		snap.Signals = append(snap.Signals, found...)
 	}
 }
@@ -408,7 +548,7 @@ func (r *DetectorRegistry) RunWithGraph(snap *models.TestSuiteSnapshot, g *depgr
 func (r *DetectorRegistry) RunDomain(snap *models.TestSuiteSnapshot, domain Domain) {
 	for _, reg := range r.registrations {
 		if reg.Meta.Domain == domain {
-			found := safeDetectWithBudget(reg, func() []models.Signal { return reg.Detector.Detect(snap) })
+			found := safeDetectChecked(reg, snap, func() []models.Signal { return reg.Detector.Detect(snap) })
 			snap.Signals = append(snap.Signals, found...)
 		}
 	}

--- a/internal/signals/manifest.go
+++ b/internal/signals/manifest.go
@@ -948,6 +948,22 @@ var allSignalManifest = []ManifestEntry{
 		EvidenceSources: []string{"static"},
 		RuleID:          "TER-ENGINE-002", RuleURI: "docs/rules/engine/detector-budget.md",
 	},
+	// Track 9.3: emitted by safeDetectChecked when a detector's
+	// declared input requirements (RequiresRuntime / RequiresBaseline
+	// / RequiresEvalArtifact) aren't satisfied by the current
+	// snapshot. Surfaces the gap so adopters know which flag to add
+	// rather than seeing silent zero-output from the affected detector.
+	{
+		Type: SignalDetectorMissingInput, ConstName: "SignalDetectorMissingInput",
+		Domain: models.CategoryQuality, Status: StatusStable,
+		Title:           "Detector Missing Input",
+		Description:     "A registered detector requires inputs (runtime artifacts, baseline snapshot, or eval-framework results) that the current snapshot doesn't carry. The detector was skipped; the rest of the pipeline ran normally.",
+		Remediation:     "The marker explanation lists the specific flag(s) to pass to `terrain analyze` to provide the missing inputs. If you don't need this detector's signals, leave the inputs absent — the marker is informational.",
+		DefaultSeverity: models.SeverityLow,
+		ConfidenceMin:   1.0, ConfidenceMax: 1.0,
+		EvidenceSources: []string{"static"},
+		RuleID:          "TER-ENGINE-003", RuleURI: "docs/rules/engine/detector-missing-input.md",
+	},
 }
 
 // Manifest returns a snapshot copy of the canonical signal manifest, sorted

--- a/internal/signals/missing_input_test.go
+++ b/internal/signals/missing_input_test.go
@@ -1,0 +1,209 @@
+package signals
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/models"
+)
+
+// noopDetector returns one signal so we can distinguish "ran" from
+// "missing-input diagnostic emitted" in test output.
+type noopDetector struct{}
+
+func (noopDetector) Detect(_ *models.TestSuiteSnapshot) []models.Signal {
+	return []models.Signal{{
+		Type:        models.SignalType("test.ran"),
+		Category:    models.CategoryQuality,
+		Severity:    models.SeverityLow,
+		Confidence:  1.0,
+		Explanation: "noop detector executed",
+	}}
+}
+
+// TestSafeDetectChecked_RunsWhenInputsPresent verifies the happy
+// path: a detector whose inputs are satisfied runs normally and
+// returns its own signals (no missing-input diagnostic).
+func TestSafeDetectChecked_RunsWhenInputsPresent(t *testing.T) {
+	t.Parallel()
+	reg := DetectorRegistration{
+		Meta: DetectorMeta{
+			ID:              "test.no-required-inputs",
+			Domain:          DomainQuality,
+		},
+		Detector: noopDetector{},
+	}
+	snap := &models.TestSuiteSnapshot{}
+
+	got := safeDetectChecked(reg, snap, func() []models.Signal {
+		return reg.Detector.Detect(snap)
+	})
+	if len(got) != 1 || got[0].Type != "test.ran" {
+		t.Errorf("expected detector to run; got: %+v", got)
+	}
+}
+
+// TestSafeDetectChecked_MissingRuntime emits the diagnostic when
+// RequiresRuntime is set but the snapshot has no runtime stats.
+func TestSafeDetectChecked_MissingRuntime(t *testing.T) {
+	t.Parallel()
+	reg := DetectorRegistration{
+		Meta: DetectorMeta{
+			ID:              "test.needs-runtime",
+			Domain:          DomainHealth,
+			RequiresRuntime: true,
+		},
+		Detector: noopDetector{},
+	}
+	snap := &models.TestSuiteSnapshot{
+		// Test files present but no RuntimeStats on any of them.
+		TestFiles: []models.TestFile{{Path: "a.test.ts"}},
+	}
+
+	got := safeDetectChecked(reg, snap, func() []models.Signal {
+		return reg.Detector.Detect(snap)
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(got))
+	}
+	if got[0].Type != signalTypeMissingInputDiagnostic {
+		t.Errorf("Type = %q, want detectorMissingInput", got[0].Type)
+	}
+	if !strings.Contains(got[0].Explanation, "test.needs-runtime") {
+		t.Errorf("explanation should name the detector: %q", got[0].Explanation)
+	}
+	if !strings.Contains(got[0].Explanation, "--runtime") {
+		t.Errorf("explanation should name the missing flag: %q", got[0].Explanation)
+	}
+}
+
+// TestSafeDetectChecked_RuntimePresent runs the detector when at
+// least one test file has runtime stats — meeting the
+// RequiresRuntime contract.
+func TestSafeDetectChecked_RuntimePresent(t *testing.T) {
+	t.Parallel()
+	reg := DetectorRegistration{
+		Meta: DetectorMeta{
+			ID:              "test.needs-runtime",
+			Domain:          DomainHealth,
+			RequiresRuntime: true,
+		},
+		Detector: noopDetector{},
+	}
+	snap := &models.TestSuiteSnapshot{
+		TestFiles: []models.TestFile{
+			{Path: "a.test.ts", RuntimeStats: &models.RuntimeStats{PassRate: 1.0}},
+		},
+	}
+
+	got := safeDetectChecked(reg, snap, func() []models.Signal {
+		return reg.Detector.Detect(snap)
+	})
+	if len(got) != 1 || got[0].Type != "test.ran" {
+		t.Errorf("expected detector to run with runtime present; got: %+v", got)
+	}
+}
+
+// TestSafeDetectChecked_MissingBaseline emits the diagnostic when
+// RequiresBaseline is set but Baseline is nil.
+func TestSafeDetectChecked_MissingBaseline(t *testing.T) {
+	t.Parallel()
+	reg := DetectorRegistration{
+		Meta: DetectorMeta{
+			ID:               "test.needs-baseline",
+			Domain:           DomainAI,
+			RequiresBaseline: true,
+		},
+		Detector: noopDetector{},
+	}
+	snap := &models.TestSuiteSnapshot{} // Baseline nil
+
+	got := safeDetectChecked(reg, snap, func() []models.Signal {
+		return reg.Detector.Detect(snap)
+	})
+	if len(got) != 1 || got[0].Type != signalTypeMissingInputDiagnostic {
+		t.Errorf("expected missing-input diagnostic, got: %+v", got)
+	}
+	if !strings.Contains(got[0].Explanation, "--baseline") {
+		t.Errorf("explanation should name --baseline: %q", got[0].Explanation)
+	}
+}
+
+// TestSafeDetectChecked_MissingEvalArtifact emits the diagnostic when
+// RequiresEvalArtifact is set but EvalRuns is empty.
+func TestSafeDetectChecked_MissingEvalArtifact(t *testing.T) {
+	t.Parallel()
+	reg := DetectorRegistration{
+		Meta: DetectorMeta{
+			ID:                   "test.needs-eval",
+			Domain:               DomainAI,
+			RequiresEvalArtifact: true,
+		},
+		Detector: noopDetector{},
+	}
+	snap := &models.TestSuiteSnapshot{} // EvalRuns nil
+
+	got := safeDetectChecked(reg, snap, func() []models.Signal {
+		return reg.Detector.Detect(snap)
+	})
+	if len(got) != 1 || got[0].Type != signalTypeMissingInputDiagnostic {
+		t.Errorf("expected missing-input diagnostic, got: %+v", got)
+	}
+	if !strings.Contains(got[0].Explanation, "promptfoo-results") {
+		t.Errorf("explanation should mention promptfoo-results / deepeval-results / ragas-results: %q",
+			got[0].Explanation)
+	}
+}
+
+// TestSafeDetectChecked_MultipleMissingInputs emits one diagnostic
+// listing all missing inputs (Oxford-comma joined). Adopters who
+// run analyze without runtime AND baseline AND eval data should see
+// one diagnostic per affected detector citing all three needs.
+func TestSafeDetectChecked_MultipleMissingInputs(t *testing.T) {
+	t.Parallel()
+	reg := DetectorRegistration{
+		Meta: DetectorMeta{
+			ID:                   "test.needs-everything",
+			Domain:               DomainAI,
+			RequiresRuntime:      true,
+			RequiresBaseline:     true,
+			RequiresEvalArtifact: true,
+		},
+		Detector: noopDetector{},
+	}
+	snap := &models.TestSuiteSnapshot{}
+
+	got := safeDetectChecked(reg, snap, func() []models.Signal {
+		return reg.Detector.Detect(snap)
+	})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 diagnostic listing all missing inputs, got %d", len(got))
+	}
+	for _, marker := range []string{"--runtime", "--baseline", "promptfoo-results"} {
+		if !strings.Contains(got[0].Explanation, marker) {
+			t.Errorf("explanation missing %q: %q", marker, got[0].Explanation)
+		}
+	}
+}
+
+// TestJoinInputNames covers the Oxford-comma formatting for 1, 2,
+// and 3+ inputs.
+func TestJoinInputNames(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{}, ""},
+		{[]string{"runtime"}, "runtime"},
+		{[]string{"runtime", "baseline"}, "runtime and baseline"},
+		{[]string{"runtime", "baseline", "eval"}, "runtime, baseline, and eval"},
+		{[]string{"a", "b", "c", "d"}, "a, b, c, and d"},
+	}
+	for _, tt := range tests {
+		if got := joinInputNames(tt.in); got != tt.want {
+			t.Errorf("joinInputNames(%v) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/signals/signal_types.go
+++ b/internal/signals/signal_types.go
@@ -87,6 +87,7 @@ const (
 	// not by registered detectors.
 	SignalDetectorPanic          models.SignalType = "detectorPanic"
 	SignalDetectorBudgetExceeded models.SignalType = "detectorBudgetExceeded"
+	SignalDetectorMissingInput   models.SignalType = "detectorMissingInput"
 )
 
 // Canonical signal type sets. Import these rather than duplicating


### PR DESCRIPTION
## Summary

Two paired Track 9 deliverables that lift detector self-description
from "what does it emit" to "what does it consume" — and surface
input gaps as visible diagnostics instead of silent zero-output.

- **Track 9.1 — Capability metadata.** Adds 5 new DetectorMeta
  fields: RequiresRuntime, RequiresBaseline, RequiresEvalArtifact,
  ContextAware, Experimental. All zero-default; existing detectors
  unchanged.
- **Track 9.3 — Missing-input diagnostics.** New `safeDetectChecked`
  emits a single SignalDetectorMissingInput marker per affected
  detector when its declared inputs aren't satisfied. Skips
  invocation; no panic; explanation names the exact flags to add.

## What changed

**New code:**
- `DetectorMeta.{RequiresRuntime,RequiresBaseline,RequiresEvalArtifact,ContextAware,Experimental}`
  — 5 new fields, all zero-default
- `safeDetectChecked(reg, snap, fn)` — canonical invocation path,
  composes input check with existing safeDetect panic recovery
- `missingInputs(meta, snap)` — returns user-facing flag names
  for each missing input
- `joinInputNames` — Oxford-comma string join (with tests
  covering 0/1/2/3+ cases)

**New signal type:**
- `SignalDetectorMissingInput` registered in signal_types.go,
  signal_catalog.go, manifest.go

**Wiring:**
- All 6 `safeDetect(reg, ...)` call sites in detector_registry.go
  (Run + RunWithGraph Phase 1/2/3 paths) routed through
  `safeDetectChecked(reg, snap, ...)`

**New doc:** `docs/rules/engine/detector-missing-input.md` (regenerated)

## Test plan

- [x] 7 new tests in `missing_input_test.go` — happy path,
      per-input missing diagnostics, multi-missing aggregation,
      join formatting
- [x] `go test ./...` — full suite green
- [x] `make docs-verify` — generated docs current

## Plan tracker

Closes Track 9.1 + 9.3. Track 9 remaining: 9.2 (panic recovery
completion), 9.5 (pipeline architectural separation), 9.6
(registry refactor), 9.7 (truth-verify). All explicitly
post-0.2.0-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)