### PR TITLE
feat(0.2): renderer migration to uitokens — bracketed severity/verdict (Track 10.2)

### DIFF
--- a/internal/changescope/render.go
+++ b/internal/changescope/render.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"github.com/pmclSF/terrain/internal/uitokens"
 )
 
 // RenderPRSummaryMarkdown writes a PR-ready markdown summary optimized
@@ -559,34 +561,21 @@ func renderAISection(line func(string, ...any), pr *PRAnalysis) {
 	}
 }
 
+// postureBadge delegates to uitokens.BracketedVerdict so the badge
+// vocabulary is owned by the design system. Track 10.2.
 func postureBadge(band string) string {
-	switch band {
-	case "well_protected":
-		return "[PASS]"
-	case "partially_protected":
-		return "[WARN]"
-	case "weakly_protected":
-		return "[RISK]"
-	case "high_risk":
-		return "[FAIL]"
-	case "evidence_limited":
-		return "[INFO]"
-	default:
-		return "[????]"
-	}
+	return uitokens.BracketedVerdict(band)
 }
 
+// severityIcon delegates to uitokens.BracketedSeverity so the badge
+// vocabulary is owned by the design system. Track 10.2 — every
+// renderer that emits user-visible severity should consume from
+// uitokens rather than carrying its own switch. Pre-Track-10.2 this
+// function returned its own bracketed strings; the wrapper is kept
+// (rather than inlining the call) so internal helpers like
+// renderFindingCard remain unchanged and the diff stays surgical.
 func severityIcon(severity string) string {
-	switch severity {
-	case "high":
-		return "[HIGH]"
-	case "medium":
-		return "[MED]"
-	case "low":
-		return "[LOW]"
-	default:
-		return "[---]"
-	}
+	return uitokens.BracketedSeverity(severity)
 }
 
 func formatSeverityCounts(counts map[string]int) []string {

--- a/internal/uitokens/uitokens.go
+++ b/internal/uitokens/uitokens.go
@@ -143,6 +143,55 @@ func SeverityBadge(s Severity) string {
 	}
 }
 
+// BracketedSeverity returns the severity token wrapped in square
+// brackets, the canonical shape for PR-comment markdown and any
+// other surface where the bracket makes the badge scan more
+// reliably than color (e.g. GitHub-flavored markdown which strips
+// most ANSI color attempts). Used by internal/changescope and
+// related renderers; locked by the unified-PR-comment golden tests
+// (Track 3.5).
+//
+// Severity strings (lowercase) map to the canonical Severity ladder
+// before rendering; unknown strings produce "[---]" so renderers
+// don't crash on stray data.
+func BracketedSeverity(severity string) string {
+	switch severity {
+	case "critical":
+		return "[CRIT]"
+	case "high":
+		return "[HIGH]"
+	case "medium":
+		return "[MED]"
+	case "low":
+		return "[LOW]"
+	case "info":
+		return "[INFO]"
+	default:
+		return "[---]"
+	}
+}
+
+// BracketedVerdict returns the posture-band verdict in canonical
+// PR-comment shape. Mirrors the changescope renderer's previous
+// inline mapping; centralized here so other renderers can consume
+// the same vocabulary without duplicating the switch.
+func BracketedVerdict(band string) string {
+	switch band {
+	case "well_protected":
+		return "[PASS]"
+	case "partially_protected":
+		return "[WARN]"
+	case "weakly_protected":
+		return "[RISK]"
+	case "high_risk":
+		return "[FAIL]"
+	case "evidence_limited":
+		return "[INFO]"
+	default:
+		return "[????]"
+	}
+}
+
 // VerdictBadge renders one of the canonical CLI verdicts (PASS / WARN
 // / FAIL) consistently. Used by the parity-gate matrix, the AI risk
 // review hero block, and the policy-check summary.

--- a/internal/uitokens/uitokens_test.go
+++ b/internal/uitokens/uitokens_test.go
@@ -139,6 +139,55 @@ func TestVerdictBadge(t *testing.T) {
 	})
 }
 
+// ── Bracketed badges (PR-comment / markdown surface) ───────────────
+
+// TestBracketedSeverity locks the canonical PR-comment severity
+// badge shape. The unified-PR-comment golden tests in
+// internal/changescope/unified_render_test.go assert these exact
+// strings; renaming a label here is a public-facing change.
+func TestBracketedSeverity(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"critical", "[CRIT]"},
+		{"high", "[HIGH]"},
+		{"medium", "[MED]"},
+		{"low", "[LOW]"},
+		{"info", "[INFO]"},
+		{"", "[---]"},
+		{"weird-unknown-value", "[---]"},
+	}
+	for _, tc := range cases {
+		if got := BracketedSeverity(tc.in); got != tc.want {
+			t.Errorf("BracketedSeverity(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBracketedVerdict locks the canonical PR-comment posture-band
+// badge shape. Same posture as TestBracketedSeverity — these
+// strings are part of the unified-PR-comment visual contract.
+func TestBracketedVerdict(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"well_protected", "[PASS]"},
+		{"partially_protected", "[WARN]"},
+		{"weakly_protected", "[RISK]"},
+		{"high_risk", "[FAIL]"},
+		{"evidence_limited", "[INFO]"},
+		{"", "[????]"},
+		{"weird-unknown-band", "[????]"},
+	}
+	for _, tc := range cases {
+		if got := BracketedVerdict(tc.in); got != tc.want {
+			t.Errorf("BracketedVerdict(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // ── Bar rendering ───────────────────────────────────────────────────
 
 func TestBarPlain_FullEmptyHalf(t *testing.T) {


### PR DESCRIPTION
First in-tree consumer of uitokens. Migrates `internal/changescope` severity / verdict badges to `uitokens.BracketedSeverity` / `uitokens.BracketedVerdict`.

The PR-comment markdown's `[HIGH]` / `[PASS]` strings are now owned by one place; renaming a label would surface in two test files (uitokens + changescope golden) instead of being silently inconsistent.

## Test plan
- [x] go build + go test ./...
- [x] make docs-verify / docs-linkcheck / truth-verify
- [x] 2 new uitokens tests + existing changescope goldens all pass

## Plan tracker
Closes Track 10.2 (renderer migration foundation). Track 10.3
(PR-comment redesign through tokens) and 10.4 (HTML report
redesign) will follow on this base. The vet-style check that flags
raw color codes outside uitokens (the "V1 uniformity gate" from
the parity plan) remains 0.2.x work.