### PR TITLE
Phase 3: gate `terrain mechanisms` behind TERRAIN_DEV; align DESIGN.md/CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,11 @@ All notable changes to Terrain are documented here. The format follows
   on stdio and loads the most-recent `terrain analyze` artifacts from
   `.terrain/`. (The server existed previously; it just wasn't reachable
   from the CLI.)
-- **`terrain doctor` infra checks** for the mechanisms registry, the
-  signal-type alias registry, the `.terrain/shadow-report.jsonl` sink,
-  and whether `.gitignore` covers `.terrain/`. Surfaces hygiene gaps
-  (e.g. shadow sink absent, runtime cache not gitignored) the legacy
-  doctor missed.
+- **`terrain doctor` infra checks** for the detector registry, the
+  signal-type alias registry, and whether `.gitignore` covers
+  `.terrain/`. Additional maintainer-only checks (per-state detector
+  breakdown, shadow-sink presence + byte count) surface only when
+  `TERRAIN_DEV=1` is set, so the default doctor output stays tight.
 - **`.terrain/shadow-report.jsonl`** sink: an append-only log of
   would-suppress / would-add events emitted by mechanisms in shadow state.
   Buffered writes; flushed on pipeline exit. `.terrain/.gitignore` is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,9 @@ All notable changes to Terrain are documented here. The format follows
   detected frameworks, AI surfaces, schema files, trace logs — followed by
   three copy-pasteable next-step commands. Strictly read-only: no
   `.terrain/` directory is created until you opt in via `terrain init`.
-- **`--mechanisms.<name>=on|off|shadow` CLI flag** plus `terrain mechanisms
-  list/show` for inspecting available detector mechanisms. Each entry is
-  tagged `preview` (no observable effect when flipped) or `live` (an active
-  gate that changes detector output). One mechanism
-  (`deprecated_test_pattern_trigger_gate`) ships live as a reference
-  consumer wiring; the rest are preview.
+- **`--mechanisms.<name>=on|off|shadow` runtime override** for per-detector
+  shadow/live experiments. Internal mechanism inspection verbs are
+  maintainer-only and gated behind `TERRAIN_DEV=1`.
 - **`terrain mcp`** is now a top-level command that starts the MCP server
   on stdio and loads the most-recent `terrain analyze` artifacts from
   `.terrain/`. (The server existed previously; it just wasn't reachable

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,16 +1,19 @@
 # Terrain — Architecture Overview
 
-Terrain is a CI gate for AI/ML systems. It treats unit tests, integration tests, e2e tests, and AI/ML evals as nodes in a single dependency graph and surfaces failures in that graph as native test cases in the platform's Tests tab — not as comments, dashboards, or emails.
+> **Pre-flight checks for AI/ML systems and the tests around them. Locally, no API key required.**
+
+Terrain is a static analyzer that treats unit tests, integration tests, e2e tests, and AI/ML evals as one dependency graph. It catches prompt-schema drift, train/test leakage, eval coverage gaps, model deprecations, framework-migration blockers, untested exports, and the cross-language cause chains general-purpose tools miss — locally, deterministically, on every PR.
 
 The product story lives in [`docs/PRODUCT.md`](docs/PRODUCT.md). This document is the technical companion: what packages exist, what artifacts they produce, and where the integration boundaries sit.
 
 ## Core principles
 
 - **Signals are the core abstraction.** Every finding is a structured signal with type, severity, evidence, and location. See `internal/signals/manifest.go` for the manifest model.
-- **The snapshot is the integration boundary.** `TestSuiteSnapshot` (`internal/models/snapshot.go`) is the serialized artifact at which detection, graph construction, impact analysis, and reporting compose. Anything that can serialize into the snapshot inherits graph traversal, impact analysis, and the diagnostic-rendering pipeline. (Note: at 0.2.0, the impact-selection code paths consult the typed graph rather than direct-scanning `LinkedCodeUnits` — see Tier 0 work in [`docs/cli-spec.md`](docs/cli-spec.md).)
+- **The snapshot is the integration boundary.** `TestSuiteSnapshot` (`internal/models/snapshot.go`) is the serialized artifact at which detection, graph construction, impact analysis, and reporting compose. Anything that can serialize into the snapshot inherits graph traversal, impact analysis, and the diagnostic-rendering pipeline.
 - **Risk must be explainable.** Risk surfaces are derived from signals with transparent scoring, not opaque scores.
-- **Local-first.** Terrain runs on a developer machine or CI runner with no accounts, SaaS, or network access required. The default configuration makes zero outbound network calls (verifiable via `terrain --print-network`).
+- **Local-first, LLM-free by default.** Terrain runs on a developer machine or CI runner with no accounts, SaaS, or network access required. No LLM API key is ever required. The default configuration makes zero outbound network calls (verifiable via `terrain --print-network`).
 - **Privacy boundary.** Aggregate metrics and benchmark exports never expose raw file paths or source code. Adopters with stringent code-confidentiality requirements can set `redact_source: true` in `terrain.yaml`.
+- **Two-tier severity.** Detectors are explicitly classified as `gate` (counts toward `--fail-on=*` gate decisions) or `observability` (informational only). The tier is mandatory on every manifest entry — no implicit default.
 
 ## Pipeline
 
@@ -35,24 +38,23 @@ Per `docs/PRODUCT.md` §7 (Architecture — three-surface model), Terrain has th
 | Surface | Renderers | Interactivity | LLM |
 |---|---|---|---|
 | **CI** | JUnit XML, GitHub check-run annotations, Step Summary, status check | One-shot, passive | Never |
-| **CLI** (`terrain test`, `terrain explain`) | Terminal (cargo-style), JUnit, JSON | Developer-driven; supports follow-up questions | Optional (Ollama default, BYOK, or none) |
+| **CLI** (`terrain analyze`, `terrain report explain`) | Terminal (cargo-style), JUnit, JSON | Developer-driven; supports follow-up questions | Optional (Ollama default, BYOK, or none) |
 | **Agent** (MCP server) | MCP tool responses to Claude Code / Cursor / Apps SDK | Conversational | The agent's LLM (adopter's existing subscription) |
 
-The artifact-as-handoff contract decouples surfaces. The CI surface can ship at full quality without LLM features ever existing; the CLI and agent surfaces are additive enrichments.
+The artifact-as-handoff contract decouples surfaces. The CI surface ships at full quality without LLM features ever existing; the CLI and agent surfaces are additive enrichments.
 
 ## Package map
 
 ```
 cmd/terrain/                  CLI entry point (adopter-facing)
 cmd/internal/                 Maintainer-only tooling (not in adopter binary surface):
-  terrain-corpus/             Corpus management (extract, gate at 0.2.0)
-  terrain-precision/          Detector precision benchmarking (score, compare at 0.2.0)
   terrain-bench/              Performance benchmarking
   terrain-bench-gate/         Benchmark regression gate (CI)
   terrain-convert-bench/      Conversion benchmark vs legacy reference
   terrain-docs-gen/           Doc stub generation from signal manifest
   terrain-docs-linkcheck/     Intra-repo markdown link check
   terrain-parity-gate/        Per-pillar parity gate
+  terrain-regression-gate/    Recall-regression gate
   terrain-truth-verify/       Manifest vs feature-status consistency check
   terrain-truthcheck/         Ground-truth fixture verifier
   terrain-voice-lint/         Voice and tone lint
@@ -67,11 +69,13 @@ internal/                     Core libraries (see internal/README.md for full li
   impact/                     Change-scope analysis and impact propagation
   measurement/                Posture-band computation
   models/                     Canonical data types (TestSuiteSnapshot, CodeSurface, Eval, etc.)
+  policy/                     Per-repo policy loader (enabled / disabled detector sets)
   quality/                    General test-quality detectors (mapped to hygiene/* and coverage/* rules at 0.2.0)
   reporting/                  Diagnostic format renderers (terminal, JUnit, GH annotations, Step Summary, SARIF)
   runtime/                    Test runtime artifact ingestion (JUnit, Jest/Vitest JSON)
   severity/                   Severity rubric and clause references
   signals/                    Signal manifest (rule registry; per-rule status: stable | experimental | planned)
+  structural/                 Structural detectors (graph + AST joins)
   testcase/                   Per-language test extraction (AST + regex fallback)
   testtype/                   Test classification (unit / integration / e2e / component / smoke)
 extension/vscode/             VS Code Marketplace extension (alpha at 0.2.0)
@@ -86,18 +90,18 @@ The complete adopter-facing CLI is documented in [`docs/cli-spec.md`](docs/cli-s
 
 | Command | Purpose |
 |---|---|
-| `terrain test [path]` | Run analysis, emit findings (cargo-style terminal + JUnit + GH annotations + Step Summary) |
-| `terrain test --json` | Stable JSON output (`version: 1`) |
-| `terrain test --junit <path>` | JUnit XML to specified path |
-| `terrain test --sarif <path>` | SARIF 2.1.0 for `security/*` findings |
-| `terrain explain <rule>` | Narrative explanation (LLM-enriched if configured; template-only otherwise) |
-| `terrain explain --from-run <id>` | Read from CI artifact, no local reproduction needed |
-| `terrain describe` | Generate surface descriptions (LLM-mediated; first-run UX with security-friendly defaults) |
-| `terrain accept-snapshot [id]` | Accept a baseline change (for `regression/snapshot-mismatch`) |
-| `terrain init` | Initialize `terrain.yaml` with sensible defaults |
-| `terrain --print-network` | Audit: list every external call Terrain would make under current config |
-
-Plus the conversion subsystem's CLI (`convert`, `migrate`, `detect`, etc.) — a parallel capability sharing the AST infrastructure but with its own product narrative.
+| `terrain analyze [path]` | What is the state of our test system? Primary entry point. |
+| `terrain test [flags]` | CI-mode wrapper around analyze (emits JUnit XML + GH annotations). |
+| `terrain report <verb>` | Read-side queries: `insights`, `impact`, `explain`, `summary`, `metrics`, `status`, `checklist`, `readiness`, `blockers`, `preview`. |
+| `terrain migrate <verb>` | Framework conversion + migration workflow. |
+| `terrain ai <verb>` | Eval scenarios: `list`, `run`, `doctor`, `record`, `baseline`, `replay`, `findings`. |
+| `terrain config <verb>` | Workspace prefs: `feedback`, `telemetry`. |
+| `terrain init [path]` | Set up Terrain in a repository. |
+| `terrain doctor [path]` | Diagnostics for current setup. |
+| `terrain mcp [--root <dir>]` | Start the MCP server on stdio for AI assistants. |
+| `terrain serve [flags]` | Local HTTP server with HTML report + JSON API. |
+| `terrain portfolio [flags]` | Multi-repo workspace intelligence. |
+| `terrain --print-network` | Audit: list every external call Terrain would make under current config. |
 
 ## Key design documents
 
@@ -106,16 +110,12 @@ Plus the conversion subsystem's CLI (`convert`, `migrate`, `detect`, etc.) — a
 | [`docs/PRODUCT.md`](docs/PRODUCT.md) | Canonical product plan (mission, goals, rule catalog, validation harness) |
 | [`docs/OVERVIEW.md`](docs/OVERVIEW.md) | 1-pager for senior decision-makers evaluating Terrain for adoption |
 | [`docs/LIMITATIONS.md`](docs/LIMITATIONS.md) | Honest list of what 0.2.0 does *not* do |
-| [`internal/docs/HARNESS.md`](internal/docs/HARNESS.md) | Validation harness internals (corpora, validators, readiness cards) |
 | [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) | RFC process, governance, rule lifecycle, issue triage |
 | [`docs/rules/_template.md`](docs/rules/_template.md) | Canonical rule-page template |
 | [`docs/integrations/_template.md`](docs/integrations/_template.md) | Canonical integration-doc template |
 | [`SECURITY.md`](SECURITY.md) | Coordinated-disclosure policy |
 | [`SECURITY-DATA-HANDLING.md`](SECURITY-DATA-HANDLING.md) | Data-flow doc for security review |
 | [`rfcs/`](rfcs/) | RFCs for significant changes |
-| [`internal/docs/architecture.md`](internal/docs/architecture.md) | Layered architecture detail |
-| [`internal/docs/signal-model.md`](internal/docs/signal-model.md) | Signal abstraction and schema |
-| [`docs/signal-catalog.md`](docs/signal-catalog.md) | Signal types and categories |
 | [`docs/cli-spec.md`](docs/cli-spec.md) | Full CLI command and flag reference |
 
 ## Vocabulary
@@ -123,11 +123,11 @@ Plus the conversion subsystem's CLI (`convert`, `migrate`, `detect`, etc.) — a
 Canonical terms used in this doc and across `docs/PRODUCT.md`:
 
 - **Surface** — point in the codebase where an AI/ML system is exposed (LLM call site, model inference endpoint, feature pipeline, prompt template, training script)
-- **Eval** — oracle that produces a verdict on a surface's behavior. Vocabulary rename from earlier "scenario" usage is a Tier 0 must-ship item ([`docs/cli-spec.md`](docs/cli-spec.md)).
+- **Eval** — oracle that produces a verdict on a surface's behavior
 - **Metric** — score produced by an eval (rubric score, accuracy, F1, AUC, drift KL, latency, cost)
 - **Finding** — single result from one rule, rendered to four surfaces
 - **Rule** — configurable detection capability with stable ID (`terrain/<category>/<rule>`), severity default, doc page
-- **Tier** — stable or preview (stable rules ship default-on at LB-measured quality; preview rules ship default-off as scope-under-evaluation)
+- **Tier** — `gate` (counts toward `--fail-on=*`) or `observability` (informational). Mandatory on every manifest entry — no implicit default.
 - **Cause path** — chain of graph nodes from a finding's primary location back to the change in the PR that caused it
 - **Unified graph** — dependency graph spanning code, tests, surfaces, evals, data, and cross-language edges (bidirectional cause attribution)
 
@@ -136,17 +136,17 @@ Canonical terms used in this doc and across `docs/PRODUCT.md`:
 Per `docs/PRODUCT.md` §11 (Stability commitments):
 
 - Rule IDs (`terrain/<category>/<rule>` namespace)
-- JSON output schema (`version: 1` on `terrain pr --json` and `findings.json`)
+- JSON output schema (`version: 1` on `terrain report pr --json` and `findings.json`)
 - `terrain.yaml` schema (versioned `v1`; closed-enumeration for surface types)
 - CLI flags
 - Artifact format (JUnit XML structure, SARIF for security rules, `findings.json` shape)
-- Documented load-bearing quality bars
+- Documented quality bars
 
 All follow the one-cycle deprecation contract per `docs/PRODUCT.md` §14 (Versioning).
 
 ## Migration context
 
-Terrain originated as a multi-framework test converter. That migration surface lives in `internal/convert/` and the conversion-subsystem CLI (`convert`, `migrate`, `detect`, etc.). It ships in the same binary as the AI/ML CI gate at 0.2.0 and is stable from the 0.2.0 release tag, but is positioned as a parallel product capability with its own narrative.
+Terrain originated as a multi-framework test converter. That migration surface lives in `internal/convert/` and the conversion-subsystem CLI (`migrate`, `convert`, `detect`, etc.). It ships in the same binary as the AI/ML CI gate at 0.2.0 and is stable from the 0.2.0 release tag, but is positioned as a parallel product capability with its own narrative.
 
 Pre-0.2.0 was unstable by design; 0.2.0 is the first release with stability commitments. Adopters using pre-0.2.0 versions treat 0.2.0 as a fresh install.
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -117,6 +117,7 @@ The complete adopter-facing CLI is documented in [`docs/cli-spec.md`](docs/cli-s
 | [`SECURITY-DATA-HANDLING.md`](SECURITY-DATA-HANDLING.md) | Data-flow doc for security review |
 | [`rfcs/`](rfcs/) | RFCs for significant changes |
 | [`docs/cli-spec.md`](docs/cli-spec.md) | Full CLI command and flag reference |
+| [`docs/signal-catalog.md`](docs/signal-catalog.md) | Signal types, categories, and the four-tier data-availability model |
 
 ## Vocabulary
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ These are explicit non-claims:
 Terrain gives AI components the same CI safety net as regular tests:
 
 - **Surface discovery** — automatically detects prompts, contexts, datasets, tool definitions, RAG pipelines, and eval scenarios in your code
-- **Calibrated findings** — `terrain ai findings` emits findings with a confidence score, severity, cohort, and full evidence chain. Per-rule false-positive rate is published per release in the readiness cards
+- **AI eval-gap findings** — `terrain ai findings` emits findings with a confidence score, severity, cohort, and full evidence chain. Per-rule false-positive rate is published per release in the readiness cards.
 - **Impact-scoped selection** — `terrain ai run --base main` runs only the eval scenarios affected by your change
 - **Protection gaps** — `terrain pr` flags changed AI surfaces that have no eval scenario covering them
 - **Policy enforcement** — block PRs that modify uncovered AI surfaces, regress accuracy, or trigger safety failures
@@ -305,12 +305,12 @@ Terrain gives AI components the same CI safety net as regular tests:
 The same structural graph that powers test selection for regular code also traces AI surface dependencies, so a change to a prompt template triggers the right eval scenarios automatically.
 
 ```bash
-terrain ai findings                      # observability posture (≥0.40)
-terrain ai findings --posture=gate       # gate posture (≥0.80)
+terrain ai findings                      # observability posture
+terrain ai findings --posture=gate       # gate posture
 terrain ai findings --json               # CI-consumable output
 ```
 
-`terrain ai list` (inventory), `terrain ai findings` (calibrated findings via the verdict engine), and the AI catalog detectors (via `terrain analyze`) answer different questions — run all three in CI.
+`terrain ai list` (inventory), `terrain ai findings` (AI eval-gap findings), and the AI catalog detectors (via `terrain analyze`) answer different questions — run all three in CI.
 
 ## Installation
 

--- a/cmd/terrain/cmd_ai_findings.go
+++ b/cmd/terrain/cmd_ai_findings.go
@@ -11,8 +11,8 @@ import (
 	"github.com/pmclSF/terrain/internal/aipiperun"
 )
 
-// runAIFindings is the user-facing entry point for the calibrated
-// aipipeline. It walks the repo root through the full pipeline
+// runAIFindings is the user-facing entry point for the AI eval-gap
+// findings pipeline. It walks the repo root through the full pipeline
 // (path-prefilter -> regex-fastscan -> ast-confirm -> cross-file-scope
 // -> change-scope -> composer) and renders the surviving findings.
 //

--- a/cmd/terrain/cmd_ai_findings.go
+++ b/cmd/terrain/cmd_ai_findings.go
@@ -120,7 +120,7 @@ func renderFindingsText(findings []aipipeline.Finding, posture aipipeline.Postur
 			fmt.Printf("    cohort:     %s\n", f.Cohort)
 		}
 		if previewTag != "" {
-			fmt.Printf("    NOTE:       this rule is in preview — confidence number is not yet corpus-validated\n")
+			fmt.Printf("    NOTE:       this rule is in preview — behavior may change between releases\n")
 		}
 		if len(f.Atoms) > 0 {
 			fmt.Printf("    evidence:\n")

--- a/cmd/terrain/cmd_convert.go
+++ b/cmd/terrain/cmd_convert.go
@@ -421,7 +421,7 @@ func runListConversions(jsonOutput bool) error {
 		}
 		fmt.Println()
 	}
-	fmt.Println("Tiers: Stable = conversion-corpus calibrated; Experimental = end-to-end but expect hand cleanup; Preview = next up for implementation; Cataloged = metadata only.")
+	fmt.Println("Tiers: Stable = validated; Experimental = end-to-end but expect hand cleanup; Preview = planned; Cataloged = metadata only.")
 	fmt.Println("Use `terrain convert <source> --from <framework> --to <framework>` to run a Go-native conversion, or add `--plan` to preview.")
 	return nil
 }
@@ -630,10 +630,10 @@ func humanizeGoNativeState(state conv.GoNativeState) string {
 // just the raw state name.
 //
 // The mapping:
-//   - implemented → "Stable"      (top-3 + conversion-corpus calibrated)
+//   - implemented → "Stable"       (validated)
 //   - experimental → "Experimental" (works end-to-end; hand cleanup expected)
-//   - prioritized → "Preview"     (next in line for implementation)
-//   - cataloged   → "Cataloged"    (metadata only; no converter today)
+//   - prioritized → "Preview"      (planned)
+//   - cataloged   → "Cataloged"     (metadata only; no converter today)
 //
 // Returned without surrounding brackets so callers can wrap as needed
 // (the list renderer adds `[ ]`; JSON consumers get the bare label).

--- a/cmd/terrain/cmd_discover.go
+++ b/cmd/terrain/cmd_discover.go
@@ -140,7 +140,7 @@ func runDiscover(root string) error {
 		fmt.Println("  Nothing AI-specific detected. Run `terrain analyze` for the full posture report.")
 	case hasAI:
 		fmt.Println("  terrain analyze                  # full posture: signals, coverage, fanout, drift")
-		fmt.Println("  terrain ai findings              # calibrated AI risks (no API key required)")
+		fmt.Println("  terrain ai findings              # AI eval-gap findings (no API key required)")
 		fmt.Println("  terrain report explain <finding> # drill into a specific finding")
 	default:
 		fmt.Println("  terrain analyze                  # full posture: signals, coverage, fanout, drift")

--- a/cmd/terrain/cmd_workflow.go
+++ b/cmd/terrain/cmd_workflow.go
@@ -372,30 +372,36 @@ func runDoctor(root string, jsonOutput, verbose bool) (conv.MigrationDoctorResul
 func terrainInfraDoctorChecks(root string) []conv.MigrationDoctorCheck {
 	var checks []conv.MigrationDoctorCheck
 
-	// Mechanisms registry — load it; report counts by state.
+	// Detector registry — load it; surface only the load result. The
+	// per-state breakdown is internal and only meaningful with
+	// TERRAIN_DEV=1.
 	if reg, err := mechanisms.Load(); err != nil {
 		checks = append(checks, conv.MigrationDoctorCheck{
-			ID: "mechanisms.registry", Label: "Mechanisms registry",
+			ID: "mechanisms.registry", Label: "Detector registry",
 			Status: "FAIL",
 			Detail: fmt.Sprintf("could not load registry: %v", err),
 		})
 	} else {
 		all := reg.All()
-		var on, shadow, off int
-		for _, m := range all {
-			switch m.State {
-			case mechanisms.StateOn:
-				on++
-			case mechanisms.StateShadow:
-				shadow++
-			default:
-				off++
+		detail := fmt.Sprintf("%d detectors registered", len(all))
+		if os.Getenv("TERRAIN_DEV") != "" {
+			var on, shadow, off int
+			for _, m := range all {
+				switch m.State {
+				case mechanisms.StateOn:
+					on++
+				case mechanisms.StateShadow:
+					shadow++
+				default:
+					off++
+				}
 			}
+			detail = fmt.Sprintf("%d detectors registered (live=%d, shadow=%d, off=%d)", len(all), on, shadow, off)
 		}
 		checks = append(checks, conv.MigrationDoctorCheck{
-			ID: "mechanisms.registry", Label: "Mechanisms registry",
+			ID: "mechanisms.registry", Label: "Detector registry",
 			Status: "PASS",
-			Detail: fmt.Sprintf("%d mechanisms loaded (live=%d, shadow=%d, off=%d)", len(all), on, shadow, off),
+			Detail: detail,
 		})
 	}
 
@@ -414,23 +420,23 @@ func terrainInfraDoctorChecks(root string) []conv.MigrationDoctorCheck {
 		})
 	}
 
-	// Shadow sink — `.terrain/shadow-report.jsonl` is optional; if it
-	// exists, report its size so the user knows shadow data is being
-	// captured.
-	shadowPath := filepath.Join(root, ".terrain", "shadow-report.jsonl")
-	if info, err := os.Stat(shadowPath); err == nil {
-		checks = append(checks, conv.MigrationDoctorCheck{
-			ID: "shadow.sink", Label: "Shadow sink",
-			Status: "PASS",
-			Detail: fmt.Sprintf("%s present (%d bytes)", shadowPath, info.Size()),
-		})
-	} else {
-		checks = append(checks, conv.MigrationDoctorCheck{
-			ID: "shadow.sink", Label: "Shadow sink",
-			Status: "WARN",
-			Detail: "no shadow events captured yet (.terrain/shadow-report.jsonl absent)",
-			Remediation: "Run `terrain analyze` once with one or more mechanisms in shadow state to populate the sink.",
-		})
+	// Shadow sink — optional debug artifact; only reported under
+	// TERRAIN_DEV so end-user doctor output stays uncluttered.
+	if os.Getenv("TERRAIN_DEV") != "" {
+		shadowPath := filepath.Join(root, ".terrain", "shadow-report.jsonl")
+		if info, err := os.Stat(shadowPath); err == nil {
+			checks = append(checks, conv.MigrationDoctorCheck{
+				ID: "shadow.sink", Label: "Shadow sink",
+				Status: "PASS",
+				Detail: fmt.Sprintf("%s present (%d bytes)", shadowPath, info.Size()),
+			})
+		} else {
+			checks = append(checks, conv.MigrationDoctorCheck{
+				ID: "shadow.sink", Label: "Shadow sink",
+				Status: "WARN",
+				Detail: "no shadow events captured yet",
+			})
+		}
 	}
 
 	// .gitignore for .terrain/ — warn if .gitignore exists but doesn't

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -195,7 +195,7 @@ func main() {
 		timeoutFlag := analyzeCmd.Duration("timeout", 0, "abort the analysis after this duration (e.g. 5m); 0 means no timeout")
 		suppressionsFlag := analyzeCmd.String("suppressions", "", "path to .terrain/suppressions.yaml (default: $root/.terrain/suppressions.yaml; missing file is fine)")
 		newOnlyFlag := analyzeCmd.Bool("new-findings-only", false, "filter signals to those NOT present in --baseline (lets established repos with debt adopt --fail-on without bricking CI)")
-		previewFlag := analyzeCmd.Bool("preview", false, "enable preview-tier AI detectors (default off; not yet calibrated)")
+		previewFlag := analyzeCmd.Bool("preview", false, "enable preview-tier AI detectors (default off; behavior may change between releases)")
 		diagFlag := analyzeCmd.Bool("diag", false, "print per-step pipeline timing diagnostics to stderr (for performance investigation)")
 		_ = analyzeCmd.Parse(os.Args[2:])
 		mountPositionalAsRoot("analyze", analyzeCmd.Args(), rootFlag)
@@ -344,6 +344,13 @@ func main() {
 		os.Exit(runDoctorCLI(os.Args[2:]))
 
 	case "mechanisms":
+		// Maintainer-only inspection of detector internals. Hidden from
+		// --help and gated on TERRAIN_DEV so end-user CLI surfaces
+		// don't expose internal mechanism IDs.
+		if os.Getenv("TERRAIN_DEV") == "" {
+			fmt.Fprintln(os.Stderr, "error: unknown command \"mechanisms\"")
+			os.Exit(2)
+		}
 		if err := runMechanismsCLI(os.Args[2:]); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(exitCodeForCLIError(err))
@@ -810,7 +817,7 @@ func main() {
 			rootFlag := aiCmd.String("root", ".", "repository root to analyze")
 			jsonFlag := aiCmd.Bool("json", false, "output JSON")
 			postureFlag := aiCmd.String("posture", "observability",
-				"emission posture: observability (≥0.40) | gate (≥0.80)")
+				"emission posture: observability | gate")
 			ruleFlag := aiCmd.String("rule", "",
 				"rule to evaluate (default: ai.surface.missing_eval; see docs/rules/ai/)")
 			_ = aiCmd.Parse(os.Args[3:])
@@ -1037,7 +1044,7 @@ var knownCommands = []string{
 	"ai", "feedback", "telemetry",
 	"debug", "depgraph",
 	"version", "serve", "help", "--help", "-h",
-	"mechanisms", "mcp",
+	"mcp",
 	"suppress", "test", "describe", "accept-snapshot",
 	"report", "config",
 }
@@ -1227,7 +1234,6 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "                            baseline, replay")
 	fmt.Fprintln(os.Stderr, "  config <verb> [flags]     workspace prefs: feedback, telemetry")
 	fmt.Fprintln(os.Stderr, "  doctor [path]             diagnostics for current setup")
-	fmt.Fprintln(os.Stderr, "  mechanisms <verb>         list / show detector mechanisms (list, show)")
 	fmt.Fprintln(os.Stderr, "  mcp [--root <dir>]        start the MCP server on stdio for AI assistants")
 	fmt.Fprintln(os.Stderr, "  debug <verb> [flags]      dependency graph drill-downs:")
 	fmt.Fprintln(os.Stderr, "                            graph, coverage, fanout, duplicates, depgraph")
@@ -1247,9 +1253,6 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  --base REF                        git base ref for diff (impact / pr / select-tests)")
 	fmt.Fprintln(os.Stderr, "  --baseline PATH                   baseline snapshot for regression detectors")
 	fmt.Fprintln(os.Stderr, "  --log-level LEVEL                 diagnostic verbosity: quiet, debug (default: info)")
-	fmt.Fprintln(os.Stderr, "  --mechanisms.<name>=<state>       override one detector mechanism per run")
-	fmt.Fprintln(os.Stderr, "                                    states: on | off | shadow")
-	fmt.Fprintln(os.Stderr, "                                    list available names: terrain mechanisms list")
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Legacy aliases (still work; scheduled for future removal — see CHANGELOG):")
 	fmt.Fprintln(os.Stderr, "  init [flags]             detect data paths and print recommended analyze command")
@@ -1332,8 +1335,8 @@ func printAIUsage() {
 	fmt.Fprintln(os.Stderr, "  baseline   manage eval baselines (show, compare, promote)")
 	fmt.Fprintln(os.Stderr, "  doctor     validate AI/eval setup and surface configuration issues")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, "Calibrated verdicts (0.2+):")
-	fmt.Fprintln(os.Stderr, "  findings   emit calibrated AI eval-gap findings (verdict pipeline)")
+	fmt.Fprintln(os.Stderr, "Per-rule AI findings:")
+	fmt.Fprintln(os.Stderr, "  findings   emit AI eval-gap findings for the specified rule")
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "Categorical AI quality checks ship via 'terrain analyze'")
 	fmt.Fprintln(os.Stderr, "and 'terrain report pr'. Run 'terrain analyze --help' for the full")


### PR DESCRIPTION
## Summary

Hide internal mechanism IDs from end-user CLI surfaces and align the framing across README / DESIGN.md / CHANGELOG.

\`terrain mechanisms list\` and \`terrain mechanisms show <name>\` previously exposed internal mechanism code-names (\`a1_def_following\`, \`a7_barrel_resolver\`, \`ascg_live_vs_catalog\`, \`surface_literal_presence_gate\`, \`runtime_config_recognizer\`, etc.) and their methodology descriptions to anyone running the binary. Now the verb returns "unknown command" unless \`TERRAIN_DEV=1\` is set. The \`--mechanisms.<name>=<state>\` runtime override still works (so maintainers' debugging hooks aren't lost) but is no longer advertised in \`--help\`.

\`terrain doctor\` per-state mechanism breakdown + \`.terrain/shadow-report.jsonl\` byte count are now \`TERRAIN_DEV\`-gated; default output shows the cleaner \`Detector registry: 10 detectors registered\`.

DESIGN.md previously opened with "CI gate for AI/ML systems" and a \`terrain test\` family CLI list that didn't match either README or \`printUsage\`. Rewritten to match README's "Pre-flight checks for AI/ML systems and the tests around them. Locally, no API key required." and the actual canonical commands (\`analyze\` / \`test\` / \`init\` / \`report <verb>\` / \`migrate <verb>\` / \`ai <verb>\` / \`config <verb>\` / \`doctor\` / \`mcp\` / \`debug\` / \`portfolio\` / \`serve\`).

## What's in here (3 commits)

- \`6009f329\` — gate \`mechanisms\` CLI; scrub help-text leaks (\`--preview\` "not yet calibrated", \`ai findings\` posture threshold numbers, \`ai --help\` "Calibrated verdicts" / "verdict pipeline", \`discover\` "calibrated AI risks", \`migrate list\` "conversion-corpus calibrated").
- \`19c0b00e\` — rewrite DESIGN.md to README's framing; update CHANGELOG \`Unreleased\` to reflect \`TERRAIN_DEV\` gating.
- \`a690b073\` — review findings: CHANGELOG \`Unreleased\` doctor-check description now matches the user-visible reality (\`Detector registry\` + alias registry + \`.gitignore\` check; per-state breakdown + shadow-sink are \`TERRAIN_DEV\`-gated); README \`AI Testing in CI\` section scrubbed of \`Calibrated findings\` / \`(≥0.40)\` / \`(≥0.80)\` / \`verdict engine\`; \`cmd_ai_findings.go\` doc-comment scrubbed; DESIGN.md adds back \`docs/signal-catalog.md\` link.

## Test plan
- [x] \`go test ./...\` green
- [x] \`terrain mechanisms list\` → \`error: unknown command "mechanisms"\` (exit 2)
- [x] \`TERRAIN_DEV=1 terrain mechanisms list\` → table renders, ID names visible
- [x] \`terrain --help\` and every sub-help variant clean of banned vocabulary
- [x] \`terrain doctor\` default + \`TERRAIN_DEV=1 terrain doctor\` both render correctly
- [x] \`terrain analyze --mechanisms.X=on\` runtime override still functional