### PR TITLE
feat(0.2): unified progress indicators (Track 10.5)

### DIFF
--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,207 @@
+// Package progress provides the unified spinner / stage-progress UI
+// used across `terrain analyze`, `terrain migrate run`, `terrain ai
+// run`, and `terrain report pr`. Track 10.5 of the 0.2.0 release
+// plan calls for one progress vocabulary so adopters see the same
+// shape regardless of which command is running.
+//
+// Design constraints:
+//
+//   - TTY-aware. When stderr is not a TTY (CI logs, pipes, file
+//     redirects), every method is a no-op. Adopters running inside
+//     CI never see spinner glyphs in their build logs.
+//   - --quiet aware. Constructors take an explicit quiet flag.
+//     A quiet Spinner is functionally equivalent to a non-TTY one.
+//   - Stateless from the caller's perspective. The Stop method is
+//     safe to call multiple times; Update is safe to call without
+//     a matching Start.
+//   - Zero dependencies on internal/uitokens at the package level
+//     so Track 10.1's design tokens can themselves use progress
+//     for long-running token-rendering operations without import
+//     cycles. Symbol vocabulary is parallel but locally owned.
+//
+// Goes to stderr by default (not stdout) so JSON / report output
+// piped to a file or another tool stays clean.
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// spinnerFrames is the canonical idle-progress glyph rotation.
+// Using Braille pattern dots so the visual width is constant
+// across frames; alternative animation (rotating slash, dots) is
+// intentionally rejected because the slash is wide and dots can
+// occupy variable widths depending on font rendering.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Spinner is a TTY-aware idle-progress indicator. Created with
+// NewSpinner; only emits glyphs when stderr is a TTY and the
+// caller didn't pass quiet=true.
+type Spinner struct {
+	out      io.Writer
+	enabled  bool
+	mu       sync.Mutex
+	stop     chan struct{}
+	done     chan struct{}
+	label    string
+	stopped  bool
+}
+
+// NewSpinner returns a Spinner that emits to stderr. quiet=true
+// returns a no-op spinner regardless of TTY state. The TTY check
+// is one-shot at construction time; subsequent stderr redirects
+// don't change behavior.
+func NewSpinner(label string, quiet bool) *Spinner {
+	return newSpinner(os.Stderr, label, quiet, isTerminal(os.Stderr))
+}
+
+// newSpinner is the test-friendly constructor. Takes an explicit
+// io.Writer + isTTY value so tests can inject a buffer and assert
+// on output without needing a real terminal.
+func newSpinner(out io.Writer, label string, quiet bool, isTTY bool) *Spinner {
+	return &Spinner{
+		out:     out,
+		label:   label,
+		enabled: !quiet && isTTY,
+	}
+}
+
+// Start kicks off the animation goroutine. No-op if the spinner
+// is disabled (not a TTY, --quiet, or already started).
+func (s *Spinner) Start() {
+	if s == nil || !s.enabled {
+		return
+	}
+	s.mu.Lock()
+	if s.stop != nil {
+		// Already running — don't double-start. Calling Start a
+		// second time is fine (defensive in callers that re-enter
+		// long-running paths).
+		s.mu.Unlock()
+		return
+	}
+	s.stop = make(chan struct{})
+	s.done = make(chan struct{})
+	s.mu.Unlock()
+
+	go s.run()
+}
+
+func (s *Spinner) run() {
+	defer close(s.done)
+	frame := 0
+	ticker := time.NewTicker(80 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stop:
+			s.clearLine()
+			return
+		case <-ticker.C:
+			s.mu.Lock()
+			label := s.label
+			s.mu.Unlock()
+			fmt.Fprintf(s.out, "\r%s %s", spinnerFrames[frame%len(spinnerFrames)], label)
+			frame++
+		}
+	}
+}
+
+// Update changes the label shown next to the spinner. Safe to
+// call from any goroutine, safe to call when the spinner is
+// stopped or disabled (becomes a no-op).
+func (s *Spinner) Update(label string) {
+	if s == nil || !s.enabled {
+		return
+	}
+	s.mu.Lock()
+	s.label = label
+	s.mu.Unlock()
+}
+
+// Stop ends the animation and clears the line. Idempotent — safe
+// to call multiple times. Safe to call without a matching Start.
+func (s *Spinner) Stop() {
+	if s == nil || !s.enabled {
+		return
+	}
+	s.mu.Lock()
+	if s.stopped || s.stop == nil {
+		s.mu.Unlock()
+		return
+	}
+	s.stopped = true
+	close(s.stop)
+	done := s.done
+	s.mu.Unlock()
+
+	// Wait for the goroutine to clean up the line before returning
+	// so the caller's next stderr write doesn't race.
+	<-done
+}
+
+// clearLine wipes the current line so the next write doesn't have
+// glyph residue. Two-step (carriage return + 80 spaces + carriage
+// return) so it works on terminals that don't fully clear on \r.
+func (s *Spinner) clearLine() {
+	fmt.Fprintf(s.out, "\r%80s\r", "")
+}
+
+// Stage is a multi-step progress reporter for the canonical
+// pipeline shape (Step 1/5 → Step 5/5). Used by analyze and ai run
+// where the work is segmented into named stages.
+type Stage struct {
+	out     io.Writer
+	enabled bool
+	total   int
+}
+
+// NewStage returns a Stage progress reporter that writes to stderr.
+func NewStage(total int, quiet bool) *Stage {
+	return newStage(os.Stderr, total, quiet, isTerminal(os.Stderr))
+}
+
+func newStage(out io.Writer, total int, quiet bool, isTTY bool) *Stage {
+	return &Stage{
+		out:     out,
+		total:   total,
+		enabled: !quiet && isTTY,
+	}
+}
+
+// Step prints "▸ Step n/total label" to stderr. No-op when
+// disabled. Used by callers that want a discrete checkpoint
+// rather than a spinning indicator.
+func (s *Stage) Step(n int, label string) {
+	if s == nil || !s.enabled {
+		return
+	}
+	fmt.Fprintf(s.out, "▸ Step %d/%d  %s\n", n, s.total, label)
+}
+
+// Done prints a final "✓ Done." marker. No-op when disabled.
+func (s *Stage) Done() {
+	if s == nil || !s.enabled {
+		return
+	}
+	fmt.Fprintln(s.out, "✓ Done.")
+}
+
+// isTerminal reports whether the given writer is a terminal. We
+// only handle the *os.File case; arbitrary io.Writer is treated
+// as non-terminal (correct default for buffers / pipes).
+func isTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -1,0 +1,173 @@
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestSpinner_DisabledOnNonTTY verifies the spinner emits nothing
+// when isTTY is false, regardless of quiet flag. CI logs / piped
+// stderr are the dominant case; spinner glyphs in those would be
+// noise.
+func TestSpinner_DisabledOnNonTTY(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := newSpinner(&buf, "scanning", false /*quiet*/, false /*isTTY*/)
+	s.Start()
+	time.Sleep(120 * time.Millisecond) // wait through one tick interval
+	s.Update("still scanning")
+	s.Stop()
+
+	if buf.Len() != 0 {
+		t.Errorf("non-TTY spinner emitted %d bytes; want 0:\n%q", buf.Len(), buf.String())
+	}
+}
+
+// TestSpinner_DisabledByQuiet verifies --quiet suppresses output
+// even on a TTY.
+func TestSpinner_DisabledByQuiet(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := newSpinner(&buf, "scanning", true /*quiet*/, true /*isTTY*/)
+	s.Start()
+	time.Sleep(120 * time.Millisecond)
+	s.Stop()
+
+	if buf.Len() != 0 {
+		t.Errorf("quiet spinner emitted %d bytes; want 0", buf.Len())
+	}
+}
+
+// TestSpinner_EnabledOnTTYNotQuiet verifies the happy path: when
+// stderr is a TTY and quiet is false, the spinner emits glyphs.
+func TestSpinner_EnabledOnTTYNotQuiet(t *testing.T) {
+	t.Parallel()
+	// Wrap a buffer with a fake-TTY shim so the constructor's TTY
+	// check returns true. Since newSpinner takes isTTY explicitly,
+	// we just pass true.
+	buf := &threadSafeBuffer{}
+	s := newSpinner(buf, "scanning", false, true)
+	s.Start()
+	time.Sleep(200 * time.Millisecond) // let at least 2 frames render
+	s.Stop()
+
+	out := buf.String()
+	// Expect at least one spinner glyph in the output.
+	hasGlyph := false
+	for _, frame := range spinnerFrames {
+		if strings.Contains(out, frame) {
+			hasGlyph = true
+			break
+		}
+	}
+	if !hasGlyph {
+		t.Errorf("spinner output should contain a frame glyph; got %q", out)
+	}
+	// Expect the label.
+	if !strings.Contains(out, "scanning") {
+		t.Errorf("spinner output should contain label %q; got %q", "scanning", out)
+	}
+}
+
+// TestSpinner_StopIdempotent verifies multiple Stop calls don't
+// panic or double-close the channel.
+func TestSpinner_StopIdempotent(t *testing.T) {
+	t.Parallel()
+	buf := &threadSafeBuffer{}
+	s := newSpinner(buf, "x", false, true)
+	s.Start()
+	s.Stop()
+	s.Stop() // second call should be a no-op
+	s.Stop() // third call too
+}
+
+// TestSpinner_StopWithoutStart verifies calling Stop on a never-
+// started spinner doesn't panic.
+func TestSpinner_StopWithoutStart(t *testing.T) {
+	t.Parallel()
+	buf := &threadSafeBuffer{}
+	s := newSpinner(buf, "x", false, true)
+	s.Stop() // should be a no-op
+}
+
+// TestSpinner_NilSafe verifies all methods are safe on a nil
+// spinner. Saves call sites from `if sp != nil { sp.Update(...) }`
+// boilerplate.
+func TestSpinner_NilSafe(t *testing.T) {
+	t.Parallel()
+	var s *Spinner
+	s.Start()
+	s.Update("x")
+	s.Stop()
+}
+
+// TestStage_DisabledOnNonTTY verifies stage progress is silent on
+// non-TTY (CI logs).
+func TestStage_DisabledOnNonTTY(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := newStage(&buf, 5, false, false)
+	s.Step(1, "scanning")
+	s.Step(2, "analyzing")
+	s.Done()
+
+	if buf.Len() != 0 {
+		t.Errorf("non-TTY stage emitted %d bytes; want 0", buf.Len())
+	}
+}
+
+// TestStage_EnabledFormat verifies the canonical stage-output
+// format: "▸ Step n/total label" + final "✓ Done.".
+func TestStage_EnabledFormat(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	s := newStage(&buf, 3, false, true)
+	s.Step(1, "scanning")
+	s.Step(2, "analyzing")
+	s.Step(3, "writing")
+	s.Done()
+
+	out := buf.String()
+	wantLines := []string{
+		"▸ Step 1/3  scanning",
+		"▸ Step 2/3  analyzing",
+		"▸ Step 3/3  writing",
+		"✓ Done.",
+	}
+	for _, want := range wantLines {
+		if !strings.Contains(out, want) {
+			t.Errorf("stage output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestStage_NilSafe verifies methods are safe on a nil stage.
+func TestStage_NilSafe(t *testing.T) {
+	t.Parallel()
+	var s *Stage
+	s.Step(1, "x")
+	s.Done()
+}
+
+// threadSafeBuffer wraps bytes.Buffer with a mutex so the spinner
+// goroutine and the test main goroutine can both access it
+// concurrently without -race screams.
+type threadSafeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *threadSafeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *threadSafeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}


### PR DESCRIPTION
Adds `internal/progress/` — the Track 10.5 deliverable. One Spinner + Stage progress vocabulary used across analyze / migrate run / ai run / pr.

Both types are silent on non-TTY (CI, pipes) and silent under --quiet. Goes to stderr so JSON / report output piped elsewhere stays clean.

## Test plan
- [x] go build + go test ./...
- [x] 9 new progress tests (TTY/quiet/nil-safety/idempotency)
- [x] make docs-verify / docs-linkcheck / truth-verify

## Plan tracker
Closes Track 10.5 foundation. Wiring into analyze / migrate run /
ai run / pr command paths is a follow-on PR that doesn't risk
breaking the unified-PR-comment goldens (those assert markdown
content, not stderr progress stream).