### PR TITLE
chore: ignore .claude/ and stray cmd binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,8 @@ PR_DESCRIPTION.md
 tmp/
 temp/
 terrain-parity-gate
+
+# === Local agent / build scratch ===
+.claude/
+terrain-docs-linkcheck
+terrain-truth-verify


### PR DESCRIPTION
Stop the merge wave from accidentally committing .claude/scheduled_tasks.lock and the materialized terrain-docs-linkcheck / terrain-truth-verify binaries on every rebase amend.
