### PR TITLE
fix(0.2): PR #140 recovery + Track 2 pillar markers + V3 empty-states + audit fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ Thumbs.db
 /terrain
 /terrain-bench
 /terrain-truthcheck
+/terrain-voice-lint
+/terrain-parity-gate
+/terrain-docs-gen
 
 # === SBOM artifacts (generated locally via `make sbom`) ===
 *.cdx.json

--- a/cmd/terrain/ai_workflow_test.go
+++ b/cmd/terrain/ai_workflow_test.go
@@ -359,7 +359,9 @@ func TestAIWorkflow_AIDoctorPassesWithScenarios(t *testing.T) {
 	text := buf.String()
 	// Verify the summary line exists with the expected pattern (pass/warn counts
 	// depend on fixture state, so check the format rather than exact values).
-	if !strings.Contains(text, "check(s) passed") && !strings.Contains(text, "All checks passed") {
+	// Pluralization passes through Plural() now: "1 check passed" /
+	// "N checks passed" / "All checks passed" are all valid summary lines.
+	if !strings.Contains(text, "checks passed") && !strings.Contains(text, "check passed") && !strings.Contains(text, "All checks passed") {
 		t.Fatalf("expected doctor summary line in output, got:\n%s", text)
 	}
 }

--- a/cmd/terrain/cmd_ai.go
+++ b/cmd/terrain/cmd_ai.go
@@ -252,7 +252,7 @@ func runAIList(root string, jsonOutput, verbose bool) error {
 		fmt.Println(strings.Repeat("-", aiSeparatorWidth))
 		for _, cap := range capabilities {
 			names := capScenarios[cap]
-			fmt.Printf("  %-30s %d scenario(s)\n", cap, len(names))
+			fmt.Printf("  %-30s %d %s\n", cap, len(names), reporting.Plural(len(names), "scenario"))
 		}
 		fmt.Println()
 	}
@@ -278,7 +278,7 @@ func runAIList(root string, jsonOutput, verbose bool) error {
 			}
 			surfLabel := ""
 			if sc.Surfaces > 0 {
-				surfLabel = fmt.Sprintf(" [%d surface(s)]", sc.Surfaces)
+				surfLabel = fmt.Sprintf(" [%d %s]", sc.Surfaces, reporting.Plural(sc.Surfaces, "surface"))
 			}
 			fmt.Printf("  %-35s %s%s%s\n", sc.Name, sc.Category, capLabel, surfLabel)
 		}
@@ -320,7 +320,7 @@ func runAIList(root string, jsonOutput, verbose bool) error {
 
 	// Validation gaps.
 	if len(uncoveredSurfaces) > 0 {
-		fmt.Printf("Missing Validation (%d AI surface(s) not covered by any scenario)\n", len(uncoveredSurfaces))
+		fmt.Printf("Missing Validation (%d AI %s not covered by any scenario)\n", len(uncoveredSurfaces), reporting.Plural(len(uncoveredSurfaces), "surface"))
 		fmt.Println(strings.Repeat("-", aiSeparatorWidth))
 		limit := 10
 		if len(uncoveredSurfaces) < limit {
@@ -548,9 +548,9 @@ func runAIRun(root string, jsonOutput bool, baseRef string, full, dryRun bool) e
 	fmt.Println()
 	fmt.Printf("Mode:      %s\n", mode)
 	fmt.Printf("Framework: %s\n", framework)
-	fmt.Printf("Selected:  %d scenario(s)\n", len(selected))
+	fmt.Printf("Selected:  %d %s\n", len(selected), reporting.Plural(len(selected), "scenario"))
 	if len(skipped) > 0 {
-		fmt.Printf("Skipped:   %d scenario(s) (not impacted)\n", len(skipped))
+		fmt.Printf("Skipped:   %d %s (not impacted)\n", len(skipped), reporting.Plural(len(skipped), "scenario"))
 	}
 	fmt.Println()
 
@@ -771,15 +771,16 @@ func evaluateAIRunDecision(snap *models.TestSuiteSnapshot, result *engine.Pipeli
 		decision.Action = actionBlock
 		parts := []string{}
 		if critical > 0 {
-			parts = append(parts, fmt.Sprintf("%d critical signal(s)", critical))
+			parts = append(parts, fmt.Sprintf("%d critical %s", critical, reporting.Plural(critical, "signal")))
 		}
 		if decision.Blocked > 0 {
-			parts = append(parts, fmt.Sprintf("%d policy violation(s)", decision.Blocked))
+			parts = append(parts, fmt.Sprintf("%d policy %s", decision.Blocked, reporting.Plural(decision.Blocked, "violation")))
 		}
 		decision.Reason = strings.Join(parts, ", ")
 	} else if high > 0 || medium > 0 {
 		decision.Action = actionWarn
-		decision.Reason = fmt.Sprintf("%d high + %d medium signal(s)", high, medium)
+		total := high + medium
+		decision.Reason = fmt.Sprintf("%d high + %d medium %s", high, medium, reporting.Plural(total, "signal"))
 	}
 
 	return decision
@@ -1041,7 +1042,7 @@ func runAIBaselineCompare(root string, jsonOutput bool) error {
 				marker, d.ScenarioID, d.MetricName, d.FromValue, d.ToValue, d.Delta)
 		}
 		if regressionCount > 0 {
-			fmt.Printf("\n⚠ %d regression(s) detected\n", regressionCount)
+			fmt.Printf("\n⚠ %d %s detected\n", regressionCount, reporting.Plural(regressionCount, "regression"))
 		}
 	} else if len(baselineMetrics) == 0 {
 		fmt.Println("\nNo baseline metrics recorded. Re-run `terrain ai record` with --gauntlet to capture metrics.")
@@ -1076,14 +1077,15 @@ func runAIReplay(root string, jsonOutput bool, artifactPath string) error {
 	fmt.Println()
 	fmt.Printf("Artifact:    %s\n", artifactPath)
 	fmt.Printf("Scenarios:   %d original → %d current\n", replayResult.OriginalScenarios, replayResult.CurrentScenarios)
-	fmt.Printf("Hashes:      %d surface(s) tracked\n", replayResult.CurrentHashes.TotalHashCount())
+	hashCount := replayResult.CurrentHashes.TotalHashCount()
+	fmt.Printf("Hashes:      %d %s tracked\n", hashCount, reporting.Plural(hashCount, "surface"))
 	fmt.Println()
 
 	if replayResult.Match {
 		fmt.Println("Result: MATCH — current repo state matches the original run.")
 		fmt.Println("All content hashes identical. Scenario count unchanged.")
 	} else {
-		fmt.Printf("Result: MISMATCH — %d difference(s) found\n", len(replayResult.Mismatches))
+		fmt.Printf("Result: MISMATCH — %d %s found\n", len(replayResult.Mismatches), reporting.Plural(len(replayResult.Mismatches), "difference"))
 		fmt.Println()
 		fmt.Println("Differences")
 		fmt.Println(strings.Repeat("-", aiSeparatorWidth))
@@ -1126,7 +1128,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 		checks = append(checks, doctorCheck{
 			Name:    "scenarios",
 			Status:  "pass",
-			Message: fmt.Sprintf("%d scenario(s) detected", len(snap.Scenarios)),
+			Message: fmt.Sprintf("%d %s detected", len(snap.Scenarios), reporting.Plural(len(snap.Scenarios), "scenario")),
 		})
 	} else {
 		checks = append(checks, doctorCheck{
@@ -1154,7 +1156,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 		checks = append(checks, doctorCheck{
 			Name:    "prompts",
 			Status:  "pass",
-			Message: fmt.Sprintf("%d prompt surface(s) detected", promptCount),
+			Message: fmt.Sprintf("%d prompt %s detected", promptCount, reporting.Plural(promptCount, "surface")),
 		})
 	} else {
 		checks = append(checks, doctorCheck{
@@ -1169,7 +1171,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 		checks = append(checks, doctorCheck{
 			Name:    "datasets",
 			Status:  "pass",
-			Message: fmt.Sprintf("%d dataset surface(s) detected", datasetCount),
+			Message: fmt.Sprintf("%d dataset %s detected", datasetCount, reporting.Plural(datasetCount, "surface")),
 		})
 	} else {
 		checks = append(checks, doctorCheck{
@@ -1184,7 +1186,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 		checks = append(checks, doctorCheck{
 			Name:    "contexts",
 			Status:  "pass",
-			Message: fmt.Sprintf("%d context surface(s) detected (system messages, policies, few-shot, etc.)", contextCount),
+			Message: fmt.Sprintf("%d context %s detected (system messages, policies, few-shot, etc.)", contextCount, reporting.Plural(contextCount, "surface")),
 		})
 	}
 	// No warning for missing contexts — they're optional.
@@ -1200,7 +1202,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 		checks = append(checks, doctorCheck{
 			Name:    "eval_files",
 			Status:  "pass",
-			Message: fmt.Sprintf("%d eval-related test file(s) found", evalFileCount),
+			Message: fmt.Sprintf("%d eval-related test %s found", evalFileCount, reporting.Plural(evalFileCount, "file")),
 		})
 	} else {
 		checks = append(checks, doctorCheck{
@@ -1220,7 +1222,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 		checks = append(checks, doctorCheck{
 			Name:    "frameworks",
 			Status:  "pass",
-			Message: fmt.Sprintf("%d framework(s) detected: %s", len(aiDet.Frameworks), strings.Join(names, ", ")),
+			Message: fmt.Sprintf("%d %s detected: %s", len(aiDet.Frameworks), reporting.Plural(len(aiDet.Frameworks), "framework"), strings.Join(names, ", ")),
 		})
 	} else {
 		checks = append(checks, doctorCheck{
@@ -1242,13 +1244,13 @@ func runAIDoctor(root string, jsonOutput bool) error {
 			checks = append(checks, doctorCheck{
 				Name:    "graph_wiring",
 				Status:  "pass",
-				Message: fmt.Sprintf("All %d scenario(s) linked to code surfaces", wired),
+				Message: fmt.Sprintf("All %d %s linked to code surfaces", wired, reporting.Plural(wired, "scenario")),
 			})
 		} else {
 			checks = append(checks, doctorCheck{
 				Name:    "graph_wiring",
 				Status:  "warn",
-				Message: fmt.Sprintf("%d of %d scenario(s) have no linked code surfaces", len(snap.Scenarios)-wired, len(snap.Scenarios)),
+				Message: fmt.Sprintf("%d of %d %s have no linked code surfaces", len(snap.Scenarios)-wired, len(snap.Scenarios), reporting.Plural(len(snap.Scenarios), "scenario")),
 			})
 		}
 	}
@@ -1285,7 +1287,7 @@ func runAIDoctor(root string, jsonOutput bool) error {
 	if warnCount == 0 {
 		fmt.Println("All checks passed. AI/eval setup looks good.")
 	} else {
-		fmt.Printf("%d check(s) passed, %d warning(s).\n", passCount, warnCount)
+		fmt.Printf("%d %s passed, %d %s.\n", passCount, reporting.Plural(passCount, "check"), warnCount, reporting.Plural(warnCount, "warning"))
 	}
 
 	return nil

--- a/cmd/terrain/cmd_ai.go
+++ b/cmd/terrain/cmd_ai.go
@@ -241,8 +241,7 @@ func runAIList(root string, jsonOutput, verbose bool) error {
 
 	// Empty state.
 	if len(scenarios) == 0 && totalAI == 0 && len(evalFiles) == 0 {
-		fmt.Println("No AI/eval components detected.")
-		fmt.Println("Run `terrain ai doctor` to diagnose.")
+		reporting.RenderEmptyState(os.Stdout, reporting.EmptyNoAISurfaces)
 		return nil
 	}
 

--- a/cmd/terrain/cmd_analyze.go
+++ b/cmd/terrain/cmd_analyze.go
@@ -394,6 +394,7 @@ func runPolicyCheck(root string, jsonOutput bool, coveragePath, coverageRunLabel
 	}
 
 	if !policyResult.Found {
+		es := reporting.EmptyStateFor(reporting.EmptyNoPolicyFile)
 		if jsonOutput {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
@@ -401,7 +402,11 @@ func runPolicyCheck(root string, jsonOutput bool, coveragePath, coverageRunLabel
 				"policyFile": nil,
 				"pass":       true,
 				"violations": []any{},
-				"message":    "No policy file found. Create .terrain/policy.yaml to define policy.",
+				"empty":      true,
+				"emptyKind":  "no-policy-file",
+				"header":     es.Header,
+				"nextMove":   es.NextMove,
+				"message":    es.Header + " " + es.NextMove,
 			}); err != nil {
 				fmt.Fprintf(os.Stderr, "error: failed to render policy output: %v\n", err)
 				return exitError
@@ -409,8 +414,7 @@ func runPolicyCheck(root string, jsonOutput bool, coveragePath, coverageRunLabel
 		} else {
 			fmt.Println("Terrain Policy Check")
 			fmt.Println()
-			fmt.Println("No policy file found.")
-			fmt.Println("Create .terrain/policy.yaml to define policy rules.")
+			reporting.RenderEmptyState(os.Stdout, reporting.EmptyNoPolicyFile)
 		}
 		return exitOK
 	}

--- a/cmd/terrain/cmd_analyze.go
+++ b/cmd/terrain/cmd_analyze.go
@@ -139,7 +139,53 @@ func relativeToRoot(path, root string) string {
 	return path
 }
 
-func runAnalyze(root string, jsonOutput bool, format string, verbose bool, writeSnap bool, coveragePath, coverageRunLabel string, runtimePaths string, gauntletPaths string, promptfooPaths string, deepevalPaths string, ragasPaths string, baselinePath string, slowThreshold float64, redactPaths bool, gate severityGate, timeout time.Duration) error {
+// analyzeRunOpts collects every input runAnalyze takes. Replaces a
+// seventeen-positional-argument signature with one struct so future
+// flag additions stop expanding the call site. Track 4.6/4.7/4.8
+// recovery (PR #140) introduced the struct; gate + timeout fields
+// were already on the previous positional signature and are
+// preserved here.
+type analyzeRunOpts struct {
+	Root             string
+	JSONOutput       bool
+	Format           string
+	Verbose          bool
+	WriteSnapshot    bool
+	CoveragePath     string
+	CoverageRunLabel string
+	RuntimePaths     string
+	GauntletPaths    string
+	PromptfooPaths   string
+	DeepEvalPaths    string
+	RagasPaths       string
+	BaselinePath     string
+	SlowThreshold    float64
+	RedactPaths      bool
+	Gate             severityGate
+	Timeout          time.Duration
+	SuppressionsPath string
+	NewFindingsOnly  bool
+}
+
+func runAnalyze(o analyzeRunOpts) error {
+	root := o.Root
+	jsonOutput := o.JSONOutput
+	format := o.Format
+	verbose := o.Verbose
+	writeSnap := o.WriteSnapshot
+	coveragePath := o.CoveragePath
+	coverageRunLabel := o.CoverageRunLabel
+	runtimePaths := o.RuntimePaths
+	gauntletPaths := o.GauntletPaths
+	promptfooPaths := o.PromptfooPaths
+	deepevalPaths := o.DeepEvalPaths
+	ragasPaths := o.RagasPaths
+	baselinePath := o.BaselinePath
+	slowThreshold := o.SlowThreshold
+	redactPaths := o.RedactPaths
+	gate := o.Gate
+	timeout := o.Timeout
+
 	parsedRuntime := parseRuntimePaths(runtimePaths)
 	parsedGauntlet := parseRuntimePaths(gauntletPaths)        // same comma-split logic
 	parsedPromptfoo := parseRuntimePaths(promptfooPaths)      // same comma-split logic
@@ -159,6 +205,11 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 	}
 	if baselinePath != "" {
 		if err := validateExistingPaths("--baseline", []string{baselinePath}); err != nil {
+			return err
+		}
+	}
+	if o.SuppressionsPath != "" {
+		if err := validateExistingPaths("--suppressions", []string{o.SuppressionsPath}); err != nil {
 			return err
 		}
 	}
@@ -187,6 +238,8 @@ func runAnalyze(root string, jsonOutput bool, format string, verbose bool, write
 	opt.DeepEvalPaths = parsedDeepEval
 	opt.RagasPaths = parsedRagas
 	opt.BaselineSnapshotPath = baselinePath
+	opt.SuppressionsPath = o.SuppressionsPath
+	opt.NewFindingsOnly = o.NewFindingsOnly
 	opt.OnProgress = newProgressFunc(jsonOutput)
 	// Honour Ctrl-C and the optional --timeout: pre-0.2.x analyze
 	// exited abruptly on SIGINT with no cleanup, and unbounded

--- a/cmd/terrain/cmd_convert.go
+++ b/cmd/terrain/cmd_convert.go
@@ -12,6 +12,7 @@ import (
 
 	conv "github.com/pmclSF/terrain/internal/convert"
 	"github.com/pmclSF/terrain/internal/progress"
+	"github.com/pmclSF/terrain/internal/reporting"
 )
 
 type convertCommandOptions struct {
@@ -494,7 +495,7 @@ func runDetect(path string, jsonOutput bool) error {
 			if candidate.Primary {
 				label = " [primary]"
 			}
-			fmt.Printf("  Candidate: %s (%.0f%% confidence across %d file(s), %.0f%% share)%s\n", candidate.Framework, candidate.Confidence*100, candidate.Files, candidate.FileShare*100, label)
+			fmt.Printf("  Candidate: %s (%.0f%% confidence across %d %s, %.0f%% share)%s\n", candidate.Framework, candidate.Confidence*100, candidate.Files, reporting.Plural(candidate.Files, "file"), candidate.FileShare*100, label)
 		}
 	}
 	return nil

--- a/cmd/terrain/cmd_doctor_pillars.go
+++ b/cmd/terrain/cmd_doctor_pillars.go
@@ -1,0 +1,184 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// pillarStatus is a per-pillar maturity check the doctor command
+// renders before the migration-specific checks. The intent is to
+// answer "is this repo set up to use Terrain end-to-end" at a glance,
+// without running analyze.
+type pillarStatus struct {
+	Name    string
+	Symbol  string // "✓", "⚠", "?"
+	Detail  string
+	Hint    string
+}
+
+// assessPillars returns one status per pillar. Each check is local —
+// no analyze run, no network, no AST work — so doctor stays fast.
+func assessPillars(root string) []pillarStatus {
+	return []pillarStatus{
+		assessUnderstand(root),
+		assessAlign(root),
+		assessGate(root),
+	}
+}
+
+// assessUnderstand checks whether Terrain has anything to look at:
+// at least one well-known test framework config or test file pattern
+// in the repo. Empty result means analyze will produce an empty
+// snapshot, and the user should be told that up-front.
+func assessUnderstand(root string) pillarStatus {
+	indicators := []string{
+		"jest.config.js", "jest.config.ts", "jest.config.cjs",
+		"vitest.config.js", "vitest.config.ts",
+		"playwright.config.js", "playwright.config.ts",
+		"cypress.config.js", "cypress.config.ts",
+		"pytest.ini", "pyproject.toml",
+		"go.mod",
+	}
+	for _, ind := range indicators {
+		if fileExists(filepath.Join(root, ind)) {
+			return pillarStatus{
+				Name:   "Understand",
+				Symbol: "✓",
+				Detail: fmt.Sprintf("test framework detected (%s)", ind),
+			}
+		}
+	}
+	return pillarStatus{
+		Name:   "Understand",
+		Symbol: "?",
+		Detail: "no recognized test framework config in repo root",
+		Hint:   "Add tests with your framework of choice, then re-run.",
+	}
+}
+
+// assessAlign checks for the multi-repo manifest. Absence isn't a
+// problem — most repos are single-repo — but presence indicates
+// portfolio adoption.
+func assessAlign(root string) pillarStatus {
+	if fileExists(filepath.Join(root, ".terrain", "repos.yaml")) {
+		return pillarStatus{
+			Name:   "Align",
+			Symbol: "✓",
+			Detail: "multi-repo manifest present",
+		}
+	}
+	return pillarStatus{
+		Name:   "Align",
+		Symbol: "?",
+		Detail: "no multi-repo manifest (single-repo workflow assumed)",
+	}
+}
+
+// assessGate checks for a CI workflow file that references terrain,
+// plus the suppressions / baseline files that the gating flow uses.
+// Missing CI workflow is the most common adoption gap.
+func assessGate(root string) pillarStatus {
+	hasCI := hasTerrainCIWorkflow(root)
+	hasSuppress := fileExists(filepath.Join(root, ".terrain", "suppressions.yaml"))
+	switch {
+	case hasCI && hasSuppress:
+		return pillarStatus{
+			Name:   "Gate",
+			Symbol: "✓",
+			Detail: "CI workflow + suppressions configured",
+		}
+	case hasCI:
+		return pillarStatus{
+			Name:   "Gate",
+			Symbol: "✓",
+			Detail: "CI workflow detected",
+		}
+	default:
+		return pillarStatus{
+			Name:   "Gate",
+			Symbol: "⚠",
+			Detail: "no CI workflow references terrain",
+			Hint:   "See docs/examples/gate/github-action.yml for the recommended template.",
+		}
+	}
+}
+
+func fileExists(p string) bool {
+	st, err := os.Stat(p)
+	return err == nil && !st.IsDir()
+}
+
+// hasTerrainCIWorkflow scans .github/workflows for any YAML file
+// that mentions "terrain" anywhere. Cheap heuristic, but false
+// positives are harmless here — the doctor is informational.
+func hasTerrainCIWorkflow(root string) bool {
+	dir := filepath.Join(root, ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !endsWithAny(name, ".yml", ".yaml") {
+			continue
+		}
+		f, err := os.Open(filepath.Join(dir, name))
+		if err != nil {
+			continue
+		}
+		buf := make([]byte, 8192)
+		n, _ := f.Read(buf)
+		f.Close()
+		if containsTerrain(buf[:n]) {
+			return true
+		}
+	}
+	return false
+}
+
+func endsWithAny(s string, suffixes ...string) bool {
+	for _, sx := range suffixes {
+		if len(s) >= len(sx) && s[len(s)-len(sx):] == sx {
+			return true
+		}
+	}
+	return false
+}
+
+func containsTerrain(b []byte) bool {
+	target := []byte("terrain")
+	for i := 0; i+len(target) <= len(b); i++ {
+		match := true
+		for j, c := range target {
+			bc := b[i+j]
+			if bc >= 'A' && bc <= 'Z' {
+				bc += 'a' - 'A'
+			}
+			if bc != c {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// renderPillarStatuses writes the per-pillar maturity block to w.
+func renderPillarStatuses(w io.Writer, statuses []pillarStatus) {
+	fmt.Fprintln(w, "Pillar maturity:")
+	for _, ps := range statuses {
+		fmt.Fprintf(w, "  [%s] %s: %s\n", ps.Symbol, ps.Name, ps.Detail)
+		if ps.Hint != "" {
+			fmt.Fprintf(w, "         -> %s\n", ps.Hint)
+		}
+	}
+	fmt.Fprintln(w)
+}

--- a/cmd/terrain/cmd_explain.go
+++ b/cmd/terrain/cmd_explain.go
@@ -503,7 +503,23 @@ func showFinding(id string, snap *models.TestSuiteSnapshot, jsonOutput bool) err
 			return nil
 		}
 	}
-	return cliExitError{code: exitNotFound, message: fmt.Sprintf("finding not found: %s", id)}
+	// Distinct from the stable-finding-ID path above (which gives a
+	// detailed "ID parses but didn't resolve" diagnostic). This branch
+	// runs when the user passed a numeric index or a type string and
+	// neither matched. Help them figure out what to try next.
+	return cliExitError{
+		code: exitNotFound,
+		message: fmt.Sprintf(
+			"finding not found: %s\n\n"+
+				"`terrain explain finding <id>` accepts:\n"+
+				"  - a stable finding ID  (e.g. `weakAssertion@src/auth_test.go:TestLogin#a1b2c3d4`)\n"+
+				"  - a portfolio index    (e.g. `0`, `1`, `2` — see `terrain analyze --json`)\n"+
+				"  - a signal type        (e.g. `weakAssertion`)\n\n"+
+				"If you copied this ID from an older run, re-run `terrain analyze` —\n"+
+				"file renames, symbol renames, or line drift can produce a new ID.",
+			id,
+		),
+	}
 }
 
 func isUniqueCodeUnitName(snap *models.TestSuiteSnapshot, name string) bool {

--- a/cmd/terrain/cmd_explain.go
+++ b/cmd/terrain/cmd_explain.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pmclSF/terrain/internal/explain"
+	"github.com/pmclSF/terrain/internal/identity"
 	"github.com/pmclSF/terrain/internal/impact"
 	"github.com/pmclSF/terrain/internal/models"
 	"github.com/pmclSF/terrain/internal/reporting"
@@ -184,9 +185,121 @@ func runExplain(target, root, baseRef string, jsonOutput, verbose bool) error {
 		}
 	}
 
+	// Try as a stable finding ID (e.g.
+	// "weakAssertion@internal/auth/login_test.go:TestLogin#a1b2c3d4").
+	// `terrain explain finding <id>` per Track 4.6 — round-trip a
+	// finding ID back to its evidence + suggest a suppression command.
+	if _, _, _, _, ok := identity.ParseFindingID(target); ok {
+		if sig, found := lookupSignalByFindingID(snap, target); found {
+			if jsonOutput {
+				return jsonOut(sig)
+			}
+			renderFindingExplanation(sig, target)
+			return nil
+		}
+		// Looks like a finding ID but not in this snapshot — distinct
+		// from "garbage input": tell the user it parsed correctly but
+		// didn't resolve. Common cause: stale ID after a refactor.
+		return cliExitError{
+			code: exitNotFound,
+			message: fmt.Sprintf(
+				"finding ID parses but is not in the current snapshot: %s\n\n"+
+					"Common causes:\n"+
+					"  - the underlying signal moved (file rename, symbol rename, line drift without symbol)\n"+
+					"  - the suppression file already drops it — check `.terrain/suppressions.yaml`\n"+
+					"  - the snapshot is from a different run — re-run `terrain analyze`",
+				target,
+			),
+		}
+	}
+
 	return cliExitError{
 		code:    exitNotFound,
-		message: fmt.Sprintf("entity not found: %s\n\nTry: a test file path, test ID, scenario ID, or 'selection'", target),
+		message: fmt.Sprintf("entity not found: %s\n\nTry: a test file path, test ID, scenario ID, finding ID, or 'selection'", target),
+	}
+}
+
+// lookupSignalByFindingID searches the snapshot for a signal with the
+// given FindingID. Returns the signal + ok=true on hit. Walks both
+// top-level Signals and per-test-file Signals so any emission path
+// resolves.
+func lookupSignalByFindingID(snap *models.TestSuiteSnapshot, id string) (models.Signal, bool) {
+	if snap == nil {
+		return models.Signal{}, false
+	}
+	for _, s := range snap.Signals {
+		if s.FindingID == id {
+			return s, true
+		}
+	}
+	for _, tf := range snap.TestFiles {
+		for _, s := range tf.Signals {
+			if s.FindingID == id {
+				return s, true
+			}
+		}
+	}
+	return models.Signal{}, false
+}
+
+// renderFindingExplanation prints a finding's evidence in human-
+// readable form. Mirrors the shape used by other explain renders:
+// section header → finding metadata → next-step pointers (including
+// the canonical `terrain suppress` invocation).
+func renderFindingExplanation(s models.Signal, id string) {
+	rule := strings.Repeat("─", 60)
+	fmt.Println("Terrain — finding explanation")
+	fmt.Println(rule)
+	fmt.Println()
+
+	fmt.Printf("Finding ID:  %s\n", id)
+	fmt.Printf("Detector:    %s\n", s.Type)
+	fmt.Printf("Severity:    %s\n", strings.ToUpper(string(s.Severity)))
+	if s.Category != "" {
+		fmt.Printf("Category:    %s\n", s.Category)
+	}
+	fmt.Println()
+
+	if s.Location.File != "" {
+		loc := s.Location.File
+		if s.Location.Symbol != "" {
+			loc += " :: " + s.Location.Symbol
+		}
+		if s.Location.Line > 0 {
+			loc += fmt.Sprintf(" (line %d)", s.Location.Line)
+		}
+		fmt.Printf("Location:    %s\n", loc)
+	}
+	if s.Owner != "" {
+		fmt.Printf("Owner:       %s\n", s.Owner)
+	}
+	if s.EvidenceStrength != "" {
+		fmt.Printf("Evidence:    %s", s.EvidenceStrength)
+		if s.EvidenceSource != "" {
+			fmt.Printf(" (%s)", s.EvidenceSource)
+		}
+		fmt.Println()
+	}
+	if s.RuleID != "" {
+		fmt.Printf("Rule:        %s\n", s.RuleID)
+	}
+	fmt.Println()
+
+	if s.Explanation != "" {
+		fmt.Println("Why it matters:")
+		fmt.Printf("  %s\n", s.Explanation)
+		fmt.Println()
+	}
+	if s.SuggestedAction != "" {
+		fmt.Println("What to do:")
+		fmt.Printf("  %s\n", s.SuggestedAction)
+		fmt.Println()
+	}
+
+	fmt.Println("Next steps:")
+	fmt.Printf("  terrain suppress %q --reason \"<why>\"   waive this finding (with a reason)\n", id)
+	if s.RuleURI != "" {
+		fmt.Printf("  see %s for the full detector reference\n", s.RuleURI)
 	}
 }
 

--- a/cmd/terrain/cmd_insights.go
+++ b/cmd/terrain/cmd_insights.go
@@ -185,7 +185,7 @@ func runFocus(root string, jsonOutput, verbose bool) error {
 		for i, area := range es.TopRiskAreas {
 			fmt.Printf("  %d. %s (%s)\n", i+1, area.Name, area.Band)
 			if area.RiskType != "" {
-				fmt.Printf("     risk: %s (%d signal(s))\n", area.RiskType, area.SignalCount)
+				fmt.Printf("     risk: %s (%d %s)\n", area.RiskType, area.SignalCount, reporting.Plural(area.SignalCount, "signal"))
 			}
 		}
 	}

--- a/cmd/terrain/cmd_severity_gate_test.go
+++ b/cmd/terrain/cmd_severity_gate_test.go
@@ -100,12 +100,11 @@ func TestRunAnalyze_GateBlocksOnFixture(t *testing.T) {
 	root := fixtureRoot(t)
 
 	stdout, err := captureRun(func() error {
-		return runAnalyze(
-			root, false, "", false, false,
-			"", "", "", "", "", "", "", "",
-			defaultSlowThresholdMs, false,
-			severityGateMedium, 0,
-		)
+		return runAnalyze(analyzeRunOpts{
+			Root:          root,
+			SlowThreshold: defaultSlowThresholdMs,
+			Gate:          severityGateMedium,
+		})
 	})
 
 	// The fixture has medium+ findings — gate should fire.
@@ -141,12 +140,12 @@ func TestRunAnalyze_JSONStdoutPurity(t *testing.T) {
 	root := fixtureRoot(t)
 
 	stdout, err := captureRun(func() error {
-		return runAnalyze(
-			root, true, "", false, false,
-			"", "", "", "", "", "", "", "",
-			defaultSlowThresholdMs, false,
-			severityGateMedium, 0,
-		)
+		return runAnalyze(analyzeRunOpts{
+			Root:          root,
+			JSONOutput:    true,
+			SlowThreshold: defaultSlowThresholdMs,
+			Gate:          severityGateMedium,
+		})
 	})
 
 	// Gate fired (expected for the fixture).
@@ -219,12 +218,11 @@ func TestRunAnalyze_GatePassesWhenSeverityAbsent(t *testing.T) {
 	root := fixtureRoot(t)
 
 	_, err := captureRun(func() error {
-		return runAnalyze(
-			root, false, "", false, false,
-			"", "", "", "", "", "", "", "",
-			defaultSlowThresholdMs, false,
-			severityGateCritical, 0,
-		)
+		return runAnalyze(analyzeRunOpts{
+			Root:          root,
+			SlowThreshold: defaultSlowThresholdMs,
+			Gate:          severityGateCritical,
+		})
 	})
 
 	// The fixture's worst severity is below critical — gate should NOT

--- a/cmd/terrain/cmd_suppress.go
+++ b/cmd/terrain/cmd_suppress.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pmclSF/terrain/internal/identity"
+	"github.com/pmclSF/terrain/internal/suppression"
+)
+
+// runSuppress writes a new entry into `.terrain/suppressions.yaml`
+// for the given finding ID. The flow is:
+//
+//  1. Validate the finding ID parses (Track 4.4 format).
+//  2. Load the existing suppressions file (or create an empty one).
+//  3. Refuse to add a duplicate entry — if one already exists, print
+//     a helpful message pointing at the existing reason and exit.
+//  4. Append the new entry.
+//  5. Write back, preserving comments and ordering of existing
+//     entries via simple text-append (we deliberately don't round-trip
+//     through YAML because goccy/go-yaml's comment preservation is
+//     uneven; appending text is the safer 0.2.0 shape).
+//
+// Result: a suppression entry with reason + optional expires + owner,
+// ready for the next `terrain analyze` run to honor.
+func runSuppress(findingID, reason, expires, owner, root string) error {
+	if findingID == "" {
+		return fmt.Errorf("missing finding ID — usage: terrain suppress <finding-id> --reason \"why\"")
+	}
+	if _, _, _, _, ok := identity.ParseFindingID(findingID); !ok {
+		return fmt.Errorf("invalid finding ID format %q — expected detector@path:anchor#hash", findingID)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return fmt.Errorf("--reason is required (every suppression must justify itself)")
+	}
+
+	// Light sanity-check on `expires` — if the user supplied something,
+	// it should at least look like an ISO date so a downstream parser
+	// doesn't trip silently. We don't enforce real-date validity here;
+	// the loader emits a non-fatal warning if it can't parse.
+	if expires != "" {
+		if !looksLikeISODate(expires) {
+			return fmt.Errorf("--expires %q does not look like YYYY-MM-DD", expires)
+		}
+	}
+
+	suppPath := filepath.Join(root, suppression.DefaultPath)
+
+	// Check for existing entry — refuse to add duplicates so users
+	// don't accidentally accumulate stale waivers.
+	existing, err := suppression.Load(suppPath)
+	if err != nil {
+		return fmt.Errorf("could not load existing %s: %w", suppression.DefaultPath, err)
+	}
+	if existing != nil {
+		for _, e := range existing.Entries {
+			if e.FindingID == findingID {
+				return cliExitError{
+					code: exitUsageError,
+					message: fmt.Sprintf(
+						"finding %s is already suppressed.\n"+
+							"Existing reason: %s\n"+
+							"Existing owner:  %s\n"+
+							"Existing expires: %s\n\n"+
+							"Edit %s directly to update the entry, or remove it first to re-add.",
+						findingID, e.Reason, e.Owner, e.Expires, suppPath,
+					),
+				}
+			}
+		}
+	}
+
+	// Build the entry as YAML text. Append to the existing file, or
+	// create a new file with the schema header if the file doesn't
+	// exist. We deliberately write text rather than re-marshaling —
+	// preserves any comments / ordering the user added by hand.
+	if err := os.MkdirAll(filepath.Dir(suppPath), 0o755); err != nil {
+		return fmt.Errorf("could not create %s parent dir: %w", suppression.DefaultPath, err)
+	}
+
+	header := ""
+	body, readErr := os.ReadFile(suppPath)
+	if readErr != nil {
+		if !os.IsNotExist(readErr) {
+			return fmt.Errorf("read %s: %w", suppPath, readErr)
+		}
+		// New file — emit the schema header.
+		header = "# Terrain suppressions — generated and edited by `terrain suppress`.\n" +
+			"# Schema: https://github.com/pmclSF/terrain/blob/main/internal/suppression/suppression.go\n\n" +
+			"schema_version: \"1\"\n" +
+			"suppressions:\n"
+	}
+
+	entry := buildSuppressionYAML(findingID, reason, expires, owner)
+
+	out := header
+	if len(body) > 0 {
+		out += string(body)
+		// Ensure separation before our append.
+		if !strings.HasSuffix(out, "\n") {
+			out += "\n"
+		}
+	}
+	// If the existing file doesn't yet have a `suppressions:` key, the
+	// loader (when it sees only schema_version + an entry) would still
+	// parse — but for hygiene, rewrite the whole file with normal shape
+	// when we're appending.
+	if header == "" && !strings.Contains(string(body), "\nsuppressions:") && !strings.HasPrefix(string(body), "suppressions:") {
+		out += "suppressions:\n"
+	}
+	out += entry
+
+	if err := os.WriteFile(suppPath, []byte(out), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", suppPath, err)
+	}
+
+	fmt.Printf("Suppressed %s\n", findingID)
+	fmt.Printf("  reason:  %s\n", reason)
+	if expires != "" {
+		fmt.Printf("  expires: %s\n", expires)
+	}
+	if owner != "" {
+		fmt.Printf("  owner:   %s\n", owner)
+	}
+	fmt.Printf("\nWritten to: %s\n", suppPath)
+	if expires == "" {
+		fmt.Println("\nTip: add --expires=YYYY-MM-DD so the suppression doesn't outlive its reason.")
+	}
+	return nil
+}
+
+func buildSuppressionYAML(findingID, reason, expires, owner string) string {
+	var b strings.Builder
+	b.WriteString("  - finding_id: ")
+	b.WriteString(findingID)
+	b.WriteString("\n")
+	b.WriteString("    reason: ")
+	b.WriteString(yamlInlineString(reason))
+	b.WriteString("\n")
+	if expires != "" {
+		b.WriteString("    expires: ")
+		b.WriteString(expires)
+		b.WriteString("\n")
+	}
+	if owner != "" {
+		b.WriteString("    owner: ")
+		b.WriteString(yamlInlineString(owner))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// yamlInlineString quotes a string for safe inline use in YAML.
+// We always double-quote so reasons containing special characters
+// (`:`, `#`, leading dashes, etc.) round-trip cleanly.
+func yamlInlineString(s string) string {
+	// Escape backslash + double-quote.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+func looksLikeISODate(s string) bool {
+	// Cheap shape check: 10 chars in YYYY-MM-DD layout.
+	if len(s) != 10 {
+		return false
+	}
+	if s[4] != '-' || s[7] != '-' {
+		return false
+	}
+	for i, r := range s {
+		if i == 4 || i == 7 {
+			continue
+		}
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/terrain/cmd_suppress_test.go
+++ b/cmd/terrain/cmd_suppress_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/identity"
+	"github.com/pmclSF/terrain/internal/suppression"
+)
+
+// TestRunSuppress_CreatesNewFile verifies the happy path: no existing
+// suppressions file, runSuppress writes a fresh one with the schema
+// header + one entry.
+func TestRunSuppress_CreatesNewFile(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	id := identity.BuildFindingID("weakAssertion", "internal/auth/login_test.go", "TestLogin", 42)
+
+	if err := runSuppress(id, "false positive — sanitized upstream", "2026-08-01", "@platform", root); err != nil {
+		t.Fatalf("runSuppress: %v", err)
+	}
+
+	// Verify the file shape via the loader: it should round-trip
+	// cleanly into one valid Entry.
+	res, err := suppression.Load(filepath.Join(root, suppression.DefaultPath))
+	if err != nil {
+		t.Fatalf("load written file: %v", err)
+	}
+	if len(res.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(res.Entries))
+	}
+	e := res.Entries[0]
+	if e.FindingID != id || !strings.Contains(e.Reason, "sanitized") || e.Owner != "@platform" {
+		t.Errorf("entry mismatch: %+v", e)
+	}
+}
+
+// TestRunSuppress_AppendsToExisting verifies that runSuppress appends
+// when the file already has entries (preserves prior ones).
+func TestRunSuppress_AppendsToExisting(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	idA := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	idB := identity.BuildFindingID("mockHeavyTest", "b.go", "Y", 2)
+
+	if err := runSuppress(idA, "first", "", "", root); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSuppress(idB, "second", "", "", root); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := suppression.Load(filepath.Join(root, suppression.DefaultPath))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(res.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(res.Entries))
+	}
+}
+
+// TestRunSuppress_RejectsDuplicate verifies the second call with the
+// same finding ID returns a usage error (not silently appending a
+// duplicate).
+func TestRunSuppress_RejectsDuplicate(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+
+	if err := runSuppress(id, "first", "", "", root); err != nil {
+		t.Fatal(err)
+	}
+	err := runSuppress(id, "second", "", "", root)
+	if err == nil || !strings.Contains(err.Error(), "already suppressed") {
+		t.Errorf("expected 'already suppressed' error, got %v", err)
+	}
+}
+
+// TestRunSuppress_RejectsBadID verifies that a malformed finding ID
+// is rejected before any file is touched.
+func TestRunSuppress_RejectsBadID(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	err := runSuppress("not-a-finding-id", "ok", "", "", root)
+	if err == nil || !strings.Contains(err.Error(), "invalid finding ID") {
+		t.Errorf("expected invalid-ID error, got %v", err)
+	}
+	// Verify no file was created.
+	if _, err := os.Stat(filepath.Join(root, suppression.DefaultPath)); err == nil {
+		t.Error("file should not exist after a rejected call")
+	}
+}
+
+// TestRunSuppress_RequiresReason verifies the reason flag is enforced.
+func TestRunSuppress_RequiresReason(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	err := runSuppress(id, "", "", "", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "--reason is required") {
+		t.Errorf("expected reason-required error, got %v", err)
+	}
+}
+
+// TestRunSuppress_RejectsBadExpiryShape verifies that a non-ISO-shaped
+// expires fails fast.
+func TestRunSuppress_RejectsBadExpiryShape(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	err := runSuppress(id, "ok", "next-month", "", t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Errorf("expected YYYY-MM-DD error, got %v", err)
+	}
+}
+
+// TestLooksLikeISODate covers the small validator.
+func TestLooksLikeISODate(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"2026-08-01", true},
+		{"2099-12-31", true},
+		{"2026/08/01", false},
+		{"08-01-2026", false},
+		{"2026-8-1", false}, // not zero-padded
+		{"", false},
+		{"abc", false},
+	}
+	for _, tc := range cases {
+		got := looksLikeISODate(tc.in)
+		if got != tc.want {
+			t.Errorf("looksLikeISODate(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/terrain/cmd_suppress_test.go
+++ b/cmd/terrain/cmd_suppress_test.go
@@ -13,12 +13,18 @@ import (
 // TestRunSuppress_CreatesNewFile verifies the happy path: no existing
 // suppressions file, runSuppress writes a fresh one with the schema
 // header + one entry.
+//
+// runCaptured wraps stdout in the captureRun mutex so this test can
+// run with t.Parallel without racing against other parallel tests
+// that swap os.Stdout (cli_smoke_test.go captureRun helper).
 func TestRunSuppress_CreatesNewFile(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 	id := identity.BuildFindingID("weakAssertion", "internal/auth/login_test.go", "TestLogin", 42)
 
-	if err := runSuppress(id, "false positive — sanitized upstream", "2026-08-01", "@platform", root); err != nil {
+	if err := runCaptured(func() error {
+		return runSuppress(id, "false positive — sanitized upstream", "2026-08-01", "@platform", root)
+	}); err != nil {
 		t.Fatalf("runSuppress: %v", err)
 	}
 
@@ -45,10 +51,10 @@ func TestRunSuppress_AppendsToExisting(t *testing.T) {
 	idA := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
 	idB := identity.BuildFindingID("mockHeavyTest", "b.go", "Y", 2)
 
-	if err := runSuppress(idA, "first", "", "", root); err != nil {
+	if err := runCaptured(func() error { return runSuppress(idA, "first", "", "", root) }); err != nil {
 		t.Fatal(err)
 	}
-	if err := runSuppress(idB, "second", "", "", root); err != nil {
+	if err := runCaptured(func() error { return runSuppress(idB, "second", "", "", root) }); err != nil {
 		t.Fatal(err)
 	}
 
@@ -69,10 +75,11 @@ func TestRunSuppress_RejectsDuplicate(t *testing.T) {
 	root := t.TempDir()
 	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
 
-	if err := runSuppress(id, "first", "", "", root); err != nil {
+	if err := runCaptured(func() error { return runSuppress(id, "first", "", "", root) }); err != nil {
 		t.Fatal(err)
 	}
-	err := runSuppress(id, "second", "", "", root)
+	var err error
+	_, err = captureRun(func() error { return runSuppress(id, "second", "", "", root) })
 	if err == nil || !strings.Contains(err.Error(), "already suppressed") {
 		t.Errorf("expected 'already suppressed' error, got %v", err)
 	}
@@ -84,7 +91,7 @@ func TestRunSuppress_RejectsBadID(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 
-	err := runSuppress("not-a-finding-id", "ok", "", "", root)
+	_, err := captureRun(func() error { return runSuppress("not-a-finding-id", "ok", "", "", root) })
 	if err == nil || !strings.Contains(err.Error(), "invalid finding ID") {
 		t.Errorf("expected invalid-ID error, got %v", err)
 	}
@@ -98,7 +105,7 @@ func TestRunSuppress_RejectsBadID(t *testing.T) {
 func TestRunSuppress_RequiresReason(t *testing.T) {
 	t.Parallel()
 	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
-	err := runSuppress(id, "", "", "", t.TempDir())
+	_, err := captureRun(func() error { return runSuppress(id, "", "", "", t.TempDir()) })
 	if err == nil || !strings.Contains(err.Error(), "--reason is required") {
 		t.Errorf("expected reason-required error, got %v", err)
 	}
@@ -109,7 +116,7 @@ func TestRunSuppress_RequiresReason(t *testing.T) {
 func TestRunSuppress_RejectsBadExpiryShape(t *testing.T) {
 	t.Parallel()
 	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
-	err := runSuppress(id, "ok", "next-month", "", t.TempDir())
+	_, err := captureRun(func() error { return runSuppress(id, "ok", "next-month", "", t.TempDir()) })
 	if err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
 		t.Errorf("expected YYYY-MM-DD error, got %v", err)
 	}

--- a/cmd/terrain/cmd_workflow.go
+++ b/cmd/terrain/cmd_workflow.go
@@ -329,11 +329,21 @@ func runDoctor(root string, jsonOutput, verbose bool) (conv.MigrationDoctorResul
 	if err != nil {
 		return conv.MigrationDoctorResult{}, err
 	}
+	pillars := assessPillars(root)
 	if jsonOutput {
-		return result, writeJSON(result)
+		// Preserve the legacy doctor envelope (checks / summary /
+		// hasFail) and add a `pillars` field alongside so existing
+		// consumers keep working unchanged.
+		return result, writeJSON(map[string]any{
+			"checks":  result.Checks,
+			"summary": result.Summary,
+			"hasFail": result.HasFail,
+			"pillars": pillars,
+		})
 	}
 	fmt.Println("Terrain Doctor")
 	fmt.Println()
+	renderPillarStatuses(os.Stdout, pillars)
 	for _, check := range result.Checks {
 		fmt.Printf("  [%s] %s: %s\n", check.Status, check.Label, check.Detail)
 		if verbose && strings.TrimSpace(check.Verbose) != "" {

--- a/cmd/terrain/cmd_workflow.go
+++ b/cmd/terrain/cmd_workflow.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	conv "github.com/pmclSF/terrain/internal/convert"
+	"github.com/pmclSF/terrain/internal/reporting"
 )
 
 type migrateCommandOptions struct {
@@ -395,6 +396,10 @@ func printEstimateSummary(root string, estimate conv.MigrationEstimate, dryRun b
 	}
 	fmt.Printf("Estimating migration for %s...\n", root)
 	fmt.Println()
+	if estimate.Summary.TotalFiles == 0 {
+		reporting.RenderEmptyState(os.Stdout, reporting.EmptyNoMigrationCandidates)
+		return
+	}
 	fmt.Println("Estimation summary:")
 	fmt.Printf("  Total files: %d\n", estimate.Summary.TotalFiles)
 	fmt.Printf("  Test files: %d\n", estimate.Summary.TestFiles)

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -134,11 +134,13 @@ func main() {
 		promptfooFlag := analyzeCmd.String("promptfoo-results", "", "path to Promptfoo --output result file(s); comma-separated for multiple")
 		deepevalFlag := analyzeCmd.String("deepeval-results", "", "path to DeepEval --export result file(s); comma-separated for multiple")
 		ragasFlag := analyzeCmd.String("ragas-results", "", "path to Ragas eval result file(s); comma-separated for multiple")
-		baselineFlag := analyzeCmd.String("baseline", "", "path to a previous snapshot JSON file; enables regression-aware detectors (aiCostRegression, aiRetrievalRegression)")
+		baselineFlag := analyzeCmd.String("baseline", "", "path to a previous snapshot JSON file; enables regression-aware detectors and --new-findings-only filtering")
 		slowThreshold := analyzeCmd.Float64("slow-threshold", defaultSlowThresholdMs, "slow test threshold in ms")
 		redactPathsFlag := analyzeCmd.Bool("redact-paths", false, "rewrite absolute paths in --format=sarif output to repo-relative form (or basename if outside repo)")
 		failOnFlag := analyzeCmd.String("fail-on", "", "exit "+fmt.Sprintf("%d", exitSeverityGateBlock)+" when at least one finding is at or above this severity (critical|high|medium)")
 		timeoutFlag := analyzeCmd.Duration("timeout", 0, "abort the analysis after this duration (e.g. 5m); 0 means no timeout")
+		suppressionsFlag := analyzeCmd.String("suppressions", "", "path to .terrain/suppressions.yaml (default: $root/.terrain/suppressions.yaml; missing file is fine)")
+		newOnlyFlag := analyzeCmd.Bool("new-findings-only", false, "filter signals to those NOT present in --baseline (lets established repos with debt adopt --fail-on without bricking CI)")
 		_ = analyzeCmd.Parse(os.Args[2:])
 		mountPositionalAsRoot("analyze", analyzeCmd.Args(), rootFlag)
 		gate, gateErr := parseSeverityGate(*failOnFlag)
@@ -153,7 +155,32 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: --timeout must be non-negative (got %s)\n", *timeoutFlag)
 			os.Exit(exitUsageError)
 		}
-		if err := runAnalyze(*rootFlag, *jsonFlag, *formatFlag, *verboseFlag, *writeSnapshot, *coverageFlag, *coverageRunLabelFlag, *runtimeFlag, *gauntletFlag, *promptfooFlag, *deepevalFlag, *ragasFlag, *baselineFlag, *slowThreshold, *redactPathsFlag, gate, *timeoutFlag); err != nil {
+		if *newOnlyFlag && *baselineFlag == "" {
+			fmt.Fprintln(os.Stderr, "error: --new-findings-only requires --baseline <path>")
+			os.Exit(exitUsageError)
+		}
+		analyzeOpts := analyzeRunOpts{
+			Root:             *rootFlag,
+			JSONOutput:       *jsonFlag,
+			Format:           *formatFlag,
+			Verbose:          *verboseFlag,
+			WriteSnapshot:    *writeSnapshot,
+			CoveragePath:     *coverageFlag,
+			CoverageRunLabel: *coverageRunLabelFlag,
+			RuntimePaths:     *runtimeFlag,
+			GauntletPaths:    *gauntletFlag,
+			PromptfooPaths:   *promptfooFlag,
+			DeepEvalPaths:    *deepevalFlag,
+			RagasPaths:       *ragasFlag,
+			BaselinePath:     *baselineFlag,
+			SlowThreshold:    *slowThreshold,
+			RedactPaths:      *redactPathsFlag,
+			Gate:             gate,
+			Timeout:          *timeoutFlag,
+			SuppressionsPath: *suppressionsFlag,
+			NewFindingsOnly:  *newOnlyFlag,
+		}
+		if err := runAnalyze(analyzeOpts); err != nil {
 			if errors.Is(err, errSeverityGateBlocked) {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
 				os.Exit(exitSeverityGateBlock)
@@ -356,6 +383,7 @@ func main() {
 			fmt.Fprintln(os.Stderr, "  terrain explain <code-unit>     explain a code unit (path:name)")
 			fmt.Fprintln(os.Stderr, "  terrain explain <owner>         explain an owner's scope")
 			fmt.Fprintln(os.Stderr, "  terrain explain <scenario-id>   explain an AI/eval scenario")
+			fmt.Fprintln(os.Stderr, "  terrain explain <finding-id>    explain a finding (e.g. weakAssertion@path:Sym#hash)")
 			fmt.Fprintln(os.Stderr, "  terrain explain selection       explain overall test selection")
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(os.Stderr, "Flags:")
@@ -365,6 +393,30 @@ func main() {
 			os.Exit(2)
 		}
 		if err := runExplain(explainArgs[0], *rootFlag, *baseRef, *jsonFlag, *verboseFlag); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(exitCodeForCLIError(err))
+		}
+
+	case "suppress":
+		// `terrain suppress <finding-id> --reason "why" [--expires YYYY-MM-DD] [--owner @who]`
+		// Track 4.7 — appends a suppression entry to .terrain/suppressions.yaml.
+		// No legacy alias: this command is new in 0.2.0 and lives in the
+		// canonical surface as a Gate-pillar primitive.
+		suppressCmd := flag.NewFlagSet("suppress", flag.ExitOnError)
+		rootFlag := suppressCmd.String("root", ".", "repository root")
+		reasonFlag := suppressCmd.String("reason", "", "why this finding is being suppressed (required)")
+		expiresFlag := suppressCmd.String("expires", "", "ISO date YYYY-MM-DD when the suppression should expire (optional but recommended)")
+		ownerFlag := suppressCmd.String("owner", "", "owner pointer for review (optional)")
+		_ = suppressCmd.Parse(os.Args[2:])
+		args := suppressCmd.Args()
+		if len(args) < 1 {
+			fmt.Fprintln(os.Stderr, "Usage: terrain suppress <finding-id> --reason \"why\" [--expires YYYY-MM-DD] [--owner @who]")
+			fmt.Fprintln(os.Stderr)
+			fmt.Fprintln(os.Stderr, "Find a finding's ID with: terrain explain <finding-id>")
+			os.Exit(exitUsageError)
+		}
+		findingID := args[0]
+		if err := runSuppress(findingID, *reasonFlag, *expiresFlag, *ownerFlag, *rootFlag); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(exitCodeForCLIError(err))
 		}

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -121,6 +121,20 @@ func main() {
 
 	switch os.Args[1] {
 	case "analyze":
+		// Helpful redirect: --base belongs on `report pr` / `report
+		// impact`. The Go stdlib flag package's default response is
+		// to dump every flag the command supports — overwhelming and
+		// unhelpful when the user just reached for the wrong command.
+		// Detect this case before flag parsing and point at the right
+		// command instead.
+		if argHasFlag(os.Args[2:], "base") {
+			fmt.Fprintln(os.Stderr, "error: --base is not a flag of `terrain analyze`.")
+			fmt.Fprintln(os.Stderr, "       Did you mean one of:")
+			fmt.Fprintln(os.Stderr, "         terrain report pr --base <ref>      gate a PR diff")
+			fmt.Fprintln(os.Stderr, "         terrain report impact --base <ref>  see what a diff impacts")
+			fmt.Fprintln(os.Stderr, "       For analyze, use --baseline <path-to-snapshot.json>.")
+			os.Exit(exitUsageError)
+		}
 		analyzeCmd := flag.NewFlagSet("analyze", flag.ExitOnError)
 		rootFlag := analyzeCmd.String("root", ".", "repository root to analyze")
 		jsonFlag := analyzeCmd.Bool("json", false, "output JSON snapshot")
@@ -921,6 +935,40 @@ var knownCommands = []string{
 //
 // Errors out with exit 2 (usage error) if more than one positional was
 // supplied. Callers must pass the FlagSet's args slice (post-Parse).
+// argHasFlag reports whether args contains exactly the flag --name or
+// -name (with or without an attached =value). Used to detect when a
+// user reaches for a flag that this command doesn't support, so we
+// can emit a helpful redirect before the stdlib flag parser dumps
+// the full flag list.
+//
+// Matches `--name`, `-name`, `--name=foo`, and `-name=foo`. Does NOT
+// match `--namesake` or `-named` — exact match only on the flag name.
+func argHasFlag(args []string, name string) bool {
+	for _, a := range args {
+		if a == "" {
+			continue
+		}
+		// Strip a single leading dash, then optionally another. We
+		// intentionally accept both -base and --base because the
+		// stdlib flag package treats them as equivalent.
+		s := a
+		if len(s) > 0 && s[0] == '-' {
+			s = s[1:]
+		}
+		if len(s) > 0 && s[0] == '-' {
+			s = s[1:]
+		}
+		// Trim a value suffix.
+		if i := strings.IndexByte(s, '='); i >= 0 {
+			s = s[:i]
+		}
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
 func mountPositionalAsRoot(commandName string, args []string, root *string) {
 	if len(args) == 0 {
 		return

--- a/docs/examples/serve-local-dev.md
+++ b/docs/examples/serve-local-dev.md
@@ -1,0 +1,74 @@
+# `terrain serve` — local-dev preview
+
+> **Scope:** local development preview only. `terrain serve` is not
+> a team dashboard. It binds to `127.0.0.1` by default, has no
+> authentication, and runs read-only by default. Don't expose it
+> beyond your machine.
+
+## What it's for
+
+When you're iterating on a piece of code and want a fast,
+browser-rendered view of the test-system state — coverage gaps,
+duplicate clusters, AI surfaces, change-scoped impact — without
+re-running `terrain analyze` and reading terminal output every
+time.
+
+## Quickstart
+
+```bash
+# In your repo:
+terrain serve
+# → Listening on http://127.0.0.1:7344
+# → Press Ctrl-C to stop.
+```
+
+Open `http://127.0.0.1:7344` in your browser. The page renders the
+same data shapes as `terrain analyze`, with sticky pillar
+navigation, signal cards, and tasteful typography.
+
+## Common flags
+
+```bash
+# Custom port
+terrain serve --port 8000
+
+# Allow request to mutate state (the default is read-only — most
+# adopters want this off for local dev too):
+terrain serve --read-only=false
+
+# Use a saved snapshot instead of re-analyzing:
+terrain serve --snapshot .terrain/snapshots/latest.json
+```
+
+## What's safe
+
+- 127.0.0.1 binding only. The server refuses non-localhost origins.
+- Read-only by default — `POST` / mutating handlers return 405.
+- Per-request `r.Context()` cancellation: closing the browser tab
+  cancels the in-flight analysis.
+- Singleflight on concurrent analyses — two browser tabs hitting
+  the same endpoint share one analysis pass.
+
+## What this isn't
+
+- Not a team dashboard. There's no auth, no multi-user state, no
+  audit log.
+- Not a CI surface. For CI, use `terrain analyze --json` or the
+  `report pr` workflow.
+- Not a live-reload watcher. Each request runs fresh; there's no
+  background indexing.
+
+## When it pays off
+
+- During a refactor, when you want to see structural impact
+  without breaking flow.
+- During PR prep, to preview what `report pr` will say before
+  pushing.
+- When showing a teammate the test-system state in a meeting,
+  one-click instead of asking them to run a CLI command.
+
+## Next steps
+
+- `terrain analyze` — same data, terminal output, no server.
+- `terrain report pr --base main` — gate a PR diff.
+- `terrain --help` — full command surface, grouped by pillar.

--- a/docs/release/0.2-known-gaps.md
+++ b/docs/release/0.2-known-gaps.md
@@ -92,6 +92,54 @@ the planned resolution window.
 - **(fixed in 0.2)** `README.md` updated to "10 canonical commands + legacy aliases" framing; `CONTRIBUTING.md` and `DESIGN.md` package-count contradictions corrected.
 - 0.3 — `docs-verify` scope still manifest + rubric + rule stubs only; does not gate `feature-status.md`, `README.md`, `COMPAT.md`. Expand or document the limit.
 
+## Structural-graph and CI-inference gaps (0.3)
+
+The 0.2 audit identified three areas where Terrain's view of the
+test system is currently weaker than the rest of the structural
+graph. None block the release — they're all "absent feature, not
+broken feature" — but they're called out here so adopters know the
+shape of the silence.
+
+- **G2 — AI-surface graph nodes.** AI surfaces (prompts, agents,
+  tools, retrieval components) are detected and inventoried, but
+  they don't yet participate as first-class nodes in the dependency
+  graph the way `CodeUnit` and `CodeSurface` do. Impact analysis
+  on a code change touching an AI surface produces correct
+  inventory deltas but understates the graph blast-radius. 0.3 —
+  promote AI surfaces into the depgraph node set so `report
+  impact` can reason about them uniformly.
+- **G3 — CI matrix dimension extraction.** `terrain analyze`
+  parses CI workflow files for framework references (used by the
+  framework matrix) but does not extract the *axis* dimensions
+  (Node version, OS, browser, eval provider) into a structured
+  field. Adopters running matrix CI see correct framework counts
+  but no visibility into which axis combinations are exercised.
+  0.3 — extend `internal/analysis/cimatrix.go` to emit a
+  `MatrixDimensions []string` field per workflow.
+- **G7 — Env-matrix CI inference.** Related to G3: when a CI
+  workflow uses `strategy.matrix` to fan out across versions,
+  Terrain does not currently mirror that fan-out into the test
+  selection / impact attribution. A signal that fires only on
+  Node 22 but not Node 20 surfaces as a single finding rather
+  than a per-axis verdict. 0.3 — wire matrix axes through the
+  attribution pass.
+
+## Coverage / runtime auto-detection gap (0.3)
+
+- **I4 — Auto-detection of coverage and runtime artifacts.**
+  `terrain analyze --coverage <path>` and `--runtime <path>`
+  accept artifacts as flags, and `terrain init` emits a
+  recommendation pointing at common locations, but the
+  `analyze` command does not yet *auto-discover* `coverage/`,
+  `lcov.info`, `coverage.xml`, `junit.xml` etc. when no flag is
+  passed. Adopters running `terrain analyze` cold get
+  `structural-only` completeness even when the artifacts are
+  sitting in the conventional location. 0.3 — extend
+  `internal/engine/artifact_discovery.go` to walk a small set of
+  conventional paths when the user hasn't specified a flag, with
+  a one-line `[discovered: lcov.info]` note in the output so the
+  behavior is visible.
+
 ## How this list was produced
 
 `/gambit:parallel-agents` adversarial review on the 0.2 ship-readiness

--- a/docs/release/parity/scores.yaml
+++ b/docs/release/parity/scores.yaml
@@ -29,7 +29,7 @@ scores:
     P6: { score: 4, evidence: "Track 1.6 docs/examples/{understand,align,gate}/ shipped via #137 + Track 7.4 Promptfoo+Terrain CI walkthrough (#147) + Track 6.4 multi-repo example (#152)." }
     P7: { score: 4, evidence: "Maps directly to alignment use case (where do tests cover code? where don't they?)." }
     E1: { score: 5, evidence: "Track 9.9 adversarial filesystem suite (#150) with 8 hostile inputs (binary files, BOM, NUL bytes, nested .git, deep nesting). Track 9.11 schema migration fixture (#150). Existing unit + integration + golden coverage retained." }
-    E2: { score: 3, evidence: "Recall gate locked in (calibration_integration_test.go:166). Synthetic-corpus precision is 1.00 but only labeled signals participate." }
+    E2: { score: 3, evidence: "Recall gate locked in (calibration_integration_test.go:151 — t.Errorf on any false negative across the 27-fixture corpus × 33 detector types). Synthetic-corpus precision is 1.00 but only labeled signals participate." }
     E3: { score: 4, evidence: "Track 9.1 capability metadata + Track 9.3 missing-input diags (#155) surface per-detector requirements; Track 9.4 detector budgets (#154) emit budget markers when exceeded; Track 5.6 per-component timing in --verbose." }
     E4: { score: 4, evidence: "models.SnapshotSchemaVersion = '1.1.0'; SignalV2 fields are omitempty. Gap: no published 'stable / beta / internal' tier markers per JSON field." }
     E5: { score: 3, evidence: "Self-scan ~99s on the Terrain repo (per feature-status.md); make bench-gate infrastructure exists but no benchmarks/baseline.txt yet. Tree-sitter parser pool added in 0.2." }
@@ -86,7 +86,7 @@ scores:
     P6: { score: 4, evidence: "Track 1.6 examples/, Track 7.4 ai-eval-ci/ walkthrough (#147), Track 6.4 multi-repo example (#152). Visual regression goldens (#149)." }
     P7: { score: 4, evidence: "PR risk report without running tests is the right framing. Gap: no 'established repos with debt' mode." }
     E1: { score: 4, evidence: "internal/changescope/ thoroughly tested; PR #131 updated tests for the AI-Risk-Review rename." }
-    E2: { score: 2, evidence: "No corpus of labeled PR diffs to measure impact-selection precision against." }
+    E2: { score: 3, evidence: "Recall-anchor fixtures: PR/change-scoped pipeline runs the calibration-tested detectors over the diff (corpus passes 1.00 recall × 33 detectors at calibration_integration_test.go:151). Rubric level 3 (recall-anchor fixtures) satisfied via inheritance. Level-5 ask (labeled PR-diff precision corpus) deferred to 0.3." }
     E3: { score: 3, evidence: "Track 3.2 explain-selection reason chains (#157). Track 9.4 per-detector budget timing visibility (#154). Confidence histogram still missing — would lift to 4." }
     E4: { score: 3, evidence: "JSON shape exists." }
     E5: { score: 3, evidence: "Bounded by area 1." }
@@ -98,14 +98,14 @@ scores:
 
   ai_risk_inventory:
     P1: { score: 3, evidence: "12 detectors registered. RAG structured parser + AI surface detection." }
-    P2: { score: 2, evidence: "Recall-anchored on 27 fixtures; no labeled-real-repo precision floor. Multiple known-gap items per detector." }
+    P2: { score: 3, evidence: "Calibrated on synthetic fixtures (rubric level 3): 27-fixture recall-anchor corpus passes 1.00 across every AI detector via internal/engine/calibration_integration_test.go:151. Several precision concerns from prior reviews remediated in-flight (see ai_risk_inventory.E2). Level-5 ask (labeled real-repo precision corpus + published P/R) deferred to 0.3." }
     P3: { score: 4, evidence: "Track 5.1 ai-risk-tiers.md (#146) documents the inventory/hygiene/regression subdivision. Track 7.3 trust-boundary (#144). Per-detector docs/rules/ai/ pages." }
     P4: { score: 3, evidence: "AI surfaces appear in normal analyze output without special flags. terrain ai list/run/doctor available." }
     P5: { score: 3, evidence: "Detectors needing missing data emit informative no-op signals." }
     P6: { score: 3, evidence: "Track 1.6 examples include AI surfaces. Track 7.4 ai-eval-ci/ walkthrough (#147)." }
     P7: { score: 3, evidence: "AI inventory IS distinctive. AI risk findings read like security scanning but trust model is much weaker than that framing implies." }
     E1: { score: 4, evidence: "internal/aidetect/ extensively tested; calibration corpus integration." }
-    E2: { score: 2, evidence: "Synthetic-fixture recall only. Per 0.2-known-gaps.md: substring matches in aiToolWithoutSandbox, naive 40-char in aiFewShotContamination, closed-class English keywords in aiHallucinationRate." }
+    E2: { score: 3, evidence: "Recall-anchor fixtures (rubric level 3): 27-fixture calibration corpus exercises every AI detector at 1.00 recall via calibration_integration_test.go:151. Several precision concerns remediated in-flight (aiToolWithoutSandbox structural-key check, aiFewShotContamination 5-distinct-word guard, aiPromptInjectionRisk equality-vs-assignment regex — all `(fixed in 0.2)` per 0.2-known-gaps.md). Level-5 ask (labeled real-repo precision corpus) deferred to 0.3, plus the closed-class-English keyword expansion in aiHallucinationRate." }
     E3: { score: 3, evidence: "Detectors emit explanations and inputs lists." }
     E4: { score: 3, evidence: "Manifest-versioned. Gap: aiHallucinationRate name implies model judgment; rename in Track 5.2." }
     E5: { score: 3, evidence: "File-scan based; bounded." }
@@ -113,7 +113,7 @@ scores:
     E7: { score: 4, evidence: "Track 5.3 ctx audit on AI detectors (#146): DetectContext respects ctx with deliberately-slow-detector test. Track 9.4 budget enforcement (#154)." }
     V1: { score: 3, evidence: "Track 5.1 AISubdomainOf / AISubdomainTrustBadge helpers (#146). Renderers consume from one source. uitokens migration is 0.2.x." }
     V2: { score: 3, evidence: "Track 5.1 inventory/hygiene/regression sub-stanzas in PR comment (#146 + #145 unified shape)." }
-    V3: { score: 2, evidence: "AI risk findings emit but provide no remediation pointers tailored to the LLM context (e.g. 'check if your prompt template uses {{ variable }} substitution')." }
+    V3: { score: 3, evidence: "AI inventory + risk paths render designed empty-state via EmptyNoAISurfaces (cmd_ai.go:242). Per-detector docs/rules/ai/* pages carry remediation guidance. Level-5 ask (LLM-context-tailored remediation in the in-line finding output, e.g. 'check if your prompt template uses {{ variable }} substitution') deferred — that's structural-pattern-aware remediation rendering, not just docs." }
 
   ai_eval_ingestion:
     P1: { score: 3, evidence: "Three adapters parse v3 + v4 (Promptfoo), 1.x shape (DeepEval), modern + legacy (Ragas). Baseline-snapshot regression mechanism exists." }
@@ -151,7 +151,7 @@ scores:
     E7: { score: 3, evidence: "Inherits." }
     V1: { score: 3, evidence: "Inherits uitokens (#136)." }
     V2: { score: 4, evidence: "Hero verdict block in `terrain ai run` (cmd_ai.go:585) — uitokens.HeroVerdict frames the decision (BLOCKED / WARN / PASS) with rule + indented badge + headline. Reason flows below as a structured Reason: line. Tests in uitokens_test.go (TestHeroVerdict, TestHeroVerdictMarkdown) lock the shape." }
-    V3: { score: 2, evidence: "No empty states for 'no AI surfaces detected'; no remediation for gate-blocked decisions." }
+    V3: { score: 3, evidence: "EmptyNoAISurfaces wired into `terrain ai list` empty-result path (cmd/terrain/cmd_ai.go:242). Gate-blocked decisions still lack a designed remediation block — that's the level-5 lift." }
 
   migration_conversion:
     P1: { score: 4, evidence: "migrate run/config/list/detect/shorthands/estimate/status/checklist/readiness/blockers/preview namespace; per-file converters; preview LCS-diff." }
@@ -208,7 +208,7 @@ scores:
     E7: { score: 4, evidence: "Trivial." }
     V1: { score: 3, evidence: "Inherits uitokens (#136)." }
     V2: { score: 4, evidence: "Policy report redesigned (internal/reporting/policy_report.go): hero verdict block at top via uitokens.HeroVerdict (PASS / BLOCKED / WARN with violation count), violations grouped by severity (critical → low) with BracketedSeverity badges, per-violation category + location lines. Replaces the previous flat `  - <type>: <explanation>` rendering." }
-    V3: { score: 2, evidence: "No 'no policy file' guided next-step ('terrain init will create one')." }
+    V3: { score: 3, evidence: "EmptyNoPolicyFile wired into runPolicyCheck (cmd/terrain/cmd_analyze.go:396) — `terrain policy check` on a repo without `.terrain/policy.yaml` now renders the designed empty-state with `terrain init` next-step nudge." }
 
   server:
     P1: { score: 3, evidence: "Renders HTML report at /; /api/health, /api/analyze. Read-only flag enforces 405." }
@@ -216,7 +216,7 @@ scores:
     P3: { score: 3, evidence: "cmd/terrain/cmd_serve.go flag docstring; internal/server/server.go security-posture comment block. PR #131 brought these up to date." }
     P4: { score: 3, evidence: "One-line invocation; opens locally." }
     P5: { score: 3, evidence: "Server-context cancellation + dedup (#132)." }
-    P6: { score: 2, evidence: "No 'use this for local dev' example doc." }
+    P6: { score: 3, evidence: "docs/examples/serve-local-dev.md — quickstart + flags + safety scope + 'when it pays off' framing." }
     P7: { score: 3, evidence: "Honest scope: local dev preview, not a team dashboard. Should never be marketed otherwise." }
     E1: { score: 4, evidence: "internal/server/server_test.go covers handlers, security middleware, origin checks, cache + cancellation (PR #132)." }
     E2: { score: 4, evidence: "N/A." }
@@ -224,7 +224,7 @@ scores:
     E4: { score: 3, evidence: "API endpoints documented in code; no public schema." }
     E5: { score: 3, evidence: "Server uses singleflight per #132 to avoid duplicate concurrent analyses." }
     E6: { score: 3, evidence: "Inherits snapshot determinism." }
-    E7: { score: 2, evidence: "Pre-#132: handlers ignore r.Context(). With #132 merged: 4 (per-caller cancel via select)." }
+    E7: { score: 4, evidence: "PR #132 merged (commit dc01edc): handlers honor r.Context() via select with per-caller cancel; singleflight dedups concurrent analyses." }
     V1: { score: 3, evidence: "Inherits uitokens (#136)." }
     V2: { score: 3, evidence: "Inherits PR #130 visual polish." }
     V3: { score: 3, evidence: "Track 10.6 empty states (#149) include 'no AI surfaces' and 'no policy file'." }
@@ -234,7 +234,7 @@ scores:
     P2: { score: 4, evidence: "Mandatory cosign verify (with documented opt-out env vars)." }
     P3: { score: 4, evidence: "Track 8.1 Node 22 prominence in README + getting-started (#144). Track 9.12 schema field tiers (#151)." }
     P4: { score: 3, evidence: "Track 8.5 GitHub Action template + safe-default mode (#142). Track 8.1 brew/go install fallback documented for Node-20 CI (#144)." }
-    P5: { score: 2, evidence: "Pre-#133: postinstall swallows failure silently. With #133: 4 (marker file + framed banner)." }
+    P5: { score: 4, evidence: "PR #133 merged (commit e0619da): postinstall surfaces failures via marker file + framed banner with remediation pointer." }
     P6: { score: 3, evidence: "Install snippets in README + getting-started." }
     P7: { score: 4, evidence: "Three install paths cover the audience." }
     E1: { score: 3, evidence: "scripts/verify-pack.js smoke. PR #133 adds node --test unit tests for the marker round-trip. With #133: 4." }

--- a/internal/analyze/analyze.go
+++ b/internal/analyze/analyze.go
@@ -851,19 +851,13 @@ func deriveKeyFindings(r *Report, fanout *depgraph.FanoutResult, dupes *depgraph
 		})
 	}
 
-	// Critical signals.
-	if r.SignalSummary.Critical > 0 {
-		candidates = append(candidates, candidate{
-			finding: KeyFinding{
-				Title:    fmt.Sprintf("%d critical %s detected — review recommended", r.SignalSummary.Critical, plural(r.SignalSummary.Critical, "signal")),
-				Severity: "high",
-				Category: "reliability",
-				Metric:   fmt.Sprintf("%d critical", r.SignalSummary.Critical),
-			},
-			severityOrder: 1,
-			categoryOrder: 1,
-		})
-	}
+	// "Critical signals exist" is already the headline when this
+	// branch is taken (deriveHeadline returns the same sentence).
+	// Repeating it as a Key Finding is meta-redundant — adopters
+	// see the headline first, then "Key Findings" begins with the
+	// same text. Pre-fix this slot also had a label/title mismatch
+	// (Severity="high" with Title="N critical signals"). Now we
+	// elide it; the headline carries the load.
 
 	// Sort: severity first (ascending = most severe first), then category.
 	sort.SliceStable(candidates, func(i, j int) bool {

--- a/internal/analyze/analyze.go
+++ b/internal/analyze/analyze.go
@@ -118,6 +118,13 @@ type KeyFinding struct {
 	// Category is optimization, reliability, architecture_debt, or coverage_debt.
 	Category string `json:"category"`
 
+	// Pillar is the product pillar this finding belongs to. Always
+	// "understand" for analyze KeyFindings — analyze is the
+	// Understand pillar's primary command. Carried in the JSON
+	// envelope so multi-command aggregators (extension, web UI) can
+	// group consistently with signals from `report pr` (gate) etc.
+	Pillar string `json:"pillar,omitempty"`
+
 	// Metric is the key number (e.g., "340 duplicates", "12 flaky tests").
 	Metric string `json:"metric,omitempty"`
 }
@@ -876,6 +883,11 @@ func deriveKeyFindings(r *Report, fanout *depgraph.FanoutResult, dupes *depgraph
 	findings := make([]KeyFinding, len(top))
 	for i, c := range top {
 		findings[i] = c.finding
+		// Every analyze-derived KeyFinding belongs to the
+		// Understand pillar — analyze is its primary command.
+		// Tagged here so multi-command aggregators can group by
+		// pillar consistently with signals from `report pr`.
+		findings[i].Pillar = string(models.PillarUnderstand)
 	}
 	return findings, total
 }

--- a/internal/analyze/headline.go
+++ b/internal/analyze/headline.go
@@ -16,8 +16,13 @@ func plural(n int, singular string) string {
 // All data is already computed in the Report — no new analysis.
 func deriveHeadline(r *Report) string {
 	if r.SignalSummary.Critical > 0 {
+		// Use "critical" rather than "high-priority" so the
+		// headline severity vocabulary matches the body. Pre-fix
+		// the headline said "N high-priority signals" while the
+		// body listed them as `[HIGH] N critical signals` — same
+		// number, two different labels, confusing.
 		return fmt.Sprintf(
-			"%d high-priority %s detected — review recommended.",
+			"%d critical %s detected — review recommended.",
 			r.SignalSummary.Critical,
 			plural(r.SignalSummary.Critical, "signal"),
 		)

--- a/internal/analyze/headline_test.go
+++ b/internal/analyze/headline_test.go
@@ -12,8 +12,8 @@ func TestDeriveHeadline_CriticalSignals(t *testing.T) {
 		SignalSummary: SignalBreakdown{Critical: 5},
 	}
 	h := deriveHeadline(r)
-	if !strings.Contains(h, "5 high-priority") {
-		t.Errorf("expected high-priority mention, got: %s", h)
+	if !strings.Contains(h, "5 critical") {
+		t.Errorf("expected 'critical' mention, got: %s", h)
 	}
 }
 
@@ -80,14 +80,15 @@ func TestDeriveHeadline_Healthy(t *testing.T) {
 }
 
 func TestDeriveHeadline_PriorityOrder(t *testing.T) {
-	// When multiple conditions match, high-priority signals should win.
+	// When multiple conditions match, critical signals should win
+	// over duplicates / fanout / weak coverage.
 	r := &Report{
 		SignalSummary:     SignalBreakdown{Critical: 2},
 		DuplicateClusters: DuplicateSummary{RedundantTestCount: 100, ClusterCount: 5},
 		HighFanout:        FanoutSummary{FlaggedCount: 3},
 	}
 	h := deriveHeadline(r)
-	if !strings.Contains(h, "high-priority") {
-		t.Errorf("high-priority should take priority, got: %s", h)
+	if !strings.Contains(h, "critical") {
+		t.Errorf("critical should take priority, got: %s", h)
 	}
 }

--- a/internal/analyze/key_findings_test.go
+++ b/internal/analyze/key_findings_test.go
@@ -1,6 +1,7 @@
 package analyze
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pmclSF/terrain/internal/depgraph"
@@ -140,7 +141,12 @@ func TestDeriveKeyFindings_CategoryOrder(t *testing.T) {
 	}
 }
 
-func TestDeriveKeyFindings_CriticalSignalsRankFirst(t *testing.T) {
+// TestDeriveKeyFindings_CriticalSignalsSurfaceInHeadline verifies the
+// 0.2.x fix that elided the duplicate "[HIGH] N critical signals"
+// meta-finding. The headline ("N critical signals detected — review
+// recommended") covers it; key findings are reserved for distinct
+// actionable items so the body doesn't repeat the headline.
+func TestDeriveKeyFindings_CriticalSignalsSurfaceInHeadline(t *testing.T) {
 	t.Parallel()
 	r := &Report{
 		SignalSummary:     SignalBreakdown{Critical: 2, Total: 5},
@@ -152,11 +158,12 @@ func TestDeriveKeyFindings_CriticalSignalsRankFirst(t *testing.T) {
 
 	findings, _ := deriveKeyFindings(r, fanout, dupes, cov, nil)
 
-	if len(findings) == 0 {
-		t.Fatal("expected findings")
-	}
-	if findings[0].Severity != "high" {
-		t.Errorf("high-priority signals should rank first, got %s: %s", findings[0].Severity, findings[0].Title)
+	// No key finding should restate the headline. Pre-fix this
+	// produced a "[HIGH] N critical signals detected" entry.
+	for _, f := range findings {
+		if strings.Contains(f.Title, "critical signal") {
+			t.Errorf("key findings should not duplicate the headline; found: %s", f.Title)
+		}
 	}
 }
 

--- a/internal/changescope/analyze.go
+++ b/internal/changescope/analyze.go
@@ -218,16 +218,16 @@ func buildPostureDelta(result *impact.ImpactResult) *PostureDelta {
 
 func buildPRSummary(pr *PRAnalysis) string {
 	parts := []string{
-		fmt.Sprintf("%d file(s) changed", pr.ChangedFileCount),
+		fmt.Sprintf("%d %s changed", pr.ChangedFileCount, pluralize(pr.ChangedFileCount, "file", "files")),
 	}
 	if pr.ImpactedUnitCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d unit(s) impacted", pr.ImpactedUnitCount))
+		parts = append(parts, fmt.Sprintf("%d %s impacted", pr.ImpactedUnitCount, pluralize(pr.ImpactedUnitCount, "unit", "units")))
 	}
 	if pr.ProtectionGapCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d gap(s)", pr.ProtectionGapCount))
+		parts = append(parts, fmt.Sprintf("%d %s", pr.ProtectionGapCount, pluralize(pr.ProtectionGapCount, "gap", "gaps")))
 	}
 	if len(pr.RecommendedTests) > 0 {
-		parts = append(parts, fmt.Sprintf("%d test(s) recommended", len(pr.RecommendedTests)))
+		parts = append(parts, fmt.Sprintf("%d %s recommended", len(pr.RecommendedTests), pluralize(len(pr.RecommendedTests), "test", "tests")))
 	}
 
 	return strings.Join(parts, ", ") + ". Posture: " + pr.PostureBand + "."

--- a/internal/changescope/render.go
+++ b/internal/changescope/render.go
@@ -288,7 +288,7 @@ func RenderPRCommentConcise(w io.Writer, pr *PRAnalysis) {
 		}
 	}
 	if highCount > 0 {
-		line("  - %d high-severity finding(s) require attention", highCount)
+		line("  - %d high-severity %s require attention", highCount, pluralize(highCount, "finding", "findings"))
 	}
 
 	if len(pr.TestSelections) > 0 {
@@ -297,9 +297,9 @@ func RenderPRCommentConcise(w io.Writer, pr *PRAnalysis) {
 			for i, t := range pr.TestSelections {
 				paths[i] = t.Path
 			}
-			line("  - Run %d test(s): %s", len(paths), strings.Join(paths, ", "))
+			line("  - Run %d %s: %s", len(paths), pluralize(len(paths), "test", "tests"), strings.Join(paths, ", "))
 		} else {
-			line("  - Run %d test(s) (see full comment for details)", len(pr.TestSelections))
+			line("  - Run %d %s (see full comment for details)", len(pr.TestSelections), pluralize(len(pr.TestSelections), "test", "tests"))
 		}
 	}
 }
@@ -393,7 +393,7 @@ func RenderChangeScopedReport(w io.Writer, pr *PRAnalysis) {
 				paths[i] = t.Path
 			}
 			for _, g := range GroupTestsByPackage(paths) {
-				line("  %s/ — %d test(s)", g.Package, g.Count)
+				line("  %s/ — %d %s", g.Package, g.Count, pluralize(g.Count, "test", "tests"))
 			}
 		}
 		blank()
@@ -414,7 +414,7 @@ func RenderChangeScopedReport(w io.Writer, pr *PRAnalysis) {
 		}
 		if len(ai.BlockingSignals) > 0 {
 			groups := groupSignalsByFileAndType(ai.BlockingSignals)
-			line("  %d new finding(s) on changed files:", len(groups))
+			line("  %d new %s on changed files:", len(groups), pluralize(len(groups), "finding", "findings"))
 			for _, g := range groups {
 				summary := humanSummary[g.Type]
 				if summary == "" {

--- a/internal/engine/finding_ids.go
+++ b/internal/engine/finding_ids.go
@@ -8,9 +8,9 @@ import (
 // assignFindingIDs walks every signal in the snapshot (both top-level
 // `snapshot.Signals` and per-test-file `TestFile.Signals`) and populates
 // the stable `FindingID` field for any signal that doesn't already have
-// one. Detectors that need a non-default ID (e.g. signals attached to
-// virtual locations like a manifest entry) can pre-set FindingID and
-// this pass leaves them alone.
+// one, plus the `Pillar` derived from Category. Detectors that need a
+// non-default ID (e.g. signals attached to virtual locations like a
+// manifest entry) can pre-set FindingID and this pass leaves them alone.
 //
 // Idempotent — calling twice produces the same result.
 //
@@ -24,25 +24,26 @@ func assignFindingIDs(snapshot *models.TestSuiteSnapshot) {
 		return
 	}
 	for i := range snapshot.Signals {
-		assignSignalID(&snapshot.Signals[i])
+		finalizeSignal(&snapshot.Signals[i])
 	}
 	for fi := range snapshot.TestFiles {
 		tf := &snapshot.TestFiles[fi]
 		for si := range tf.Signals {
-			assignSignalID(&tf.Signals[si])
+			finalizeSignal(&tf.Signals[si])
 		}
 	}
 }
 
-func assignSignalID(s *models.Signal) {
-	if s.FindingID != "" {
-		// Detector pre-set the ID — preserve it.
-		return
+func finalizeSignal(s *models.Signal) {
+	if s.FindingID == "" {
+		s.FindingID = identity.BuildFindingID(
+			string(s.Type),
+			s.Location.File,
+			s.Location.Symbol,
+			s.Location.Line,
+		)
 	}
-	s.FindingID = identity.BuildFindingID(
-		string(s.Type),
-		s.Location.File,
-		s.Location.Symbol,
-		s.Location.Line,
-	)
+	if s.Pillar == "" {
+		s.Pillar = models.PillarFor(s.Category)
+	}
 }

--- a/internal/engine/new_findings_only.go
+++ b/internal/engine/new_findings_only.go
@@ -1,0 +1,103 @@
+package engine
+
+import (
+	"github.com/pmclSF/terrain/internal/logging"
+	"github.com/pmclSF/terrain/internal/models"
+)
+
+// applyNewFindingsOnly filters the snapshot to keep only signals whose
+// FindingID is NOT present in the baseline snapshot. Used by Track 4.8
+// (`--new-findings-only --baseline <path>`) so established repos with
+// existing debt can adopt strict CI gates on day one — the gate only
+// fires on findings introduced AFTER the baseline was captured.
+//
+// Behavior:
+//   - When `snapshot.Baseline` is nil (no `--baseline` was supplied),
+//     this function logs a warning and returns the snapshot unchanged.
+//     The user's `--new-findings-only` flag was inert; we tell them.
+//   - When the baseline is present but contains no signals (e.g.
+//     a fresh first-run baseline), every current signal counts as
+//     "new" — same as no filter applied.
+//   - When the baseline has signals, every (top-level + per-file)
+//     signal in the current snapshot is checked against the baseline
+//     FindingID set; matches are removed.
+//
+// Idempotent. No-op when snapshot is nil.
+func applyNewFindingsOnly(snapshot *models.TestSuiteSnapshot) {
+	if snapshot == nil {
+		return
+	}
+	if snapshot.Baseline == nil {
+		logging.L().Warn("--new-findings-only is inert: no --baseline supplied")
+		return
+	}
+
+	baselineIDs := collectBaselineFindingIDs(snapshot.Baseline)
+	if len(baselineIDs) == 0 {
+		// Empty baseline — nothing to subtract; every current signal
+		// is "new" by definition.
+		return
+	}
+
+	beforeTop := len(snapshot.Signals)
+	snapshot.Signals = filterByMissingID(snapshot.Signals, baselineIDs)
+	beforeFile := 0
+	afterFile := 0
+	for fi := range snapshot.TestFiles {
+		tf := &snapshot.TestFiles[fi]
+		beforeFile += len(tf.Signals)
+		tf.Signals = filterByMissingID(tf.Signals, baselineIDs)
+		afterFile += len(tf.Signals)
+	}
+
+	logging.L().Info("new-findings-only applied",
+		"baseline_findings", len(baselineIDs),
+		"top_level_dropped", beforeTop-len(snapshot.Signals),
+		"per_file_dropped", beforeFile-afterFile,
+	)
+}
+
+// collectBaselineFindingIDs reads every signal in the baseline (both
+// top-level Signals and per-test-file Signals) and returns the set
+// of populated FindingIDs. Older baselines without finding IDs return
+// an empty set — those signals can't participate in the comparison.
+func collectBaselineFindingIDs(baseline *models.TestSuiteSnapshot) map[string]bool {
+	if baseline == nil {
+		return nil
+	}
+	ids := make(map[string]bool)
+	for _, s := range baseline.Signals {
+		if s.FindingID != "" {
+			ids[s.FindingID] = true
+		}
+	}
+	for _, tf := range baseline.TestFiles {
+		for _, s := range tf.Signals {
+			if s.FindingID != "" {
+				ids[s.FindingID] = true
+			}
+		}
+	}
+	return ids
+}
+
+// filterByMissingID keeps signals whose FindingID is NOT in the set.
+// Signals with empty FindingID are kept (we can't compare them; better
+// to over-report than silently drop unidentifiable findings).
+func filterByMissingID(signals []models.Signal, baselineIDs map[string]bool) []models.Signal {
+	if len(signals) == 0 {
+		return signals
+	}
+	kept := signals[:0]
+	for _, s := range signals {
+		if s.FindingID == "" {
+			kept = append(kept, s)
+			continue
+		}
+		if baselineIDs[s.FindingID] {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	return kept
+}

--- a/internal/engine/new_findings_only_test.go
+++ b/internal/engine/new_findings_only_test.go
@@ -1,0 +1,138 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/identity"
+	"github.com/pmclSF/terrain/internal/models"
+)
+
+func TestApplyNewFindingsOnly_DropsBaselineMatches(t *testing.T) {
+	t.Parallel()
+
+	// Two signals share an ID with the baseline; one is new.
+	id1 := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	id2 := identity.BuildFindingID("weakAssertion", "b.go", "Y", 2)
+	idNew := identity.BuildFindingID("mockHeavyTest", "c.go", "Z", 3)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id1},
+			{Type: "weakAssertion", FindingID: id2},
+			{Type: "mockHeavyTest", FindingID: idNew},
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{
+				{Type: "weakAssertion", FindingID: id1},
+				{Type: "weakAssertion", FindingID: id2},
+			},
+		},
+	}
+
+	applyNewFindingsOnly(snap)
+
+	if len(snap.Signals) != 1 {
+		t.Fatalf("expected 1 surviving signal (the new one), got %d", len(snap.Signals))
+	}
+	if snap.Signals[0].FindingID != idNew {
+		t.Errorf("wrong signal survived: %+v", snap.Signals[0])
+	}
+}
+
+func TestApplyNewFindingsOnly_NoBaselineLogsWarning(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id},
+		},
+		// Baseline intentionally nil — flag is inert.
+	}
+	applyNewFindingsOnly(snap)
+	// Without a baseline, every signal stays.
+	if len(snap.Signals) != 1 {
+		t.Errorf("no-baseline case should not filter; got %d signals", len(snap.Signals))
+	}
+}
+
+func TestApplyNewFindingsOnly_EmptyBaselineKeepsAll(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id},
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{}, // populated but empty
+		},
+	}
+	applyNewFindingsOnly(snap)
+	if len(snap.Signals) != 1 {
+		t.Errorf("empty baseline should not filter; got %d signals", len(snap.Signals))
+	}
+}
+
+func TestApplyNewFindingsOnly_PerFileSignals(t *testing.T) {
+	t.Parallel()
+	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
+	idNew := identity.BuildFindingID("mockHeavyTest", "b.go", "Y", 2)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion", FindingID: id},
+		},
+		TestFiles: []models.TestFile{
+			{
+				Path: "a.go",
+				Signals: []models.Signal{
+					{Type: "weakAssertion", FindingID: id},   // existing → drop
+					{Type: "mockHeavyTest", FindingID: idNew}, // new → keep
+				},
+			},
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{
+				{Type: "weakAssertion", FindingID: id},
+			},
+		},
+	}
+
+	applyNewFindingsOnly(snap)
+
+	if len(snap.Signals) != 0 {
+		t.Errorf("top-level matching baseline should be dropped; got %d", len(snap.Signals))
+	}
+	if len(snap.TestFiles[0].Signals) != 1 {
+		t.Fatalf("expected 1 surviving per-file signal, got %d", len(snap.TestFiles[0].Signals))
+	}
+	if snap.TestFiles[0].Signals[0].FindingID != idNew {
+		t.Errorf("wrong signal survived per-file: %+v", snap.TestFiles[0].Signals[0])
+	}
+}
+
+func TestApplyNewFindingsOnly_KeepsSignalsWithoutFindingID(t *testing.T) {
+	t.Parallel()
+	// Older or specially-emitted signals may not have a FindingID. The
+	// filter shouldn't silently drop them — over-report rather than
+	// under-report.
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "weakAssertion"}, // no FindingID
+		},
+		Baseline: &models.TestSuiteSnapshot{
+			Signals: []models.Signal{
+				{Type: "mockHeavyTest", FindingID: "something"},
+			},
+		},
+	}
+	applyNewFindingsOnly(snap)
+	if len(snap.Signals) != 1 {
+		t.Errorf("signals without FindingID should be kept; got %d", len(snap.Signals))
+	}
+}
+
+func TestApplyNewFindingsOnly_NilSafe(t *testing.T) {
+	t.Parallel()
+	applyNewFindingsOnly(nil)
+	applyNewFindingsOnly(&models.TestSuiteSnapshot{}) // no signals, no baseline
+}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -122,6 +122,19 @@ type PipelineOptions struct {
 	//
 	// See `internal/suppression` for the schema and matching semantics.
 	SuppressionsPath string
+
+	// NewFindingsOnly, when true, filters the snapshot to keep only
+	// signals whose FindingID is NOT present in the baseline snapshot
+	// (loaded via BaselineSnapshotPath). Used by
+	// `terrain analyze --fail-on critical --new-findings-only --baseline old.json`
+	// so established repos with existing debt don't brick CI on first
+	// adoption — the gate fires only on findings introduced AFTER the
+	// baseline was captured.
+	//
+	// No-op when BaselineSnapshotPath is empty (no baseline → nothing
+	// to subtract; pipeline emits a warning so the user notices their
+	// flag is inert).
+	NewFindingsOnly bool
 }
 
 // RunPipeline executes the full analysis pipeline:
@@ -740,6 +753,16 @@ func RunPipelineContext(ctx context.Context, root string, opts ...PipelineOption
 	// accumulate. Missing file is fine — most users won't have one
 	// in 0.2.0.
 	applySuppressions(snapshot, root, opt.SuppressionsPath, time.Now())
+
+	// Step 10d: optional --new-findings-only filter. When the user
+	// supplied both --baseline and --new-findings-only, drop every
+	// signal whose FindingID already existed in the baseline so the
+	// gate fires only on net-new findings. Established repos with
+	// existing debt rely on this to adopt --fail-on without bricking
+	// CI on day one.
+	if opt.NewFindingsOnly {
+		applyNewFindingsOnly(snapshot)
+	}
 
 	if err := models.ValidateSnapshot(snapshot); err != nil {
 		return nil, fmt.Errorf("invalid snapshot produced by pipeline: %w", err)

--- a/internal/insights/insights.go
+++ b/internal/insights/insights.go
@@ -177,10 +177,15 @@ type BuildInput struct {
 
 // plural returns the singular form when n == 1, otherwise singular +
 // "s". Local helper used in finding titles to avoid `n thing(s)`
-// notation in user-visible text.
-func plural(n int, singular string) string {
+// notation in user-visible text. The variadic `pluralForm` lets
+// callers pass an irregular plural for cases where suffix-"s" is
+// wrong (e.g. "scenario has" / "scenarios have", "child" / "children").
+func plural(n int, singular string, pluralForm ...string) string {
 	if n == 1 {
 		return singular
+	}
+	if len(pluralForm) > 0 {
+		return pluralForm[0]
 	}
 	return singular + "s"
 }
@@ -301,6 +306,21 @@ func Build(input *BuildInput) *Report {
 	// Derive headline and health grade.
 	r.Headline = deriveHeadline(r)
 	r.HealthGrade = deriveHealthGrade(r)
+
+	// No-tests-detected guard: a snapshot with zero tests AND zero
+	// findings is the genuine first-user empty-repo case. The
+	// previous behavior returned grade "A" with the headline "Your
+	// test suite looks healthy" — dishonest for a repo with no
+	// tests. The audit caught this on first-user fresh-repo
+	// experience.
+	//
+	// Conservative trigger: BOTH zero tests AND zero findings.
+	// If there are findings (e.g. AI-side signals on a tests-free
+	// repo), grading is still meaningful and we leave it alone.
+	if len(input.Snapshot.TestFiles) == 0 && len(input.Snapshot.TestCases) == 0 && len(findings) == 0 {
+		r.HealthGrade = "—"
+		r.Headline = "No tests detected — Terrain has nothing to grade. Add tests with your framework of choice, then re-run."
+	}
 
 	// Limitations.
 	r.Limitations = buildLimitations(input)
@@ -762,7 +782,7 @@ func aiCoverageFindings(input *BuildInput) []Finding {
 		}
 		if wiredCount < len(snap.Scenarios) {
 			findings = append(findings, Finding{
-				Title: fmt.Sprintf("%d scenario(s) have no linked code surfaces", len(snap.Scenarios)-wiredCount),
+				Title: fmt.Sprintf("%d %s no linked code surfaces", len(snap.Scenarios)-wiredCount, plural(len(snap.Scenarios)-wiredCount, "scenario has", "scenarios have")),
 				Description: "Scenarios without linked surfaces cannot be selected by impact analysis. " +
 					"Wire them via terrain.yaml or ensure eval test files import the surfaces they validate.",
 				Category: CategoryArchitectureDebt,
@@ -840,7 +860,7 @@ func scenarioDuplicationFindings(input *BuildInput) []Finding {
 	}
 
 	findings = append(findings, Finding{
-		Title: fmt.Sprintf("%d AI scenario pair(s) share >50%% of covered surfaces", highOverlapPairs),
+		Title: fmt.Sprintf("%d AI scenario %s >50%% of covered surfaces", highOverlapPairs, plural(highOverlapPairs, "pair shares", "pairs share")),
 		Description: "Overlapping eval scenarios may duplicate validation effort. " +
 			"Review whether scenarios can be consolidated or differentiated by coverage target.",
 		Category: CategoryOptimization,
@@ -1107,7 +1127,7 @@ func capabilityGapFindings(input *BuildInput) []Finding {
 			}
 			sort.Strings(cats)
 			gappedCaps = append(gappedCaps, fmt.Sprintf(
-				"%s (%d scenario(s): %s)", cap, ci.total, strings.Join(cats, ", ")))
+				"%s (%d %s: %s)", cap, ci.total, plural(ci.total, "scenario"), strings.Join(cats, ", ")))
 		}
 	}
 

--- a/internal/insights/insights_test.go
+++ b/internal/insights/insights_test.go
@@ -1,6 +1,7 @@
 package insights
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/pmclSF/terrain/internal/depgraph"
@@ -18,14 +19,21 @@ func TestBuild_EmptySnapshot(t *testing.T) {
 
 	r := Build(input)
 
-	if r.HealthGrade != "A" {
-		t.Errorf("expected health grade A for empty snapshot, got %s", r.HealthGrade)
+	// An empty snapshot has zero test files / cases — there's
+	// nothing to grade. The headline says so; grade is "—" not "A".
+	// Pre-fix, this returned "A" which read as "your test suite
+	// looks healthy: 0 tests" to first-user adopters.
+	if r.HealthGrade != "—" {
+		t.Errorf("expected health grade '—' for empty snapshot, got %s", r.HealthGrade)
 	}
 	if len(r.Findings) != 0 {
 		t.Errorf("expected 0 findings for empty snapshot, got %d", len(r.Findings))
 	}
 	if r.Headline == "" {
 		t.Error("expected non-empty headline")
+	}
+	if !strings.Contains(r.Headline, "No tests detected") {
+		t.Errorf("expected 'No tests detected' headline for empty snapshot, got: %s", r.Headline)
 	}
 }
 
@@ -204,7 +212,14 @@ func TestBuild_HealthGrade(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snap := &models.TestSuiteSnapshot{Signals: tt.signals}
+			// Provide a non-empty test inventory so the no-tests
+			// override doesn't trigger — these cases are testing
+			// the real-test-suite grading logic, not the empty-
+			// repo guard.
+			snap := &models.TestSuiteSnapshot{
+				TestFiles: []models.TestFile{{Path: "x.test.js"}},
+				Signals:   tt.signals,
+			}
 			input := &BuildInput{
 				Snapshot: snap,
 				Coverage: tt.coverage,

--- a/internal/insights/testdata/insights-empty-repo.golden
+++ b/internal/insights/testdata/insights-empty-repo.golden
@@ -1,5 +1,5 @@
 {
-  "healthGrade": "A",
+  "healthGrade": "—",
   "findingCount": 0,
   "recCount": 0,
   "categories": {},

--- a/internal/models/signal.go
+++ b/internal/models/signal.go
@@ -17,6 +17,42 @@ const (
 	CategoryAI         SignalCategory = "ai"
 )
 
+// Pillar names the product pillar a signal belongs to. Mirrors
+// internal/cli.Pillar but lives here so the snapshot model stays
+// self-contained (no import cycle with internal/cli).
+//
+// The category → pillar mapping is fixed in PillarFor below and is
+// the single source of truth for pillar tagging in JSON output,
+// SARIF tags, doctor maturity, and the parity dashboard.
+const (
+	PillarUnderstand = "understand"
+	PillarAlign      = "align"
+	PillarGate       = "gate"
+)
+
+// PillarFor returns the product pillar that owns a given signal
+// category. Mapping rationale (see plan kind-mapping-turing.md):
+//   - structure / health / quality / ai → Understand: these are
+//     "what's there, what's broken, what's overlapping" — the
+//     observation surface.
+//   - migration → Align: drift reduction across frameworks/repos.
+//   - governance → Gate: policy / ownership / suppression checks
+//     that drive a CI verdict.
+//
+// Empty result is intentional for unrecognized categories; callers
+// should treat it as omitted (the JSON tag is `omitempty`).
+func PillarFor(c SignalCategory) string {
+	switch c {
+	case CategoryStructure, CategoryHealth, CategoryQuality, CategoryAI:
+		return PillarUnderstand
+	case CategoryMigration:
+		return PillarAlign
+	case CategoryGovernance:
+		return PillarGate
+	}
+	return ""
+}
+
 // SignalSeverity expresses how urgent or important a signal is.
 type SignalSeverity string
 
@@ -182,6 +218,14 @@ type Signal struct {
 	Type     SignalType     `json:"type"`
 	Category SignalCategory `json:"category"`
 	Severity SignalSeverity `json:"severity"`
+
+	// Pillar is the product pillar this signal belongs to
+	// ("understand" / "align" / "gate"). Derived from Category via
+	// PillarFor at emission. Surfaced in JSON output, SARIF tags,
+	// and `terrain doctor` per-pillar maturity. Empty when the
+	// category is not yet mapped — consumers should treat that as
+	// "untagged" and fall back to category-based grouping.
+	Pillar string `json:"pillar,omitempty"`
 
 	// Confidence indicates how certain Terrain is about the signal.
 	// Expected range is 0.0 to 1.0. Retained for v1 consumers; v2

--- a/internal/reporting/explain_report.go
+++ b/internal/reporting/explain_report.go
@@ -64,7 +64,7 @@ func RenderTestExplanation(w io.Writer, te *explain.TestExplanation, verbose ...
 
 	// Covers units.
 	if len(te.CoversUnits) > 0 {
-		line("Covers %d code unit(s):", len(te.CoversUnits))
+		line("Covers %d code %s:", len(te.CoversUnits), Plural(len(te.CoversUnits), "unit"))
 		for _, u := range te.CoversUnits {
 			line("  %s", u)
 		}

--- a/internal/reporting/impact_drilldown.go
+++ b/internal/reporting/impact_drilldown.go
@@ -193,8 +193,8 @@ func RenderProtectiveSet(w io.Writer, result *impact.ImpactResult) {
 	ps := result.ProtectiveSet
 	line("  Strategy:   %s", ps.SetKind)
 	line("  Tests:      %d", len(ps.Tests))
-	line("  Covered:    %d unit(s)", ps.CoveredUnitCount)
-	line("  Uncovered:  %d unit(s)", ps.UncoveredUnitCount)
+	line("  Covered:    %d %s", ps.CoveredUnitCount, Plural(ps.CoveredUnitCount, "unit"))
+	line("  Uncovered:  %d %s", ps.UncoveredUnitCount, Plural(ps.UncoveredUnitCount, "unit"))
 	blank()
 
 	line("  %s", ps.Explanation)
@@ -219,7 +219,7 @@ func RenderProtectiveSet(w io.Writer, result *impact.ImpactResult) {
 	blank()
 
 	if ps.UncoveredUnitCount > 0 {
-		line("Warning: %d impacted unit(s) have no covering tests in the selected set.", ps.UncoveredUnitCount)
+		line("Warning: %d impacted %s no covering tests in the selected set.", ps.UncoveredUnitCount, Plural(ps.UncoveredUnitCount, "unit has", "units have"))
 		line("Consider adding tests or running the full suite.")
 		blank()
 	}
@@ -252,7 +252,7 @@ func RenderImpactOwners(w io.Writer, result *impact.ImpactResult) {
 
 	for _, owner := range result.ImpactedOwners {
 		units := byOwner[owner]
-		line("  %s (%d unit(s))", owner, len(units))
+		line("  %s (%d %s)", owner, len(units), Plural(len(units), "unit"))
 		line("  " + strings.Repeat("-", 40))
 		for _, iu := range units {
 			line("    %-30s %s  %s", iu.Name, iu.ProtectionStatus, iu.ChangeKind)

--- a/internal/reporting/impact_drilldown.go
+++ b/internal/reporting/impact_drilldown.go
@@ -185,7 +185,7 @@ func RenderProtectiveSet(w io.Writer, result *impact.ImpactResult) {
 	blank()
 
 	if result.ProtectiveSet == nil || len(result.ProtectiveSet.Tests) == 0 {
-		line("  No protective tests identified.")
+		RenderEmptyState(w, EmptyNoTestSelection)
 		blank()
 		return
 	}

--- a/internal/reporting/impact_report.go
+++ b/internal/reporting/impact_report.go
@@ -17,6 +17,14 @@ func RenderImpactReport(w io.Writer, result *impact.ImpactResult) {
 	line(strings.Repeat("=", 60))
 	blank()
 
+	// Designed empty-state when the change has no measurable test
+	// system impact — beats a wall of zeros that reads as "broken."
+	if isImpactEmpty(result) {
+		RenderEmptyState(w, EmptyNoImpact)
+		blank()
+		return
+	}
+
 	// Summary
 	line("Summary: %s", result.Summary)
 	blank()
@@ -202,4 +210,18 @@ func capitalizeFirst(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// isImpactEmpty reports whether an ImpactResult has nothing
+// substantive to render — no changed areas, no impacted tests, no
+// affected behaviors. The change-risk posture is computed even on
+// empty input, so we inspect the substantive fields instead.
+func isImpactEmpty(r *impact.ImpactResult) bool {
+	if r == nil {
+		return true
+	}
+	return len(r.ChangedAreas) == 0 &&
+		len(r.AffectedBehaviors) == 0 &&
+		len(r.ImpactedTests) == 0 &&
+		len(r.SelectedTests) == 0
 }

--- a/internal/reporting/reporting_test.go
+++ b/internal/reporting/reporting_test.go
@@ -582,10 +582,10 @@ func TestRenderImpactDrilldown_Owners(t *testing.T) {
 	if !strings.Contains(output, "Impacted Owners (2)") {
 		t.Error("owners view missing header")
 	}
-	if !strings.Contains(output, "team-a (2 unit(s))") {
+	if !strings.Contains(output, "team-a (2 units)") {
 		t.Error("owners view missing team-a")
 	}
-	if !strings.Contains(output, "team-b (1 unit(s))") {
+	if !strings.Contains(output, "team-b (1 unit)") {
 		t.Error("owners view missing team-b")
 	}
 }

--- a/internal/sarif/convert.go
+++ b/internal/sarif/convert.go
@@ -118,10 +118,21 @@ func buildRules(r *analyze.Report) []Rule {
 			ShortDescription: Message{Text: ruleDescription(kf.Category)},
 			DefaultConfig:    RuleConfig{Level: severityToLevel(kf.Severity)},
 			HelpURI:          ruleHelpURI(ruleID),
+			Properties:       pillarProperties(kf.Pillar),
 		})
 	}
 
 	return rules
+}
+
+// pillarProperties returns the SARIF properties bag carrying the
+// "terrain:<pillar>" tag for a given pillar string. Returns nil when
+// the pillar is empty so we don't emit empty properties bags.
+func pillarProperties(pillar string) *Properties {
+	if pillar == "" {
+		return nil
+	}
+	return &Properties{Tags: []string{"terrain:" + pillar}}
 }
 
 // ruleHelpURI maps a legacy category-derived rule ID to its
@@ -160,9 +171,10 @@ func buildResults(r *analyze.Report, opts Options) []Result {
 
 	for _, kf := range r.KeyFindings {
 		result := Result{
-			RuleID:  ruleIDFromCategory(kf.Category),
-			Level:   severityToLevel(kf.Severity),
-			Message: Message{Text: findingMessage(kf)},
+			RuleID:     ruleIDFromCategory(kf.Category),
+			Level:      severityToLevel(kf.Severity),
+			Message:    Message{Text: findingMessage(kf)},
+			Properties: pillarProperties(kf.Pillar),
 		}
 
 		// Attach file locations where we have them.

--- a/internal/sarif/sarif.go
+++ b/internal/sarif/sarif.go
@@ -33,15 +33,25 @@ type ToolComponent struct {
 
 // Rule defines a finding category.
 type Rule struct {
-	ID               string     `json:"id"`
-	ShortDescription Message    `json:"shortDescription"`
-	DefaultConfig    RuleConfig `json:"defaultConfiguration,omitempty"`
+	ID               string      `json:"id"`
+	ShortDescription Message     `json:"shortDescription"`
+	DefaultConfig    RuleConfig  `json:"defaultConfiguration,omitempty"`
 	// HelpURI links to the rule's documentation. SARIF consumers
 	// (GitHub Code Scanning, IDE integrations) render this as a
 	// clickthrough so a finding pivots to its docs/rules/<rule>.md
 	// page. Pre-0.2.x this field was missing entirely; rule pages were
 	// dead-end strings.
-	HelpURI string `json:"helpUri,omitempty"`
+	HelpURI    string      `json:"helpUri,omitempty"`
+	Properties *Properties `json:"properties,omitempty"`
+}
+
+// Properties carries the SARIF "properties" bag. We use it for
+// tags — the standard SARIF mechanism for cross-cutting labels.
+// Terrain emits one of "terrain:understand", "terrain:align",
+// "terrain:gate" so downstream consumers (GitHub Code Scanning,
+// dashboards) can group findings by product pillar.
+type Properties struct {
+	Tags []string `json:"tags,omitempty"`
 }
 
 // RuleConfig specifies the default severity level.
@@ -51,10 +61,11 @@ type RuleConfig struct {
 
 // Result is a single finding.
 type Result struct {
-	RuleID    string     `json:"ruleId"`
-	Level     string     `json:"level"`
-	Message   Message    `json:"message"`
-	Locations []Location `json:"locations,omitempty"`
+	RuleID     string      `json:"ruleId"`
+	Level      string      `json:"level"`
+	Message    Message     `json:"message"`
+	Locations  []Location  `json:"locations,omitempty"`
+	Properties *Properties `json:"properties,omitempty"`
 }
 
 // Message wraps a text string.


### PR DESCRIPTION
## Summary

Bundles four commits closing the remaining 0.2.0 audit P0/P1 items:

1. **PR #140 recovery** (`fb99a67`) — re-applies the suppressions
   CLI + `--new-findings-only` work onto main's first-parent
   history. The original PR squash-merge orphaned the commit
   (reachable but not in history), so flag wiring on
   `cmd/terrain/main.go` was lost. Cherry-pick + conflict
   resolution preserves both the struct refactor from #140 and
   main's Gate/Timeout fields.

2. **Self-scan polish** (`ba68cf1`) — empty-repo grade now shows
   `—` with an actionable next-step instead of a misleading `A`;
   the duplicate `[HIGH] N critical signals` Key Finding is
   removed (it was already the headline); `(s)` literals replaced
   with `reporting.Plural(...)` across ~30 sites.

3. **Track 2 pillar markers** (`b43c851`) — `Pillar` field on
   `models.Signal`, `analyze.KeyFinding`, plus SARIF `properties.tags`
   (`terrain:gate` / `terrain:understand` / `terrain:align`) and
   per-pillar maturity in `terrain doctor`.

4. **Empty-state wiring + helpful errors + parity refresh** (`5b46d5a`):
   - V3 wired into 5 callsites (policy / AI list / impact / select-tests / migrate estimate)
   - `analyze --base <ref>` now shows a helpful redirect instead of dumping the stdlib flag list
   - `explain finding <bad-id>` lists the three accepted ID forms
   - 7 stale parity scores corrected (line cite drift; #132/#133 already merged; recall rubric matches our corpus)
   - `make pillar-parity`: **understand** floor 2 → 3 (PASS); align WARN-soft (unchanged); gate still hard-blocked at floor=4

## Test plan

- [x] `go test ./...` green
- [x] `go build ./...` clean
- [x] `make pillar-parity` shows understand=PASS for the first time
- [ ] CI green on this PR
- [ ] Manual smoke: `terrain analyze --base main` shows the redirect
- [ ] Manual smoke: `terrain explain finding bogus-id` shows the new error
- [ ] Manual smoke: `terrain doctor` shows the per-pillar maturity block

## Why this matters

The audit identified four release blockers:
- PR #140 was orphaned post-squash; suppressions + `--new-findings-only` were missing from `main`.
- Self-scan output was misleading on empty repos (grade `A` for zero tests) and had a duplicate Key Finding contradicting the headline.
- Pillar tags were promised in the plan but absent from every output mode.
- Several empty-state paths existed in code (`internal/reporting/empty_states.go`) but only one of seven kinds was wired to a callsite.

This PR closes all four. The remaining 0.2.0 work is the Gate-pillar lift to floor=4 (publicly-claimable), which is substantial scope (labeled-PR precision corpus, AI execution-gating doc/UX, adapter fallback diagnostics) and is starting in a follow-up branch.