### PR TITLE
docs: AI/ML-first README rewrite (698 → 170 lines)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,646 +1,109 @@
 # Terrain
 
-> **Terrain is the control plane for your test system.**
->
-> It maps how your unit, integration, e2e, and AI tests actually relate
-> to your code — and lets you gate changes based on that system as a whole.
->
-> See what's covered, what's missing, and what's overlapping.
-> See which tests matter for a PR — and why.
-> Bring AI evals into the same review pipeline as the rest of your tests.
+Terrain is a CI gate for AI/ML codebases. It builds one structural graph spanning your source code, test files, prompt files, eval scenarios, and model artifacts — then fires on the gap edges between them. Default detectors flag the AI and ML hygiene gaps that no other tool sees: prompts shipping without eval coverage, AI surfaces with no test path, declared capabilities never validated, training pipelines with leakage risk.
 
-*Map your test terrain.* Two commands an adopter learns first, in order:
+The thesis: AI shouldn't be a black box to the codebase, and the codebase shouldn't be a black box to AI testing. Static analyzers see source. Test runners see tests. Eval frameworks see prompts. Terrain sees all four surfaces at once and gates pull requests against the unified picture.
 
-```bash
-terrain analyze         # Understand your test system
-terrain report pr       # Gate PR changes based on it
-```
+Generic test-quality detectors are still in the binary, but they're demoted to Low unless they participate in a boundary signal. Terrain doesn't replace Ruff or ESLint on the source side, or Jest / pytest / go test on the runner side. It operates one layer above — reading what the runners produce, modeling the system as one thing, and gating against it.
 
-Everything else is a deeper view *off* this primary workflow.
+Everything runs locally. No SaaS, no account, no analytics. Reports stay on the machine that produced them.
 
 ## Install
 
 ```bash
-# Homebrew
+# Homebrew (macOS / Linux)
 brew install pmclSF/terrain/mapterrain
 
-# npm — requires Node 22+ and cosign on PATH for signed-binary verification.
-# (CI on Node 20 LTS? Use the brew or `go install` path above.)
-# brew install cosign  (macOS / Linux)
-# scoop install cosign (Windows)
-# Set TERRAIN_INSTALLER_ALLOW_MISSING_COSIGN=1 to fall back to checksum-only,
-# or TERRAIN_INSTALLER_SKIP_VERIFY=1 to skip verification entirely.
+# npm (Node 22+ required for signed-binary verification)
 npm install -g mapterrain
 
+# Go install (Go 1.23+)
+go install github.com/pmclSF/terrain/cmd/terrain@latest
+```
+
+Pre-built binaries for macOS / Linux / Windows are on [GitHub Releases](https://github.com/pmclSF/terrain/releases). Detailed install paths and cosign verification are in [docs/quickstart.md](docs/quickstart.md).
+
+## First report in 30 seconds
+
+```bash
 cd your-repo
 terrain analyze
 ```
 
-No config and no test execution are required for the basic scan. Stronger
-findings (runtime health, eval regression, policy enforcement) are unlocked
-by optional artifacts; degrade gracefully when absent.
+No config, no annotations, no test execution required. Coverage and runtime artifacts are picked up automatically if present, ignored if absent. Stronger findings (runtime health, eval regression, policy enforcement) unlock when those artifacts exist.
 
-> **New here?** Read the [Quickstart Guide](docs/quickstart.md) to understand your first report in 5 minutes.
-> **Going deeper?** [`docs/product/vision.md`](docs/product/vision.md) is the full product narrative.
-> **Adopting in CI?** See [What 0.2 is and isn't](#what-02-is-and-isnt) below first.
+## What Terrain detects
 
----
+The AI/ML-side detectors that ship in 0.2:
 
-Terrain operates one layer above the test runners — the same architectural pattern as a Kubernetes control plane, but for the test system. Test runners (Jest / pytest / Go test / Playwright / Promptfoo) continue to execute; Terrain reads what they produce, models the system as one thing, and gates against it.
+| Detector | Fires when |
+|---|---|
+| `promptFileMissingEval` | A prompt file has no eval scenario covering it |
+| `uncoveredAISurface` | An AI surface (agent / tool / RAG step) has no covering test |
+| `phantomEvalScenario` | An eval references a surface that no longer exists |
+| `untestedPromptFlow` | A prompt flow connects surfaces with no end-to-end coverage |
+| `capabilityValidationGap` | A declared capability is never validated by any eval |
+| `aiSafetyEvalMissing` | A safety-tagged AI surface ships without a safety eval |
+| `aiPromptInjectionRisk` | Source code structurally permits prompt injection |
+| `aiHardcodedAPIKey` | API keys appear in source (heuristic) |
+| `aiToolWithoutSandbox` | An agent tool definition lacks sandboxing markers |
+| `aiModelDeprecationRisk` | A deprecated model string is still referenced |
+| `targetLeakage` / `missingTrainTestSplit` / `dataLeakageSuspected` | ML training pipelines with dataset hygiene gaps |
 
-When the testing surface drifts from the code surface — exports without tests, frameworks fragmenting across directories, AI surfaces shipping without scenarios, one team's posture diverging from another's — Terrain shows where the drift is and what convergence would take. That's the alignment side of the job. Conversion (migrating frameworks, e.g. Jest → Vitest) is one mode of alignment, not a separate product.
+Plus the eval-regression family (`accuracyRegression`, `costRegression`, `hallucinationRate`, `retrievalRegression`, `latencyRegression`, ...) that fires when Promptfoo / DeepEval / Ragas artifacts are present.
 
-## What "Test Terrain" Means
+[Full detector catalog →](docs/signal-catalog.md)
 
-Most teams know what tests they have. Few teams understand the *terrain* underneath:
-
-- Which source files have no structural test coverage?
-- Which shared fixtures fan out to thousands of tests, making any change to them a blast-radius problem?
-- Which test clusters are near-duplicates burning CI time?
-- Which areas have tests but weak assertions that wouldn't catch a real regression?
-- When you change `auth/session.ts`, which 41 of your 18,000 tests actually matter?
-
-Test terrain is the structural topology of your test system — the dependency graph, the coverage landscape, the duplication clusters, the fanout hotspots, the skip debt. Terrain maps it.
-
-## Problems Terrain Solves
-
-**"We don't know the state of our test system."** Teams inherit test suites they didn't write. Terrain gives a baseline in seconds: framework mix, coverage confidence, duplication, risk posture.
-
-**"CI takes too long and we don't know what to cut."** Terrain identifies redundant tests, high-fanout fixtures, and confidence-based test selection — showing where CI time is wasted and what can be safely reduced.
-
-**"We changed auth code — what tests should we worry about?"** Terrain traces your change through the import graph and structural dependencies, returning the impacted tests ranked by confidence, with reason chains explaining each selection.
-
-**"A tool flagged something but won't explain why."** Every Terrain finding carries an evidence chain. `terrain explain` shows exactly what signals, dependency paths, and scoring rules produced each decision.
-
-**"We're migrating frameworks and need to know what's blocking us."** Migration readiness, blockers by type, and preview-scoped difficulty assessment — all derived from static analysis.
-
-## The Four Canonical Workflows
-
-Terrain is organized around four questions. Everything else is a supporting view.
-
-```
-terrain analyze     "What is the state of our test system?"
-terrain insights    "What should we fix in our test system?"
-terrain impact      "What validations matter for this change?"
-terrain explain     "Why did Terrain make this decision?"
-```
-
-> **About the example outputs below.** The CLI dumps in this section illustrate the *shape* of Terrain's reports on a large pandas-style repository — they are not literal output from a single live run. A few specific signals shown (`xfailAccumulation` age, statistical flaky-test failure rates, the `0.91+` duplicate similarity threshold) are marked `[experimental]` or `[planned]` in 0.2.0; see [docs/release/feature-status.md](docs/release/feature-status.md) for what's stable, what's experimental, and what's planned. The headline "30 seconds" promise refers to small-to-medium repos (≤ 1,000 test files) on commodity hardware; expect 5–15 seconds on a typical service repo and longer on monorepos.
-
-### 1. Analyze — understand the test system
+## The four primary commands
 
 ```bash
-terrain analyze
+terrain analyze     # What is the state of our test system?
+terrain insights    # What should we fix?
+terrain impact      # What tests and evals matter for this change?
+terrain explain     # Why did Terrain say that?
 ```
 
-```
-Terrain — Test Suite Analysis
-============================================================
+Every finding carries an evidence chain: signal type, confidence, dependency path, scoring rule. `terrain explain <target>` exposes the full reasoning behind any decision. See [docs/examples/](docs/examples/) for sample output.
 
-  conftest.py fixture fans out to 3,100 tests — any change retriggers the frame/ suite.
+Other useful commands: `terrain pr` (PR-scoped report), `terrain ai list` (AI surface inventory), `terrain ai run` (impact-scoped eval execution), `terrain policy check` (local policy enforcement). Full reference: [docs/cli-spec.md](docs/cli-spec.md).
 
-Key Findings
-------------------------------------------------------------
-  1. [HIGH] 23 source files (18%) have low structural coverage
-  2. [HIGH] 8 duplicate test clusters with 0.91+ similarity
-  3. [MEDIUM] 34 xfail markers older than 180 days
-
-Repository Profile
-------------------------------------------------------------
-  Test volume:          very large
-  CI pressure:          high
-  Coverage confidence:  medium
-  Redundancy level:     medium
-  Fanout burden:        high
-
-Validation Inventory
-------------------------------------------------------------
-  Test files:     1,047
-  Test cases:     52,341
-  Frameworks:
-    pytest                1,047 files [unit]
-
-Risk Posture
-------------------------------------------------------------
-  health:              MODERATE
-  coverage_depth:      ELEVATED
-  coverage_diversity:  STRONG
-  structural_risk:     STRONG
-  operational_risk:    STRONG
-
-Next steps:
-  terrain insights            prioritized actions and recommendations
-  terrain impact              what tests matter for this change?
-```
-
-### 2. Insights — find what to improve
-
-```bash
-terrain insights
-```
-
-```
-Terrain — Test System Health Report
-============================================================
-
-Health Grade: C
-
-Reliability Problems (2)
-  [HIGH] 12 flaky tests with >10% failure rate
-  [MEDIUM] 34 skipped tests consuming CI resources
-
-Coverage Debt (2)
-  [HIGH] 23 source files (18%) have low structural coverage
-  [MEDIUM] conftest.py fixture fans out to 3,100 tests
-
-Recommended Actions
-  1. [reliability] Quarantine 12 flaky tests
-     why: Flaky tests block unrelated PRs and erode CI trust.
-  2. [coverage] Add tests for 23 uncovered source files
-     why: Changes in uncovered files cannot trigger test selection.
-  3. [optimization] Consolidate 8 duplicate test clusters
-     why: 0.91+ similarity — redundant CI cost with no coverage benefit.
-```
-
-### 3. Impact — understand what a change affects
-
-```bash
-terrain impact --base main
-```
-
-```
-Terrain Impact Analysis
-============================================================
-
-Summary: 3 file(s) changed, 41 test(s) relevant. Posture: needs_attention.
-
-Impacted tests:          127 of 52,341 total
-Coverage confidence:     High
-
-Recommended Tests (41)
-------------------------------------------------------------
-  tests/groupby/test_groupby.py [exact]
-    Covers: groupby.py:GroupBy.aggregate
-  tests/groupby/test_apply.py [exact]
-    Covers: groupby.py:GroupBy.apply
-  tests/resample/test_base.py [inferred]
-    Reached via shared fixture path
-  ...and 38 more
-
-Protection Gaps
-------------------------------------------------------------
-  [medium] pandas/core/groupby/ops.py — no covering tests found
-
-Next steps:
-  terrain impact --show tests      full test list
-  terrain impact --show gaps       all protection gaps
-```
-
-### 4. Explain — understand why
-
-```bash
-terrain explain tests/io/json/test_pandas.py
-```
-
-```
-Test File: tests/io/json/test_pandas.py
-Framework: pytest
-Tests: 84    Assertions: 312
-
-Signals (3):
-  [high]   networkDependency: 12 tests use @pytest.mark.network — flaky in CI
-  [medium] weakAssertion: 8 bare assert statements without descriptive messages
-  [low]    xfailAccumulation: 3 xfail markers older than 180 days
-
-Next steps:
-  terrain explain selection       explain overall test selection strategy
-  terrain impact --show tests     see all impacted tests
-```
-
-See [Canonical User Journeys](docs/product/canonical-user-journeys.md) for the full workflow specification and [example outputs](docs/examples/) for detailed report samples.
-
-## Product Philosophy
-
-**Inference first.** Terrain reads code. It parses imports, detects frameworks, resolves coverage relationships, and builds dependency graphs from what already exists in the repository. No annotations, no test tagging, no SDK integration required.
-
-**Zero-config by default.** `terrain analyze` works on any repository with test files. Coverage data, runtime artifacts, ownership files, and policy rules are optional inputs that enrich the model — but the core analysis requires nothing beyond the code itself.
-
-**Explainability over magic.** Every finding carries evidence: which signal type, what confidence level, what dependency path, what scoring rule. `terrain explain` exposes the full reasoning chain behind any decision. Teams should never wonder *why* Terrain said something.
-
-**Conservative under uncertainty.** When Terrain encounters ambiguity — a dependency path with low confidence, a file that might or might not be a test — it flags the uncertainty rather than guessing. Impact analysis uses fallback policies with explicit confidence penalties rather than silently expanding scope.
-
-**System health, not individual productivity.** Terrain measures the test system. It never attributes quality to individual developers. Ownership information is used for routing and triage, not scoring.
-
-## What Terrain Is Not
-
-It's worth stating what Terrain *doesn't* try to do, because the test-tooling space has a lot of overlapping vendors and the boundaries matter.
-
-- **Not a test runner.** Terrain doesn't execute your tests. It analyzes the test system around them. Pair it with `jest`, `pytest`, `go test`, your existing CI runner — Terrain reads the artifacts those produce, it doesn't replace them.
-- **Not a coverage tool.** Terrain ingests coverage reports if you have them and uses them as evidence, but it doesn't instrument code or compute coverage itself. Bring coverage from `c8`, `istanbul`, `coverage.py`, `gcov` — Terrain is the layer that turns coverage into structural insight.
-- **Not a static analyzer for application code.** Terrain inspects *test* code structure (assertions, mocks, framework patterns, scenario coverage). Tools like Sonar, Semgrep, and CodeQL stay better-positioned for source-side bug-finding; Terrain doesn't compete.
-- **Not an LLM eval framework.** Terrain understands AI surfaces (prompts, scenarios, RAG pipelines) and the eval *artifacts* that promptfoo / DeepEval / Ragas produce, but it doesn't run the evals itself. Use those tools to execute; use Terrain to analyze what they produce in CI.
-- **Not a test-flake whack-a-mole tool.** Terrain reports flakiness as a signal among many. If your only need is "rerun flaky tests until they pass", point-tools like `pytest-rerunfailures` or `jest-circus` ship that directly.
-- **Not a developer-productivity dashboard.** Terrain measures the test system, not the people writing tests. It deliberately produces no leaderboards, no per-developer metrics, no "engineer productivity" rankings. Ownership data is used for routing, not scoring.
-- **Not a service.** Terrain analysis is local. No SaaS, no analytics, no account required. Reports stay where you produce them. (Note: `npm install -g mapterrain` and `brew install` download signed binaries from GitHub Releases as part of installation; analysis itself does not phone home.)
-
-If you're evaluating Terrain against another tool and the boundary isn't obvious, please open an issue — we'll write the comparison entry under `docs/compare/`.
-
-## What 0.2 Is and Isn't
-
-Read this before adopting in CI. Source of truth per-capability is
-[`docs/release/feature-status.md`](docs/release/feature-status.md);
-this is the summary view.
-
-Capabilities are tiered:
-
-- **Tier 1** — covered by tests, documented behavior, claimed publicly. Floor ≥ 3 on the parity rubric in 0.2.0; Gate floor lifts to ≥ 4 in 0.3 once the labeled real-repo precision corpus lands.
-- **Tier 2** — shipping but explicitly experimental; useful but not yet hardened. Floor ≥ 3.
-- **Tier 3** — in development, opt-in, no public claim. Wait for promotion.
-
-### By pillar
-
-**Understand** (Tier 1 unless noted):
-
-- `terrain analyze` — snapshot + signals + posture
-- `terrain report summary / posture / metrics / insights / explain` — read-side queries
-- `terrain compare` — snapshots over time
-- AI surface inventory — what AI surfaces exist, where they are, what evals cover them
-- `terrain serve` (Tier 2) — local HTTP report; localhost-only, no auth
-- `terrain portfolio` (Tier 2, emerging) — multi-repo aggregation; partial in 0.2.0
-- `terrain debug *` (Tier 2) — diagnostic drill-downs
-
-**Align** (Tier 1):
-
-- `terrain migrate` / `terrain convert` — framework migration with per-file confidence
-- `terrain report select-tests` (Tier 2) — recommended protective test set for a change
-- Alignment views in `posture` and `portfolio` — drift between code surface and test surface
-
-**Gate** (Tier 1 unless noted):
-
-- `terrain report pr` — change-scoped PR risk report
-- `terrain report impact` — impact selection with reason chains (`--explain-selection`)
-- `terrain analyze --fail-on / --timeout / --new-findings-only` — CI gating primitives
-- `terrain policy check` — policy enforcement
-- Eval artifact ingestion — Promptfoo / DeepEval / Ragas adapters
-- AI risk: **inventory** (Tier 1, reliable)
-- AI risk: **hygiene** + **regression** (Tier 2, visible but not gating-critical)
-- `terrain ai run` + `terrain ai record` + `terrain ai baseline compare` (Tier 2) — regression-aware AI gate (record a baseline, then compare subsequent runs)
-
-### Anti-goals (0.2.x)
-
-These are explicit non-claims:
-
-- **Terrain does not guarantee safe test skipping.** It provides explainable selection and gating signals. The "see which tests matter — and why" pitch is a clarity claim, not a safe-skip claim.
-- **Terrain does not run your tests.** Test runners execute; Terrain reads what they produce.
-- **Terrain does not judge model truthfulness.** AI risk detectors surface heuristic structural patterns and ingest eval-framework metadata.
-- **Terrain does not promise public-grade precision floors in 0.2.x.** Recall-anchored calibration only; labeled-corpus precision floors are 0.3 work.
-
-### Planned for 0.3
-
-- Per-detector precision benchmarking against a labeled-repo corpus
-- AST-grade taint analysis for prompt injection
-- Suppression lifecycle (expiry, owner, audit) — basic suppressions ship in 0.2.0
-- `terrain ai gate` standalone command
-- Plugin architecture for community adapters
-- Sandboxing for eval execution
-- Legacy CLI alias removal (with a 0.2.x deprecation runway)
-- AI-aware integration / e2e tests under the control plane (0.4 trajectory)
-
-## Who Uses Terrain
-
-Terrain is framework-agnostic and language-aware. The same analysis model applies across:
-
-- **Frontend teams** — React/Vue component tests, Playwright/Cypress E2E suites, Vitest/Jest unit tests
-- **Backend teams** — Go test suites, pytest collections, JUnit hierarchies, integration test infrastructure
-- **Mobile teams** — cross-platform test suites with standard test frameworks
-- **QA / SDET** — test portfolio management, coverage gap analysis, migration planning across frameworks
-- **SRE / Platform** — CI optimization, test selection for pipelines, policy enforcement
-- **AI / ML evaluation** — evaluation suite structure, benchmark test management, coverage across model behaviors
-
-The structural model is the same. The signals and recommendations adapt to the framework and test patterns detected.
-
-## AI Testing in CI
-
-Terrain gives AI components the same CI safety net as regular tests:
-
-- **Surface discovery** — automatically detects prompts, contexts, datasets, tool definitions, RAG pipelines, and eval scenarios in your code
-- **Impact-scoped selection** — `terrain ai run --base main` runs only the eval scenarios affected by your change
-- **Protection gaps** — `terrain pr` flags changed AI surfaces that have no eval scenario covering them
-- **Policy enforcement** — block PRs that modify uncovered AI surfaces, regress accuracy, or trigger safety failures
-- **GitHub Action** — drop-in `terrain-ai.yml` workflow template for AI CI gates
-
-The same structural graph that powers test selection for regular code also traces AI surface dependencies, so a change to a prompt template triggers the right eval scenarios automatically.
-
-## How CI Optimization Emerges
-
-Terrain does not start with CI optimization. It starts with understanding.
-
-When you run `terrain analyze`, Terrain builds a structural model: which tests exist, which source files they cover, how they depend on shared fixtures, where duplication lives. From that model, CI optimization *emerges*:
-
-- **Test selection** — `terrain impact` traces a diff through the dependency graph and returns only the tests that structurally matter, ranked by confidence. This is not a heuristic skip list — it is a graph traversal with evidence.
-- **Redundancy reduction** — `terrain insights` surfaces duplicate test clusters. Removing or consolidating them directly reduces CI time without reducing coverage.
-- **Fanout control** — High-fanout fixtures that trigger thousands of tests on any change are identified and prioritized for splitting.
-- **Confidence-based runs** — Impact analysis assigns confidence scores. CI pipelines can run high-confidence tests immediately and defer low-confidence tests to nightly runs.
-- **What to test next** — `terrain insights` ranks untested source files by dependency count, telling you which test to write first for maximum impact.
-
-The result is faster CI that comes from *understanding the test system*, not from skipping tests and hoping for the best.
-
-## Installation
-
-### Homebrew (macOS and Linux)
-
-```bash
-brew install pmclSF/terrain/mapterrain
-```
-
-After the first install, you can also tap once and use the short formula name:
-
-```bash
-brew tap pmclSF/terrain
-brew install mapterrain
-```
-
-### npm
-
-```bash
-npm install -g mapterrain
-```
-
-> **Node 22 required.** The npm postinstall verifies signed binaries
-> with cosign and uses APIs (`fetch`, top-level await, modern stream
-> primitives) that landed in Node 22. CI images on Node 20 LTS
-> should use the Homebrew or `go install` path until 0.3 ships
-> Node-20 compat. Run `node --version` to check.
-
-### Go install
-
-```bash
-go install github.com/pmclSF/terrain/cmd/terrain@latest
-```
-
-Requires Go 1.23 or later.
-
-### Pre-built binaries
-
-Download the appropriate binary for your platform from [GitHub Releases](https://github.com/pmclSF/terrain/releases), then:
-
-```bash
-chmod +x terrain
-sudo mv terrain /usr/local/bin/
-```
-
-Binaries are available for macOS (amd64 + arm64), Linux (amd64 + arm64), and Windows (amd64).
-
-### Build from source
-
-```bash
-git clone https://github.com/pmclSF/terrain.git
-cd terrain
-go build -o terrain ./cmd/terrain
-```
-
-### Verify installation
-
-```bash
-terrain --version
-```
-
-## Quick Start
-
-```bash
-# Detect coverage/runtime data paths (recommended first step)
-terrain init
-
-# Analyze the current repository
-terrain analyze
-
-# JSON output for any command
-terrain analyze --json
-
-# See what a change affects
-terrain impact --base main
-
-# Get prioritized recommendations
-terrain insights
-
-# Drill into a specific test, code unit, owner, or finding
-terrain explain src/auth/login.test.ts
-```
-
-## GitHub Actions templates
-
-Drop one of these into `.github/workflows/terrain.yml` and you're done.
-
-### Minimal — analyze on every PR
+## CI integration
 
 ```yaml
+# .github/workflows/terrain.yml
 name: terrain
-on:
-  pull_request:
-
-jobs:
-  analyze:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: '22.x'
-
-      - run: npm install -g mapterrain
-      - run: terrain analyze --root . --json > terrain-report.json
-      - run: terrain impact --base origin/main --root .
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: terrain-report
-          path: terrain-report.json
-```
-
-### Strict — block on Critical / High signals
-
-```yaml
-name: terrain-gate
-on:
-  pull_request:
+on: pull_request
 
 jobs:
   gate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - run: |
-          curl -L https://github.com/pmclSF/terrain/releases/latest/download/terrain_linux_amd64.tar.gz \
-            | tar -xz
-
-      # Fail the job (exit 6) if any Critical or High severity signals
-      # are present. `--fail-on` is the supported severity gate; distinct
-      # exit codes per docs/cli-spec.md. Use `--new-findings-only --baseline`
-      # if you're onboarding an established repo with pre-existing debt.
-      - run: ./terrain analyze --root . --fail-on=high
-```
-
-### AI-aware — gate on AI-domain Criticals only
-
-```yaml
-name: terrain-ai-gate
-on:
-  pull_request:
-    paths:
-      - '**/*.py'
-      - '**/*.js'
-      - '**/*.ts'
-      - '**/.terrain/**'
-      - '**/promptfoo*.yaml'
-      - '**/eval*.yaml'
-
-jobs:
-  ai-gate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v6
+        with: { node-version: '22.x' }
       - run: npm install -g mapterrain
-      - run: terrain ai list --root . --json > ai-inventory.json
-
-      # Gate on Critical findings repo-wide (exit 6). For AI-only gating
-      # against an eval baseline, use `terrain ai run` — see the
-      # walkthrough at docs/examples/gate/ai-eval-ci/.
-      - run: terrain analyze --root . --fail-on=critical
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: ai-inventory
-          path: ai-inventory.json
+      - run: terrain analyze --root . --fail-on=high
 ```
 
-## Commands
+`--fail-on=high` exits non-zero (code 6) on Critical or High findings. For onboarding to an established repo, add `--new-findings-only --baseline=<file>` so existing debt doesn't fail the first PR. AI-specific gating and Strict / Minimal templates: [docs/examples/gate/](docs/examples/gate/).
 
-### Primary commands
+## What Terrain doesn't do
 
-| Command | Question |
-|---------|----------|
-| `terrain analyze` | What is the state of our test system? |
-| `terrain insights` | What should we fix in our test system? |
-| `terrain impact` | What validations matter for this change? |
-| `terrain explain <target>` | Why did Terrain make this decision? |
+- **Doesn't run your tests.** Test runners execute; Terrain reads their artifacts.
+- **Doesn't instrument coverage.** Bring `c8` / `istanbul` / `coverage.py` / `gcov`; Terrain turns coverage into structural insight.
+- **Doesn't compete with Ruff / ESLint / Semgrep / Sonar.** Source-side bug-finding stays with them.
+- **Doesn't execute evals.** Promptfoo / DeepEval / Ragas run them; Terrain ingests their output.
+- **Doesn't profile developers.** Test-system health only, never per-person metrics or leaderboards.
+- **Doesn't phone home.** Analysis is local; installation downloads signed binaries from GitHub Releases.
 
-### Supporting commands
-
-| Command | Purpose |
-|---------|---------|
-| `terrain init` | Detect data files and print recommended analyze command |
-| `terrain summary` | Executive summary with risk, trends, benchmark readiness |
-| `terrain focus` | Prioritized next actions |
-| `terrain posture` | Detailed posture breakdown with measurement evidence |
-| `terrain portfolio` | Portfolio intelligence: cost, breadth, leverage, redundancy. *(Top-level canonical command, but feature-status: experimental — multi-repo rollups solidify in 0.3.)* |
-| `terrain metrics` | Aggregate metrics scorecard |
-| `terrain compare` | Compare two snapshots for trend tracking |
-| `terrain select-tests` | Recommend protective test set for a change |
-| `terrain pr` | PR/change-scoped analysis |
-| `terrain show <type> <id>` | Drill into test, unit, owner, or finding |
-| `terrain migration <sub>` | Migration readiness, blockers, or preview |
-| `terrain policy check` | Evaluate local policy rules |
-| `terrain export benchmark` | Privacy-safe JSON export for benchmarking |
-| `terrain serve` | Local HTTP server with HTML report and JSON API |
-
-### AI / eval
-
-| Command | Purpose |
-|---------|---------|
-| `terrain ai list` | List detected scenarios, prompts, datasets, eval files |
-| `terrain ai doctor` | Validate AI/eval setup and surface configuration issues |
-| `terrain ai run` | Execute eval scenarios and collect results |
-| `terrain ai replay` | Replay and verify a previous eval run artifact |
-| `terrain ai record` | Record eval results as a baseline snapshot |
-| `terrain ai baseline` | Manage eval baselines (show, compare) |
-
-### Conversion / migration
-
-| Command | Purpose |
-|---------|---------|
-| `terrain convert <source>` | Go-native test conversion (25 directions) |
-| `terrain convert-config <source>` | Convert framework config files |
-| `terrain migrate <dir>` | Project-wide migration with state tracking |
-| `terrain estimate <dir>` | Estimate migration complexity |
-| `terrain status` | Show migration progress |
-| `terrain checklist` | Generate migration checklist |
-| `terrain doctor [path]` | Run migration diagnostics |
-| `terrain reset` | Clear migration state |
-| `terrain list-conversions` | List supported conversion directions |
-| `terrain shorthands` | List shorthand aliases (e.g., `cy2pw`, `jest2vt`) |
-| `terrain detect <file-or-dir>` | Detect dominant framework |
-
-### Advanced / debug
-
-| Command | Purpose |
-|---------|---------|
-| `terrain debug graph` | Dependency graph statistics |
-| `terrain debug coverage` | Structural coverage analysis |
-| `terrain debug fanout` | High-fanout node analysis |
-| `terrain debug duplicates` | Duplicate test cluster analysis |
-| `terrain debug depgraph` | Full dependency graph analysis (all engines) |
-
-Repository-scoped commands support `--root PATH`, and machine-readable commands support `--json`. Most analysis commands support `--verbose` for additional detail. Run `terrain <command> --help` for full flag documentation.
-
-## Architecture Overview
-
-Terrain is built around a signal-first architecture:
-
-```
-Repository scan  →  Signal detection  →  Risk modeling  →  Reporting
-     │                    │                    │               │
-  test files         framework-specific    explainable     human-readable
-  source files       pattern detectors     risk scoring    + JSON output
-  coverage data      quality signals       with evidence
-  runtime artifacts  health signals        chains
-  ownership files    migration signals
-  policy rules       governance signals
-```
-
-- **Signals** are the core abstraction — every finding is a structured signal with type, severity, confidence, evidence, and location
-- **Snapshots** (`TestSuiteSnapshot`) are the canonical serialized artifact — the complete structural model of a test system at a point in time
-- **Risk surfaces** are derived from signals with explainable scoring across dimensions (quality, reliability, speed, governance)
-- **Dependency graphs** model import relationships, fixture fanout, and structural coverage
-- **Reports** synthesize signals, risk, trends, and benchmark readiness into actionable output
-
-```
-cmd/terrain/     CLI — canonical surface (analyze, report, migrate,
-                 convert, posture, doctor, ai, serve, version, help)
-                 plus legacy aliases retained through 0.2.x
-internal/        53 Go packages covering analysis, signals, risk,
-                 impact, depgraph, measurement, reporting, and more
-```
-
-See [DESIGN.md](DESIGN.md) for the full architecture overview and package map, [docs/architecture/](docs/architecture/) for detailed design documents, and [docs/json-schema.md](docs/json-schema.md) for JSON output structure.
-
-## Snapshot Workflow
-
-Terrain supports local snapshot history for trend tracking:
+## Snapshots and trend tracking
 
 ```bash
-# Save a snapshot
-terrain analyze --write-snapshot
-
-# Later, save another snapshot
-terrain analyze --write-snapshot
-
-# Compare the two most recent snapshots
-terrain compare
-
-# Executive summary automatically includes trend highlights
-terrain summary
+terrain analyze --write-snapshot   # Save snapshot to .terrain/snapshots/
+terrain compare                    # Compare the two most recent
+terrain summary                    # Executive summary with trend highlights
 ```
-
-Snapshots are stored in `.terrain/snapshots/` as timestamped JSON files.
 
 ## Policy
 
@@ -653,46 +116,54 @@ rules:
   max_mock_heavy_tests: 5
 ```
 
-Then check compliance:
+Then: `terrain policy check` (exit 0 pass, 2 violations, 1 error).
 
-```bash
-terrain policy check        # human-readable output
-terrain policy check --json # JSON output for CI
+## What's stable in 0.2 vs. what's planned
+
+Tier 1 (covered by tests, documented, claimed): `terrain analyze`, `terrain insights`, `terrain impact`, `terrain explain`, `terrain pr`, `terrain policy check`, AI surface inventory, eval-artifact ingestion, the gate-tier detectors.
+
+Tier 2 (shipping but explicitly experimental): `terrain serve`, `terrain portfolio`, the AI hygiene + regression detectors, regression-aware `terrain ai run` + `record` + `baseline compare`.
+
+Tier 3 (in development): per-detector precision benchmarking against a labeled corpus, AST-grade prompt-injection taint analysis, suppression lifecycle, sandboxed eval execution.
+
+Full per-capability status: [docs/release/feature-status.md](docs/release/feature-status.md).
+
+## Architecture
+
+```
+Repository scan → Signal detection → Risk modeling → Reporting
+   test files       framework-aware    explainable      human-readable
+   source files     pattern detectors  risk scoring     + JSON output
+   prompt files     boundary edges     with evidence
+   eval scenarios   gap detection      chains
 ```
 
-Exit code 0 = pass, 2 = violations found, 1 = error.
+- **Signals** are the core abstraction — every finding is a structured signal with type, severity, confidence, evidence, and location.
+- **Snapshots** (`TestSuiteSnapshot`) are the canonical serialized artifact — the full structural model at a point in time.
+- **Unified graph** spans source files, test files, prompt files, eval scenarios, model artifacts, and the typed edges between them.
+
+[DESIGN.md](DESIGN.md) has the package map. [docs/architecture/](docs/architecture/) has the technical design documents.
 
 ## Documentation
 
-- [Quickstart Guide](docs/quickstart.md) — understand your first report in 5 minutes
-- [CLI Specification](docs/cli-spec.md) — full command and flag reference
-- [Example Reports](docs/examples/) — analyze, impact, insights, explain output samples
-- [Canonical User Journeys](docs/product/canonical-user-journeys.md) — primary workflows and expected outcomes
-- [Signal Model](docs/signal-model.md) — the core signal abstraction
-- [Glossary](docs/glossary.md) — Terrain-specific vocabulary in one page
-- [Architecture](docs/architecture/) — design documents and technical specifications
-- [Versioning Policy](docs/versioning.md) — what's a breaking change vs behavior change vs bug fix
+- [Quickstart](docs/quickstart.md) — first report in 5 minutes
+- [Product vision](docs/product/vision.md) — the full narrative
+- [Signal catalog](docs/signal-catalog.md) — every detector, what it fires on
+- [CLI reference](docs/cli-spec.md) — every command and flag
+- [JSON schema](docs/json-schema.md) — for tooling that reads Terrain output
+- [Examples](docs/examples/) — sample analyze / impact / insights / explain reports
+- [Feature status](docs/release/feature-status.md) — stable / experimental / planned
 - [Compatibility](docs/compatibility.md) — supported OSes, Go versions, frameworks
-- [Integrations](docs/integrations/) — Promptfoo / DeepEval / Ragas wiring guides
-- [Feature Status](docs/release/feature-status.md) — what's stable, experimental, or planned in the current release
-- [CHANGELOG](CHANGELOG.md) — release history and per-version changes
-- [Security](SECURITY.md) — supported versions and vulnerability disclosure
-- [Code of Conduct](CODE_OF_CONDUCT.md) — community standards
-- [Contributing](CONTRIBUTING.md) — how to build, test, and extend Terrain
+- [CHANGELOG](CHANGELOG.md), [CONTRIBUTING](CONTRIBUTING.md), [SECURITY](SECURITY.md)
 
 ## Development
 
 ```bash
-# Build
 go build -o terrain ./cmd/terrain
-
-# Test
 go test ./cmd/... ./internal/...
-
-# Full release verification
 make release-verify
 ```
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE) for details.
+Apache License 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Replaces 698-line README with a 170-line, AI/ML-first version
- Leads with the strategic moat (\"CI gate for AI/ML codebases\") instead of generic test-tooling positioning
- Centers a detector table with 11 named, shipping detectors — names verified against \`internal/signals/signal_types.go\`
- Cuts 143 lines of not-literal example output (now links to \`docs/examples/\`)
- Consolidates three duplicate install sections into one
- One voice throughout; removes Product Philosophy / Who Uses Terrain / How CI Optimization Emerges manifesto sections (which live in \`docs/product/vision.md\`)
- Compresses Tier 1/2/3 status from 60 lines to 6, with link to \`docs/release/feature-status.md\` for full detail

## Why now

The previous README opened with \"control plane for your test system\" and never explained what made Terrain different from Codecov + Vitest + a JUnit reporter. It welded together three different identities (test tool, AI tool, framework-migration tool), duplicated install + quickstart sections three times, and embedded fake example output with a disclaimer that it wasn't real. An engineer evaluating in 30 seconds couldn't tell what Terrain does.

This rewrite is aligned to the AI/ML-first strategic direction and names the killer-gap detectors that are the actual moat.

## Test plan

- [ ] Visual check: render on GitHub looks clean
- [ ] All linked docs paths exist (verified locally against \`docs/\` tree)
- [ ] All detector names match \`internal/signals/signal_types.go\` (verified)
- [ ] No phantom detectors named (verified — \`train_script_missing_tracker\` from boundary edges intentionally omitted since it's not a deployed signal yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)