### PR TITLE
docs: tighten README — drop defensive framing, lead with concrete claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,45 @@
 # Terrain
 
-Terrain is a CI gate for AI/ML codebases. It builds one structural graph spanning your source code, test files, prompt files, eval scenarios, and model artifacts — then fires on the gap edges between them. Default detectors flag the AI and ML hygiene gaps that no other tool sees: prompts shipping without eval coverage, AI surfaces with no test path, declared capabilities never validated, training pipelines with leakage risk.
+Terrain is the CI gate for AI/ML codebases.
 
-The thesis: AI shouldn't be a black box to the codebase, and the codebase shouldn't be a black box to AI testing. Static analyzers see source. Test runners see tests. Eval frameworks see prompts. Terrain sees all four surfaces at once and gates pull requests against the unified picture.
+Change a prompt — Terrain knows whether an eval covers it. Add an agent — Terrain knows whether it has a test path. Touch a training pipeline with target leakage — Terrain flags it before the PR lands on main.
 
-Generic test-quality detectors are still in the binary, but they're demoted to Low unless they participate in a boundary signal. Terrain doesn't replace Ruff or ESLint on the source side, or Jest / pytest / go test on the runner side. It operates one layer above — reading what the runners produce, modeling the system as one thing, and gating against it.
+It works because Terrain builds one structural graph across your source code, test files, prompt files, eval scenarios, and model artifacts, then fires on the gap edges between them. AI shouldn't be a black box to the codebase. The codebase shouldn't be a black box to AI testing.
 
-Everything runs locally. No SaaS, no account, no analytics. Reports stay on the machine that produced them.
+Everything runs locally. No SaaS, no account, no analytics.
 
 ## Install
 
 ```bash
-# Homebrew (macOS / Linux)
-brew install pmclSF/terrain/mapterrain
-
-# npm (Node 22+ required for signed-binary verification)
-npm install -g mapterrain
-
-# Go install (Go 1.23+)
-go install github.com/pmclSF/terrain/cmd/terrain@latest
+brew install pmclSF/terrain/mapterrain                            # macOS / Linux
+npm install -g mapterrain                                         # Node 22+
+go install github.com/pmclSF/terrain/cmd/terrain@latest           # Go 1.23+
 ```
 
-Pre-built binaries for macOS / Linux / Windows are on [GitHub Releases](https://github.com/pmclSF/terrain/releases). Detailed install paths and cosign verification are in [docs/quickstart.md](docs/quickstart.md).
+Pre-built binaries are on [GitHub Releases](https://github.com/pmclSF/terrain/releases). Cosign verification and full install detail: [docs/quickstart.md](docs/quickstart.md).
 
-## First report in 30 seconds
+## First report
 
 ```bash
 cd your-repo
 terrain analyze
 ```
 
-No config, no annotations, no test execution required. Coverage and runtime artifacts are picked up automatically if present, ignored if absent. Stronger findings (runtime health, eval regression, policy enforcement) unlock when those artifacts exist.
+No config, no annotations, no test execution required. Coverage and runtime artifacts get picked up if present, ignored if absent.
 
-## What Terrain detects
+## What Terrain catches
 
-The AI/ML-side detectors that ship in 0.2:
+The strategic moat is gap detection at the boundary between code and tests, prompts and evals, training and tracking:
 
-| Detector | Fires when |
-|---|---|
-| `promptFileMissingEval` | A prompt file has no eval scenario covering it |
-| `uncoveredAISurface` | An AI surface (agent / tool / RAG step) has no covering test |
-| `phantomEvalScenario` | An eval references a surface that no longer exists |
-| `untestedPromptFlow` | A prompt flow connects surfaces with no end-to-end coverage |
-| `capabilityValidationGap` | A declared capability is never validated by any eval |
-| `aiSafetyEvalMissing` | A safety-tagged AI surface ships without a safety eval |
-| `aiPromptInjectionRisk` | Source code structurally permits prompt injection |
-| `aiHardcodedAPIKey` | API keys appear in source (heuristic) |
-| `aiToolWithoutSandbox` | An agent tool definition lacks sandboxing markers |
-| `aiModelDeprecationRisk` | A deprecated model string is still referenced |
-| `targetLeakage` / `missingTrainTestSplit` / `dataLeakageSuspected` | ML training pipelines with dataset hygiene gaps |
+- **`promptFileMissingEval`** — a prompt ships in source but no eval covers it
+- **`uncoveredAISurface`** — an agent / tool / RAG step has no test path
+- **`capabilityValidationGap`** — a declared capability is never validated by any eval
+- **`phantomEvalScenario`** — an eval still references a surface that was deleted
+- **`targetLeakage` / `missingTrainTestSplit`** — training pipelines with data hygiene gaps
 
-Plus the eval-regression family (`accuracyRegression`, `costRegression`, `hallucinationRate`, `retrievalRegression`, `latencyRegression`, ...) that fires when Promptfoo / DeepEval / Ragas artifacts are present.
+Plus the eval-regression family (`accuracyRegression`, `costRegression`, `hallucinationRate`, `retrievalRegression`) that fires when Promptfoo, DeepEval, or Ragas artifacts are present.
 
-[Full detector catalog →](docs/signal-catalog.md)
+Full detector catalog: [docs/signal-catalog.md](docs/signal-catalog.md).
 
 ## The four primary commands
 
@@ -63,9 +50,7 @@ terrain impact      # What tests and evals matter for this change?
 terrain explain     # Why did Terrain say that?
 ```
 
-Every finding carries an evidence chain: signal type, confidence, dependency path, scoring rule. `terrain explain <target>` exposes the full reasoning behind any decision. See [docs/examples/](docs/examples/) for sample output.
-
-Other useful commands: `terrain pr` (PR-scoped report), `terrain ai list` (AI surface inventory), `terrain ai run` (impact-scoped eval execution), `terrain policy check` (local policy enforcement). Full reference: [docs/cli-spec.md](docs/cli-spec.md).
+Every finding carries an evidence chain: signal type, dependency path, confidence, scoring rule. `terrain explain <target>` exposes the full reasoning behind any decision. See [docs/examples/](docs/examples/) for sample output.
 
 ## CI integration
 
@@ -73,7 +58,6 @@ Other useful commands: `terrain pr` (PR-scoped report), `terrain ai list` (AI su
 # .github/workflows/terrain.yml
 name: terrain
 on: pull_request
-
 jobs:
   gate:
     runs-on: ubuntu-latest
@@ -86,84 +70,16 @@ jobs:
       - run: terrain analyze --root . --fail-on=high
 ```
 
-`--fail-on=high` exits non-zero (code 6) on Critical or High findings. For onboarding to an established repo, add `--new-findings-only --baseline=<file>` so existing debt doesn't fail the first PR. AI-specific gating and Strict / Minimal templates: [docs/examples/gate/](docs/examples/gate/).
-
-## What Terrain doesn't do
-
-- **Doesn't run your tests.** Test runners execute; Terrain reads their artifacts.
-- **Doesn't instrument coverage.** Bring `c8` / `istanbul` / `coverage.py` / `gcov`; Terrain turns coverage into structural insight.
-- **Doesn't compete with Ruff / ESLint / Semgrep / Sonar.** Source-side bug-finding stays with them.
-- **Doesn't execute evals.** Promptfoo / DeepEval / Ragas run them; Terrain ingests their output.
-- **Doesn't profile developers.** Test-system health only, never per-person metrics or leaderboards.
-- **Doesn't phone home.** Analysis is local; installation downloads signed binaries from GitHub Releases.
-
-## Snapshots and trend tracking
-
-```bash
-terrain analyze --write-snapshot   # Save snapshot to .terrain/snapshots/
-terrain compare                    # Compare the two most recent
-terrain summary                    # Executive summary with trend highlights
-```
-
-## Policy
-
-Define local policy rules in `.terrain/policy.yaml`:
-
-```yaml
-rules:
-  disallow_skipped_tests: true
-  max_weak_assertions: 10
-  max_mock_heavy_tests: 5
-```
-
-Then: `terrain policy check` (exit 0 pass, 2 violations, 1 error).
-
-## What's stable in 0.2 vs. what's planned
-
-Tier 1 (covered by tests, documented, claimed): `terrain analyze`, `terrain insights`, `terrain impact`, `terrain explain`, `terrain pr`, `terrain policy check`, AI surface inventory, eval-artifact ingestion, the gate-tier detectors.
-
-Tier 2 (shipping but explicitly experimental): `terrain serve`, `terrain portfolio`, the AI hygiene + regression detectors, regression-aware `terrain ai run` + `record` + `baseline compare`.
-
-Tier 3 (in development): per-detector precision benchmarking against a labeled corpus, AST-grade prompt-injection taint analysis, suppression lifecycle, sandboxed eval execution.
-
-Full per-capability status: [docs/release/feature-status.md](docs/release/feature-status.md).
-
-## Architecture
-
-```
-Repository scan → Signal detection → Risk modeling → Reporting
-   test files       framework-aware    explainable      human-readable
-   source files     pattern detectors  risk scoring     + JSON output
-   prompt files     boundary edges     with evidence
-   eval scenarios   gap detection      chains
-```
-
-- **Signals** are the core abstraction — every finding is a structured signal with type, severity, confidence, evidence, and location.
-- **Snapshots** (`TestSuiteSnapshot`) are the canonical serialized artifact — the full structural model at a point in time.
-- **Unified graph** spans source files, test files, prompt files, eval scenarios, model artifacts, and the typed edges between them.
-
-[DESIGN.md](DESIGN.md) has the package map. [docs/architecture/](docs/architecture/) has the technical design documents.
+Onboarding to a repo with existing debt: add `--new-findings-only --baseline=<file>` so prior signals don't fail the first PR.
 
 ## Documentation
 
 - [Quickstart](docs/quickstart.md) — first report in 5 minutes
 - [Product vision](docs/product/vision.md) — the full narrative
-- [Signal catalog](docs/signal-catalog.md) — every detector, what it fires on
+- [Signal catalog](docs/signal-catalog.md) — every detector and what it fires on
 - [CLI reference](docs/cli-spec.md) — every command and flag
-- [JSON schema](docs/json-schema.md) — for tooling that reads Terrain output
-- [Examples](docs/examples/) — sample analyze / impact / insights / explain reports
-- [Feature status](docs/release/feature-status.md) — stable / experimental / planned
-- [Compatibility](docs/compatibility.md) — supported OSes, Go versions, frameworks
-- [CHANGELOG](CHANGELOG.md), [CONTRIBUTING](CONTRIBUTING.md), [SECURITY](SECURITY.md)
+- [Examples](docs/examples/) — sample analyze / impact / insights / explain output
+- [Architecture](DESIGN.md) — unified graph, signal model, package map
+- [Feature status](docs/release/feature-status.md) — stable, experimental, planned
 
-## Development
-
-```bash
-go build -o terrain ./cmd/terrain
-go test ./cmd/... ./internal/...
-make release-verify
-```
-
-## License
-
-Apache License 2.0 — see [LICENSE](LICENSE).
+[CHANGELOG](CHANGELOG.md) · [CONTRIBUTING](CONTRIBUTING.md) · [SECURITY](SECURITY.md) · License: Apache 2.0


### PR DESCRIPTION
## Summary

Tightening pass on the v1 rewrite (PR #180) after feedback that it was still too defensive and a little vague.

- Opens with three concrete behavior claims (change a prompt, add an agent, touch a training pipeline) instead of an abstract pitch
- Cuts the \"doesn't replace Ruff / ESLint\" hedge — confident products don't pre-disclaim what they aren't
- Cuts the \"What Terrain doesn't do\" section entirely (six anti-claims that say nothing positive)
- Trims the detector list from 11 to 5 — only the boundary-gap moat detectors, not the AI hygiene patterns that overlap with Semgrep / secret scanners
- Cuts Snapshots, Policy, Architecture, and What's-stable-in-0.2 sections — all link out to docs

**Length: 169 → 85 lines.**

## Test plan

- [ ] Render check on GitHub
- [ ] Detector names still match \`internal/signals/signal_types.go\`
- [ ] All linked docs paths exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)