### PR TITLE
fix(0.2): adopter-facing polish caught running the binary cold

### DIFF
--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -981,7 +981,10 @@ func isHelpArg(arg string) bool {
 }
 
 func printUsage() {
-	fmt.Fprintln(os.Stderr, "Terrain — test system intelligence platform")
+	fmt.Fprintln(os.Stderr, "Terrain — the control plane for your test system.")
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "Maps how your unit, integration, e2e, and AI tests relate to your code,")
+	fmt.Fprintln(os.Stderr, "and lets you gate changes based on the system as a whole.")
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Canonical commands (0.2 — recommended):")
 	fmt.Fprintln(os.Stderr)

--- a/internal/analyze/headline.go
+++ b/internal/analyze/headline.go
@@ -72,11 +72,18 @@ func deriveHeadline(r *Report) string {
 		)
 	}
 
-	// Healthy default.
+	// Empty repo or repo with no detected tests — say so honestly
+	// rather than calling zero tests "healthy".
+	tfCount := r.TestsDetected.TestFileCount
 	fwCount := len(r.TestsDetected.Frameworks)
+	if tfCount == 0 {
+		return "No test files detected. Add tests with your framework of choice, then re-run `terrain analyze`."
+	}
+
+	// Healthy default.
 	return fmt.Sprintf(
-		"Your test suite looks healthy: %d test files across %d frameworks.",
-		r.TestsDetected.TestFileCount,
-		fwCount,
+		"Your test suite looks healthy: %d test %s across %d %s.",
+		tfCount, plural(tfCount, "file"),
+		fwCount, plural(fwCount, "framework"),
 	)
 }

--- a/internal/changescope/render.go
+++ b/internal/changescope/render.go
@@ -84,8 +84,9 @@ func RenderPRSummaryMarkdown(w io.Writer, pr *PRAnalysis) {
 	}
 	if len(pr.RecommendedTests) > 0 {
 		if pr.TotalTestCount > 0 {
-			pct := 100 * len(pr.RecommendedTests) / pr.TotalTestCount
-			line("| **Tests selected** | %d of %d (%d%% of suite) |", len(pr.RecommendedTests), pr.TotalTestCount, pct)
+			line("| **Tests selected** | %d of %d (%s of suite) |",
+				len(pr.RecommendedTests), pr.TotalTestCount,
+				formatSuitePercent(len(pr.RecommendedTests), pr.TotalTestCount))
 		} else {
 			line("| **Tests selected** | %d |", len(pr.RecommendedTests))
 		}
@@ -576,6 +577,26 @@ func postureBadge(band string) string {
 // renderFindingCard remain unchanged and the diff stays surgical.
 func severityIcon(severity string) string {
 	return uitokens.BracketedSeverity(severity)
+}
+
+// formatSuitePercent renders selected/total as a percentage with
+// honest precision for small fractions. Pre-fix the integer-division
+// formula floored 7-of-796 to "0% of suite" — adopters seeing
+// "0%" reasonably wonder whether selection ran at all. Now sub-1%
+// fractions render as "<1%", and values ≥1% render as integer
+// percentages.
+func formatSuitePercent(selected, total int) string {
+	if total <= 0 {
+		return "—"
+	}
+	if selected <= 0 {
+		return "0%"
+	}
+	pct := 100 * selected / total
+	if pct == 0 {
+		return "<1%"
+	}
+	return fmt.Sprintf("%d%%", pct)
 }
 
 func formatSeverityCounts(counts map[string]int) []string {

--- a/internal/impact/analysis.go
+++ b/internal/impact/analysis.go
@@ -397,6 +397,30 @@ func surfaceKindLabel(kind models.CodeSurfaceKind) string {
 }
 
 // findProtectionGaps identifies where changed code lacks adequate coverage.
+// unitKindLabel maps a CodeUnitKind to the noun used in user-facing
+// gap messages. The labels are deliberately plain English: "function"
+// not "func", "type" not "struct", "value" for symbols where the
+// kind didn't carry through (vars, constants — these come through
+// without explicit kinds today and would otherwise default to
+// "function" via the legacy message).
+func unitKindLabel(kind string) string {
+	switch kind {
+	case "function":
+		return "function"
+	case "method":
+		return "method"
+	case "class":
+		return "class"
+	case "module":
+		return "module"
+	default:
+		// Unknown kinds (vars, types, constants where the parser
+		// didn't classify) get the neutral "symbol" label. Better
+		// to be vague than to claim a `var` is a "function".
+		return "symbol"
+	}
+}
+
 func findProtectionGaps(units []ImpactedCodeUnit, tests []ImpactedTest, snap *models.TestSuiteSnapshot) []ProtectionGap {
 	var gaps []ProtectionGap
 
@@ -414,8 +438,13 @@ func findProtectionGaps(units []ImpactedCodeUnit, tests []ImpactedTest, snap *mo
 			if iu.Exported {
 				severity = "high"
 				gapType = "untested_export"
-				explanation = fmt.Sprintf("Exported function %s has no observed test coverage.", iu.Name)
-				action = fmt.Sprintf("Add unit tests for exported function %s — this is public API surface.", iu.Name)
+				// Use the actual code-unit kind in the message so
+				// `Default` (a var) doesn't get labeled "Exported
+				// function" and confuse adopters. Falls back to
+				// "exported symbol" when the kind is unknown.
+				kindLabel := unitKindLabel(iu.Kind)
+				explanation = fmt.Sprintf("Exported %s %s has no observed test coverage.", kindLabel, iu.Name)
+				action = fmt.Sprintf("Add unit tests for exported %s %s — this is public API surface.", kindLabel, iu.Name)
 			}
 
 			// Downgrade when no coverage artifacts were provided: the gap


### PR DESCRIPTION
Five user-visible issues caught by actually running `terrain analyze` and `terrain report pr` against a fresh repo + this repo before cutting 0.2.0. None of the existing tests caught these — they're shape-of-output issues that only surface to a human reading the output.

1. **Help text leads with pitch, not legacy tagline.** `terrain --help` opened with the old "test system intelligence platform" framing.
2. **Pluralization** — fresh-repo analyze said "1 test files across 1 frameworks".
3. **Empty repo lied** — said "Your test suite looks healthy: 0 test files". Calling zero tests "healthy" is wrong.
4. **Sub-1% percentages floored to 0%** — "7 of 796 (0% of suite)" reads as "nothing selected".
5. **"Exported function X" misnomer** for vars/types/methods — adopters with an exported `var` saw it labeled a "function".

Pure polish, no behavior or schema changes.

## Test plan
- [x] go test ./... clean
- [x] make voice-lint / docs-verify / docs-linkcheck / truth-verify clean
- [x] manual smoke: fresh-repo + this-repo render correctly

## Plan tracker
This is the kind of quality-bar work the parity plan calls 'first-user smoke gate' work — caught by reading output, not by asserting on goldens. With this in, the release reads honestly to a new adopter.