### PR TITLE
Phase 5a: BLOCK/GATE/WATCH/NOTE labels + alias-aware suppression API

### DIFF
--- a/internal/suppression/suppression.go
+++ b/internal/suppression/suppression.go
@@ -52,6 +52,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/pmclSF/terrain/internal/aliases"
 	"github.com/pmclSF/terrain/internal/models"
 )
 
@@ -163,7 +164,25 @@ func Load(path string) (*LoadResult, error) {
 //  3. Rewrite the signal slices without matched signals.
 //
 // `now` is injected so tests can drive expiry deterministically.
+//
+// Calls ApplyWithAliases with a nil registry — `signal_type` matches
+// require literal-string equality. Callers that want a renamed-rule
+// suppression to also suppress the new ID during the deprecation
+// window should use ApplyWithAliases.
 func Apply(snapshot *models.TestSuiteSnapshot, entries []Entry, now time.Time) (matched []Entry, expired []Entry) {
+	return ApplyWithAliases(snapshot, entries, nil, now)
+}
+
+// ApplyWithAliases is the alias-aware form of Apply. When `reg` is
+// non-nil, `signal_type` entries match any signal whose Type is in
+// `reg.ExpandOldID(e.SignalType)`. The expansion is one-way: a
+// suppression on the OLD rule_id continues to suppress findings
+// emitted under the NEW rule_id(s) during the deprecation window.
+// The reverse (suppression on new ID auto-suppresses findings still
+// labeled old) is deliberately NOT supported — adopters who write
+// suppressions against new IDs are post-migration; the OLD ID will
+// stop firing before the alias entry is removed.
+func ApplyWithAliases(snapshot *models.TestSuiteSnapshot, entries []Entry, reg *aliases.Registry, now time.Time) (matched []Entry, expired []Entry) {
 	if snapshot == nil {
 		return nil, nil
 	}
@@ -185,12 +204,28 @@ func Apply(snapshot *models.TestSuiteSnapshot, entries []Entry, now time.Time) (
 		return nil, expired
 	}
 
+	// Pre-expand each entry's SignalType into a set so the inner loop
+	// is O(1) per signal-type compare instead of O(n_aliases).
+	expanded := make([]map[string]bool, len(active))
+	for i, e := range active {
+		if e.SignalType == "" {
+			continue
+		}
+		set := map[string]bool{e.SignalType: true}
+		if reg != nil {
+			for _, id := range reg.ExpandOldID(e.SignalType) {
+				set[id] = true
+			}
+		}
+		expanded[i] = set
+	}
+
 	matchedIdx := make(map[int]bool, len(active))
 
-	snapshot.Signals = filterSignals(snapshot.Signals, active, matchedIdx)
+	snapshot.Signals = filterSignals(snapshot.Signals, active, expanded, matchedIdx)
 	for fi := range snapshot.TestFiles {
 		tf := &snapshot.TestFiles[fi]
-		tf.Signals = filterSignals(tf.Signals, active, matchedIdx)
+		tf.Signals = filterSignals(tf.Signals, active, expanded, matchedIdx)
 	}
 
 	for i, e := range active {
@@ -201,7 +236,7 @@ func Apply(snapshot *models.TestSuiteSnapshot, entries []Entry, now time.Time) (
 	return matched, expired
 }
 
-func filterSignals(signals []models.Signal, active []Entry, matchedIdx map[int]bool) []models.Signal {
+func filterSignals(signals []models.Signal, active []Entry, expanded []map[string]bool, matchedIdx map[int]bool) []models.Signal {
 	if len(signals) == 0 {
 		return signals
 	}
@@ -209,7 +244,7 @@ func filterSignals(signals []models.Signal, active []Entry, matchedIdx map[int]b
 	for _, s := range signals {
 		hitIdx := -1
 		for i, e := range active {
-			if matches(e, s) {
+			if matches(e, s, expanded[i]) {
 				hitIdx = i
 				break
 			}
@@ -223,16 +258,24 @@ func filterSignals(signals []models.Signal, active []Entry, matchedIdx map[int]b
 	return kept
 }
 
-// matches returns true if entry e suppresses signal s.
-func matches(e Entry, s models.Signal) bool {
+// matches returns true if entry e suppresses signal s. `expandedTypes`
+// is the pre-computed set of signal-type strings that count as a hit
+// for e (the literal e.SignalType plus any new IDs from the alias
+// registry). Nil/empty set falls back to literal-equality on
+// e.SignalType.
+func matches(e Entry, s models.Signal, expandedTypes map[string]bool) bool {
 	if e.FindingID != "" {
 		return e.FindingID == s.FindingID
 	}
 	// signal_type + file path match.
-	if string(s.Type) != e.SignalType {
+	if e.File == "" {
 		return false
 	}
-	if e.File == "" {
+	if expandedTypes != nil {
+		if !expandedTypes[string(s.Type)] {
+			return false
+		}
+	} else if string(s.Type) != e.SignalType {
 		return false
 	}
 	matched, err := pathMatch(e.File, s.Location.File)

--- a/internal/suppression/suppression_test.go
+++ b/internal/suppression/suppression_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pmclSF/terrain/internal/aliases"
 	"github.com/pmclSF/terrain/internal/identity"
 	"github.com/pmclSF/terrain/internal/models"
 )
@@ -318,4 +319,170 @@ func writeTemp(t *testing.T, body string) string {
 		t.Fatal(err)
 	}
 	return path
+}
+
+// ── ApplyWithAliases (alias-aware suppression) ────────────────────
+
+// TestApplyWithAliases_NilRegistryEquivalentToApply confirms the
+// no-registry path matches literal SignalType only (same as Apply).
+func TestApplyWithAliases_NilRegistryEquivalentToApply(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "ruleA", Location: models.SignalLocation{File: "a.go"}},
+			{Type: "ruleB", Location: models.SignalLocation{File: "b.go"}},
+		},
+	}
+	entries := []Entry{
+		{SignalType: "ruleA", File: "**", Reason: "test"},
+	}
+	matched, expired := ApplyWithAliases(snap, entries, nil, time.Now())
+	if len(matched) != 1 {
+		t.Errorf("matched = %d, want 1", len(matched))
+	}
+	if len(expired) != 0 {
+		t.Errorf("expired = %d, want 0", len(expired))
+	}
+	if len(snap.Signals) != 1 || snap.Signals[0].Type != "ruleB" {
+		t.Errorf("post-Apply signals = %+v, want only ruleB", snap.Signals)
+	}
+}
+
+// TestApplyWithAliases_OldIDSuppressesNew validates the deprecation-
+// window contract: a suppression on the old rule_id continues to
+// suppress findings emitted under any new rule_id from the alias's
+// ReplacesWith list.
+func TestApplyWithAliases_OldIDSuppressesNew(t *testing.T) {
+	yamlBody := []byte(`
+version: 1
+aliases:
+  oldRule:
+    replaces_with: [newRuleA, newRuleB]
+    why: "split for clarity"
+`)
+	reg, err := aliases.LoadFromBytes(yamlBody)
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "newRuleA", Location: models.SignalLocation{File: "a.go"}},
+			{Type: "newRuleB", Location: models.SignalLocation{File: "b.go"}},
+			{Type: "oldRule", Location: models.SignalLocation{File: "c.go"}},
+			{Type: "unrelated", Location: models.SignalLocation{File: "d.go"}},
+		},
+	}
+	entries := []Entry{
+		{SignalType: "oldRule", File: "**", Reason: "deprecation window"},
+	}
+	matched, _ := ApplyWithAliases(snap, entries, reg, time.Now())
+
+	// The single entry should match (counted once, not three times).
+	if len(matched) != 1 {
+		t.Errorf("matched = %d, want 1 (single entry hit)", len(matched))
+	}
+	// Only the unrelated signal should remain.
+	if len(snap.Signals) != 1 || snap.Signals[0].Type != "unrelated" {
+		got := []string{}
+		for _, s := range snap.Signals {
+			got = append(got, string(s.Type))
+		}
+		t.Errorf("post-Apply types = %v, want [\"unrelated\"]", got)
+	}
+}
+
+// TestApplyWithAliases_NewIDSuppressionDoesNotMatchOld is the
+// one-way-contract test: a suppression written against a NEW id does
+// not auto-suppress findings still emitted under the OLD id. Adopters
+// who write suppressions against new IDs are post-migration; the OLD
+// id will have stopped firing.
+func TestApplyWithAliases_NewIDSuppressionDoesNotMatchOld(t *testing.T) {
+	yamlBody := []byte(`
+version: 1
+aliases:
+  oldRule:
+    replaces_with: [newRule]
+`)
+	reg, err := aliases.LoadFromBytes(yamlBody)
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "oldRule", Location: models.SignalLocation{File: "a.go"}},
+		},
+	}
+	entries := []Entry{
+		{SignalType: "newRule", File: "**", Reason: "post-migration"},
+	}
+	matched, _ := ApplyWithAliases(snap, entries, reg, time.Now())
+
+	if len(matched) != 0 {
+		t.Errorf("matched = %d, want 0 (new ID suppression does not match old)", len(matched))
+	}
+	if len(snap.Signals) != 1 {
+		t.Errorf("post-Apply signals = %d, want 1 (old ID retained)", len(snap.Signals))
+	}
+}
+
+// TestApplyWithAliases_FindingIDPathUnaffected: alias expansion only
+// applies to SignalType matching. FindingID-based suppressions
+// continue to require exact match (no alias rewriting).
+func TestApplyWithAliases_FindingIDPathUnaffected(t *testing.T) {
+	yamlBody := []byte(`
+version: 1
+aliases:
+  oldRule:
+    replaces_with: [newRule]
+`)
+	reg, _ := aliases.LoadFromBytes(yamlBody)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "newRule", FindingID: "newRule@a.go:Sym#abc12345", Location: models.SignalLocation{File: "a.go"}},
+		},
+	}
+	entries := []Entry{
+		// FindingID-only entry against a different id — must not match
+		// even though "oldRule" is an alias for "newRule".
+		{FindingID: "oldRule@a.go:Sym#abc12345", Reason: "stale pin"},
+	}
+	matched, _ := ApplyWithAliases(snap, entries, reg, time.Now())
+	if len(matched) != 0 {
+		t.Errorf("matched = %d, want 0 (FindingID requires exact match)", len(matched))
+	}
+}
+
+// TestApplyWithAliases_ExpiryRespected confirms that expired entries
+// are partitioned out before the alias-aware match runs.
+func TestApplyWithAliases_ExpiryRespected(t *testing.T) {
+	yamlBody := []byte(`
+version: 1
+aliases:
+  oldRule:
+    replaces_with: [newRule]
+`)
+	reg, _ := aliases.LoadFromBytes(yamlBody)
+
+	expiredEntry := Entry{SignalType: "oldRule", File: "**", Reason: "x"}
+	expiredEntry.Expires = "2020-01-01"
+	expiredEntry.expiresAt, _ = time.Parse("2006-01-02", expiredEntry.Expires)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "newRule", Location: models.SignalLocation{File: "a.go"}},
+		},
+	}
+	now := time.Now()
+	matched, expired := ApplyWithAliases(snap, []Entry{expiredEntry}, reg, now)
+	if len(matched) != 0 {
+		t.Errorf("matched = %d, want 0 (entry expired)", len(matched))
+	}
+	if len(expired) != 1 {
+		t.Errorf("expired = %d, want 1", len(expired))
+	}
+	if len(snap.Signals) != 1 {
+		t.Errorf("post-Apply signals = %d, want 1 (suppression expired)", len(snap.Signals))
+	}
 }

--- a/internal/uitokens/uitokens.go
+++ b/internal/uitokens/uitokens.go
@@ -170,6 +170,61 @@ func BracketedSeverity(severity string) string {
 	}
 }
 
+// PRLabel returns the four-rung user-visible label for the
+// PR-comment surface: "BLOCK", "GATE", "WATCH", or "NOTE". An empty
+// string means the finding should NOT appear on the PR surface
+// (info-tier signals).
+//
+// The label encodes both gate-relevance and "do I act on this now?"
+// in one token, distinct from the five-rung Critical/High/Medium/Low/
+// Info severity ladder used for internal scoring and JSON output.
+//
+//	BLOCK — gate-tier, Critical severity. Required check fails.
+//	GATE  — gate-tier, High or Medium severity. Required check fails.
+//	WATCH — observability-tier, any severity (capped at Medium).
+//	        Informational check.
+//	NOTE  — Low severity, any tier. Quiet hint.
+//	(Info-tier signals drop from PR surface; JSON output retains them.)
+//
+// `tier` is "gate" or "observability". `severity` is one of
+// "critical", "high", "medium", "low", "info" (the canonical lowercase
+// strings used across the manifest). Unknown combinations return "".
+func PRLabel(tier, severity string) string {
+	severity = strings.ToLower(strings.TrimSpace(severity))
+	tier = strings.ToLower(strings.TrimSpace(tier))
+	if severity == "info" {
+		return ""
+	}
+	if severity == "low" {
+		return "NOTE"
+	}
+	// Above Low: tier decides between gate-shape and watch-shape.
+	if tier == "observability" {
+		return "WATCH"
+	}
+	// Treat empty / unrecognized tier as gate (legacy callers that
+	// don't yet thread the tier through default to the gate label,
+	// matching the pre-Phase-1 behavior).
+	switch severity {
+	case "critical":
+		return "BLOCK"
+	case "high", "medium":
+		return "GATE"
+	}
+	return ""
+}
+
+// BracketedPRLabel returns the PRLabel wrapped in `[...]` for the
+// canonical PR-comment markdown shape, or "" when the finding should
+// drop from the PR surface (info-tier).
+func BracketedPRLabel(tier, severity string) string {
+	label := PRLabel(tier, severity)
+	if label == "" {
+		return ""
+	}
+	return "[" + label + "]"
+}
+
 // BracketedVerdict returns the posture-band verdict in canonical
 // PR-comment shape. Mirrors the changescope renderer's previous
 // inline mapping; centralized here so other renderers can consume

--- a/internal/uitokens/uitokens_test.go
+++ b/internal/uitokens/uitokens_test.go
@@ -397,3 +397,59 @@ func TestColorComposition_BoldOnTopOfColor(t *testing.T) {
 		}
 	})
 }
+
+// ── PRLabel: BLOCK / GATE / WATCH / NOTE ──────────────────────────
+
+// TestPRLabel pins the four-rung user-visible PR-comment label
+// mapping. The four labels (plus the "drop from PR" empty case for
+// info-tier) compress the (tier, severity) cross-product into the
+// vocabulary actual humans use when reading a PR comment.
+func TestPRLabel(t *testing.T) {
+	cases := []struct {
+		name             string
+		tier, severity   string
+		want, wantBracket string
+	}{
+		// Gate-tier rungs.
+		{"gate+critical → BLOCK", "gate", "critical", "BLOCK", "[BLOCK]"},
+		{"gate+high → GATE", "gate", "high", "GATE", "[GATE]"},
+		{"gate+medium → GATE", "gate", "medium", "GATE", "[GATE]"},
+
+		// Observability-tier: capped at Medium per EffectiveSeverity,
+		// but the renderer must handle declared-higher values defensively.
+		{"observability+medium → WATCH", "observability", "medium", "WATCH", "[WATCH]"},
+		{"observability+high → WATCH", "observability", "high", "WATCH", "[WATCH]"},
+		{"observability+critical → WATCH", "observability", "critical", "WATCH", "[WATCH]"},
+
+		// Low severity collapses to NOTE regardless of tier.
+		{"gate+low → NOTE", "gate", "low", "NOTE", "[NOTE]"},
+		{"observability+low → NOTE", "observability", "low", "NOTE", "[NOTE]"},
+
+		// Info-tier drops entirely from the PR surface.
+		{"gate+info → (drop)", "gate", "info", "", ""},
+		{"observability+info → (drop)", "observability", "info", "", ""},
+
+		// Defensive: empty tier defaults to gate-shape (legacy callers
+		// pre-Phase-1 where tier wasn't threaded).
+		{"empty tier+critical → BLOCK", "", "critical", "BLOCK", "[BLOCK]"},
+		{"empty tier+medium → GATE", "", "medium", "GATE", "[GATE]"},
+		{"empty tier+low → NOTE", "", "low", "NOTE", "[NOTE]"},
+
+		// Case-insensitive, whitespace-tolerant.
+		{"casing: GATE/Critical", "GATE", "Critical", "BLOCK", "[BLOCK]"},
+		{"whitespace: ' gate '/ medium ", " gate ", " medium ", "GATE", "[GATE]"},
+
+		// Unknown severity: empty (defensive — caller bug).
+		{"unknown severity drops", "gate", "bogus", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := PRLabel(c.tier, c.severity); got != c.want {
+				t.Errorf("PRLabel(%q, %q) = %q, want %q", c.tier, c.severity, got, c.want)
+			}
+			if got := BracketedPRLabel(c.tier, c.severity); got != c.wantBracket {
+				t.Errorf("BracketedPRLabel(%q, %q) = %q, want %q", c.tier, c.severity, got, c.wantBracket)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Foundational pair for the Phase 5 PR-comment surface redesign.

**P5.5** — Four-rung user-visible PR-comment label (\`BLOCK\` / \`GATE\` / \`WATCH\` / \`NOTE\`) plus info-tier-drops-from-PR-surface.

\`uitokens.PRLabel(tier, severity)\` maps the (Tier, Severity) cross-product to one of four labels:
- gate + Critical → \`BLOCK\`
- gate + High|Medium → \`GATE\`
- observability + anything-above-Low → \`WATCH\`
- any + Low → \`NOTE\`
- Info-tier → "" (drops from PR surface)

**P5.8** — Alias-aware suppression API. \`suppression.ApplyWithAliases(snap, entries, reg, now)\` expands old rule_ids through the alias registry so a suppression on the OLD id continues to suppress findings emitted under the NEW id(s) during the deprecation window. One-way: NEW-id suppressions don't match OLD findings.

The existing engine path (which duplicates entries per ExpandOldID before calling Apply) is untouched; ApplyWithAliases is an additive API for the slash-command surface in PR 5e and the per-repo learning surface in PR 5f.

17 + 5 tests pinning the cross-product behavior + alias contract.