### PR TITLE
feat(0.2): wire progress.Spinner into runConvert (Track 10.5 follow-on)

### DIFF
--- a/cmd/terrain/cmd_convert.go
+++ b/cmd/terrain/cmd_convert.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	conv "github.com/pmclSF/terrain/internal/convert"
+	"github.com/pmclSF/terrain/internal/progress"
 )
 
 type convertCommandOptions struct {
@@ -185,6 +186,21 @@ func runConvert(source string, opts convertCommandOptions) error {
 	validationMode, err := resolveConvertValidationMode(opts)
 	if err != nil {
 		return cliUsageError{message: err.Error()}
+	}
+
+	// Track 10.5 — surface a TTY-aware spinner while the conversion
+	// runs. No-op when stdout/stderr is piped, when --json suppresses
+	// progress, or when running in a Plan/DryRun mode (those are fast
+	// enough that progress would flash and disappear).
+	var sp *progress.Spinner
+	if !opts.JSON && !opts.Plan && !opts.DryRun {
+		label := "Converting"
+		if opts.From != "" && opts.To != "" {
+			label = fmt.Sprintf("Converting %s → %s", opts.From, opts.To)
+		}
+		sp = progress.NewSpinner(label, false)
+		sp.Start()
+		defer sp.Stop()
 	}
 
 	result, err := conv.RunTestMigration(source, conv.TestMigrationOptions{


### PR DESCRIPTION
First in-tree consumer of `internal/progress` (PR #162). Adds a TTY-aware spinner to `terrain convert` — the longest-running CLI path that previously had no progress indicator.

Goes to stderr; no-op under --json / --plan / --dry-run; defer cleanup on early returns.

## Test plan
- [x] go build + go test ./...
- [x] make voice-lint clean
- [x] Convert tests unaffected

## Plan tracker
Closes Track 10.5 wiring follow-on. Future PRs can extend the same pattern to analyze / migrate run / ai run / pr.