### PR TITLE
chore: gitignore tier-4 corpus research + .terrain scratch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,28 @@ terrain-parity-gate
 .claude/
 terrain-docs-linkcheck
 terrain-truth-verify
+/terrain-corpus
+/terrain-precision
+
+# === Corpus research data — NEVER publish ===
+# tier-4/ contains the harvested graph: PR walks, boundary edges,
+# labels, per-repo signal data. This is research scratch, kept local.
+# Allowlist the small artifacts that ARE legitimate documentation
+# (markdown reports, hand-labeled TSVs, repo URL lists).
+tier-4/*.jsonl
+tier-4/*.jsonl.gz
+tier-4/*.json
+tier-4/*.json.gz
+tier-4/streams/
+tier-4/expand-streams/
+tier-4/expand2-streams/
+tier-4/bnd-rescan-streams/
+tier-4/track2-ablation/
+tier-4/logs/
+!tier-4/**/*.tsv
+!tier-4/**/*.md
+!tier-4/ai-repos-to-reclone.txt
+
+# === Local snapshot scratch ===
+.terrain/snapshots/
+.terrain/cache/


### PR DESCRIPTION
## Summary

- Ignores raw corpus graph data in \`tier-4/\` (walks, boundaries, labels)
- Allowlists the small artifacts that ARE legitimate documentation: markdown reports, hand-labeled TSVs, repo URL lists
- Ignores \`.terrain/snapshots/\` and \`.terrain/cache/\` (per-run scratch)
- Adds \`/terrain-precision\` to match the existing \`/terrain-corpus\` rule

## Why

The tier-4/ directory holds the harvested graph used for detector calibration. Without an ignore rule, accidental \`git add tier-4/\` sweeps in 300+ MB JSONL files (already triggered a push rejection during the README PR work). These are research scratch — they belong on the local machine that runs the harvest, never on GitHub.

No tier-4 data files are currently on origin/main. This is forward-looking only.

## Test plan

- [ ] After merge, \`git status\` in a fresh checkout shows no tier-4/*.jsonl as untracked
- [ ] Existing tracked tier-4 markdown reports stay tracked (allowlist works)
- [ ] \`.terrain/snapshots/\` ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)