### PR TITLE
Phase 5b: suppressions schema v2 — scope + content_hash + default expiry

### DIFF
--- a/cmd/terrain/cmd_suppress.go
+++ b/cmd/terrain/cmd_suppress.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/pmclSF/terrain/internal/identity"
 	"github.com/pmclSF/terrain/internal/suppression"
@@ -14,36 +15,80 @@ import (
 // for the given finding ID. The flow is:
 //
 //  1. Validate the finding ID parses (format).
-//  2. Load the existing suppressions file (or create an empty one).
-//  3. Refuse to add a duplicate entry — if one already exists, print
+//  2. Resolve the scope (default: instance for FindingID).
+//  3. Compute the content hash when scope=instance and the file+line
+//     are available, so the suppression invalidates if the line
+//     changes.
+//  4. Apply a per-scope default expiry when --expires is not passed
+//     (instance=+90d, file=+180d, directory=+180d, repo=+365d).
+//  5. Load the existing suppressions file (or create an empty one).
+//  6. Refuse to add a duplicate entry — if one already exists, print
 //     a helpful message pointing at the existing reason and exit.
-//  4. Append the new entry.
-//  5. Write back, preserving comments and ordering of existing
+//  7. Append the new entry.
+//  8. Write back, preserving comments and ordering of existing
 //     entries via simple text-append (we deliberately don't round-trip
 //     through YAML because goccy/go-yaml's comment preservation is
 //     uneven; appending text is the safer 0.2.0 shape).
 //
-// Result: a suppression entry with reason + optional expires + owner,
-// ready for the next `terrain analyze` run to honor.
-func runSuppress(findingID, reason, expires, owner, root string) error {
+// Result: a schema-v2 suppression entry with reason + optional
+// expires + owner + scope + content_hash, ready for the next
+// `terrain analyze` run to honor.
+func runSuppress(findingID, reason, expires, owner, scope, root string) error {
 	if findingID == "" {
 		return fmt.Errorf("missing finding ID — usage: terrain suppress <finding-id> --reason \"why\"")
 	}
-	if _, _, _, _, ok := identity.ParseFindingID(findingID); !ok {
+	_, filePath, anchor, _, ok := identity.ParseFindingID(findingID)
+	if !ok {
 		return fmt.Errorf("invalid finding ID format %q — expected detector@path:anchor#hash", findingID)
 	}
+	// Anchor is either a symbol (e.g. "TestLogin"), "L<line>", or "_".
+	// Extract line when present so we can hash the context window.
+	line := lineFromAnchor(anchor)
 	if strings.TrimSpace(reason) == "" {
 		return fmt.Errorf("--reason is required (every suppression must justify itself)")
 	}
 
-	// Light sanity-check on `expires` — if the user supplied something,
-	// it should at least look like an ISO date so a downstream parser
-	// doesn't trip silently. We don't enforce real-date validity here;
-	// the loader emits a non-fatal warning if it can't parse.
-	if expires != "" {
-		if !looksLikeISODate(expires) {
-			return fmt.Errorf("--expires %q does not look like YYYY-MM-DD", expires)
+	// Resolve scope: default to "instance" for FindingID-based
+	// suppressions (the most precise shape).
+	resolvedScope := suppression.Scope(strings.TrimSpace(scope))
+	if resolvedScope == "" {
+		resolvedScope = suppression.ScopeInstance
+	}
+	switch resolvedScope {
+	case suppression.ScopeInstance, suppression.ScopeFile, suppression.ScopeDirectory, suppression.ScopeRepo:
+		// ok
+	default:
+		return fmt.Errorf("invalid --scope %q (expected: instance, file, directory, repo)", scope)
+	}
+
+	// Auto-apply per-scope default expiry if the user didn't pass one.
+	// Adopters who want a permanent waiver can pass --expires=never
+	// (rejected by looksLikeISODate; they'll need to edit the file
+	// directly, by design — permanent suppressions should be a
+	// deliberate file-edit choice, not a CLI shortcut).
+	if expires == "" {
+		expires = time.Now().Add(suppression.DefaultExpiryForScope(resolvedScope)).Format("2006-01-02")
+	}
+	// Light sanity-check on `expires`.
+	if !looksLikeISODate(expires) {
+		return fmt.Errorf("--expires %q does not look like YYYY-MM-DD", expires)
+	}
+
+	// Compute content_hash when scope=instance and we can locate the
+	// finding's source line. The hash anchors the suppression to the
+	// surrounding 5-line context window so it invalidates when the
+	// line itself changes (typical signal: the user fixed the issue).
+	var contentHash string
+	if resolvedScope == suppression.ScopeInstance && filePath != "" && line > 0 {
+		absPath := filepath.Join(root, filePath)
+		h, herr := suppression.ContextHash(absPath, line)
+		if herr != nil {
+			return fmt.Errorf("compute content hash for %s:%d: %w", filePath, line, herr)
 		}
+		// h may be empty when the file doesn't exist (e.g., user passed
+		// a stale FindingID). In that case fall back to no hash;
+		// matcher will use signal_type + file alone.
+		contentHash = h
 	}
 
 	suppPath := filepath.Join(root, suppression.DefaultPath)
@@ -89,11 +134,11 @@ func runSuppress(findingID, reason, expires, owner, root string) error {
 		// New file — emit the schema header.
 		header = "# Terrain suppressions — generated and edited by `terrain suppress`.\n" +
 			"# Schema: https://github.com/pmclSF/terrain/blob/main/internal/suppression/suppression.go\n\n" +
-			"schema_version: \"1\"\n" +
+			"schema_version: \"" + suppression.CurrentSchemaVersion + "\"\n" +
 			"suppressions:\n"
 	}
 
-	entry := buildSuppressionYAML(findingID, reason, expires, owner)
+	entry := buildSuppressionYAML(findingID, reason, expires, owner, resolvedScope, contentHash)
 
 	out := header
 	if len(body) > 0 {
@@ -131,7 +176,7 @@ func runSuppress(findingID, reason, expires, owner, root string) error {
 	return nil
 }
 
-func buildSuppressionYAML(findingID, reason, expires, owner string) string {
+func buildSuppressionYAML(findingID, reason, expires, owner string, scope suppression.Scope, contentHash string) string {
 	var b strings.Builder
 	b.WriteString("  - finding_id: ")
 	b.WriteString(findingID)
@@ -139,6 +184,16 @@ func buildSuppressionYAML(findingID, reason, expires, owner string) string {
 	b.WriteString("    reason: ")
 	b.WriteString(yamlInlineString(reason))
 	b.WriteString("\n")
+	if scope != "" {
+		b.WriteString("    scope: ")
+		b.WriteString(string(scope))
+		b.WriteString("\n")
+	}
+	if contentHash != "" {
+		b.WriteString("    content_hash: ")
+		b.WriteString(contentHash)
+		b.WriteString("\n")
+	}
 	if expires != "" {
 		b.WriteString("    expires: ")
 		b.WriteString(expires)
@@ -160,6 +215,24 @@ func yamlInlineString(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
 	return `"` + s + `"`
+}
+
+// lineFromAnchor returns the line number encoded in a FindingID
+// anchor, or 0 when the anchor is a symbol name / placeholder.
+// Anchor shapes are "L<line>" (line-only), "<symbol>" (symbol-only),
+// or "_" (neither).
+func lineFromAnchor(anchor string) int {
+	if len(anchor) > 1 && anchor[0] == 'L' {
+		n := 0
+		for i := 1; i < len(anchor); i++ {
+			if anchor[i] < '0' || anchor[i] > '9' {
+				return 0
+			}
+			n = n*10 + int(anchor[i]-'0')
+		}
+		return n
+	}
+	return 0
 }
 
 func looksLikeISODate(s string) bool {

--- a/cmd/terrain/cmd_suppress_test.go
+++ b/cmd/terrain/cmd_suppress_test.go
@@ -23,7 +23,7 @@ func TestRunSuppress_CreatesNewFile(t *testing.T) {
 	id := identity.BuildFindingID("weakAssertion", "internal/auth/login_test.go", "TestLogin", 42)
 
 	if err := runCaptured(func() error {
-		return runSuppress(id, "false positive — sanitized upstream", "2099-08-01", "@platform", root)
+		return runSuppress(id, "false positive — sanitized upstream", "2099-08-01", "@platform", "", root)
 	}); err != nil {
 		t.Fatalf("runSuppress: %v", err)
 	}
@@ -51,10 +51,10 @@ func TestRunSuppress_AppendsToExisting(t *testing.T) {
 	idA := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
 	idB := identity.BuildFindingID("mockHeavyTest", "b.go", "Y", 2)
 
-	if err := runCaptured(func() error { return runSuppress(idA, "first", "", "", root) }); err != nil {
+	if err := runCaptured(func() error { return runSuppress(idA, "first", "", "", "", root) }); err != nil {
 		t.Fatal(err)
 	}
-	if err := runCaptured(func() error { return runSuppress(idB, "second", "", "", root) }); err != nil {
+	if err := runCaptured(func() error { return runSuppress(idB, "second", "", "", "", root) }); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,11 +75,11 @@ func TestRunSuppress_RejectsDuplicate(t *testing.T) {
 	root := t.TempDir()
 	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
 
-	if err := runCaptured(func() error { return runSuppress(id, "first", "", "", root) }); err != nil {
+	if err := runCaptured(func() error { return runSuppress(id, "first", "", "", "", root) }); err != nil {
 		t.Fatal(err)
 	}
 	var err error
-	_, err = captureRun(func() error { return runSuppress(id, "second", "", "", root) })
+	_, err = captureRun(func() error { return runSuppress(id, "second", "", "", "", root) })
 	if err == nil || !strings.Contains(err.Error(), "already suppressed") {
 		t.Errorf("expected 'already suppressed' error, got %v", err)
 	}
@@ -91,7 +91,7 @@ func TestRunSuppress_RejectsBadID(t *testing.T) {
 	t.Parallel()
 	root := t.TempDir()
 
-	_, err := captureRun(func() error { return runSuppress("not-a-finding-id", "ok", "", "", root) })
+	_, err := captureRun(func() error { return runSuppress("not-a-finding-id", "ok", "", "", "", root) })
 	if err == nil || !strings.Contains(err.Error(), "invalid finding ID") {
 		t.Errorf("expected invalid-ID error, got %v", err)
 	}
@@ -105,7 +105,7 @@ func TestRunSuppress_RejectsBadID(t *testing.T) {
 func TestRunSuppress_RequiresReason(t *testing.T) {
 	t.Parallel()
 	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
-	_, err := captureRun(func() error { return runSuppress(id, "", "", "", t.TempDir()) })
+	_, err := captureRun(func() error { return runSuppress(id, "", "", "", "", t.TempDir()) })
 	if err == nil || !strings.Contains(err.Error(), "--reason is required") {
 		t.Errorf("expected reason-required error, got %v", err)
 	}
@@ -116,7 +116,7 @@ func TestRunSuppress_RequiresReason(t *testing.T) {
 func TestRunSuppress_RejectsBadExpiryShape(t *testing.T) {
 	t.Parallel()
 	id := identity.BuildFindingID("weakAssertion", "a.go", "X", 1)
-	_, err := captureRun(func() error { return runSuppress(id, "ok", "next-month", "", t.TempDir()) })
+	_, err := captureRun(func() error { return runSuppress(id, "ok", "next-month", "", "", t.TempDir()) })
 	if err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
 		t.Errorf("expected YYYY-MM-DD error, got %v", err)
 	}

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -502,18 +502,19 @@ func main() {
 		suppressCmd := flag.NewFlagSet("suppress", flag.ExitOnError)
 		rootFlag := suppressCmd.String("root", ".", "repository root")
 		reasonFlag := suppressCmd.String("reason", "", "why this finding is being suppressed (required)")
-		expiresFlag := suppressCmd.String("expires", "", "ISO date YYYY-MM-DD when the suppression should expire (optional but recommended)")
+		expiresFlag := suppressCmd.String("expires", "", "ISO date YYYY-MM-DD when the suppression should expire (default: per-scope; instance=+90d, file=+180d, directory=+180d, repo=+365d)")
 		ownerFlag := suppressCmd.String("owner", "", "owner pointer for review (optional)")
+		scopeFlag := suppressCmd.String("scope", "", "instance | file | directory | repo (default: instance for FindingID, file otherwise)")
 		_ = suppressCmd.Parse(os.Args[2:])
 		args := suppressCmd.Args()
 		if len(args) < 1 {
-			fmt.Fprintln(os.Stderr, "Usage: terrain suppress <finding-id> --reason \"why\" [--expires YYYY-MM-DD] [--owner @who]")
+			fmt.Fprintln(os.Stderr, "Usage: terrain suppress <finding-id> --reason \"why\" [--expires YYYY-MM-DD] [--owner @who] [--scope instance|file|directory|repo]")
 			fmt.Fprintln(os.Stderr)
 			fmt.Fprintln(os.Stderr, "Find a finding's ID with: terrain explain <finding-id>")
 			os.Exit(exitUsageError)
 		}
 		findingID := args[0]
-		if err := runSuppress(findingID, *reasonFlag, *expiresFlag, *ownerFlag, *rootFlag); err != nil {
+		if err := runSuppress(findingID, *reasonFlag, *expiresFlag, *ownerFlag, *scopeFlag, *rootFlag); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(exitCodeForCLIError(err))
 		}

--- a/internal/suppression/contenthash.go
+++ b/internal/suppression/contenthash.go
@@ -1,0 +1,104 @@
+package suppression
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// ContextHashRadius is the number of lines included on each side of
+// the finding's anchor line. Total window size = 2*radius + 1 = 5.
+const ContextHashRadius = 2
+
+// ContextHash returns the SHA-256 of the normalized context window
+// around (file, line). The window covers `line - ContextHashRadius`
+// through `line + ContextHashRadius` (inclusive). Lines outside the
+// file's actual bounds contribute as empty strings.
+//
+// Normalization: each line in the window has trailing whitespace
+// trimmed (via strings.TrimRight on " \t"). Internal whitespace and
+// leading whitespace are preserved — an indent change still
+// invalidates the hash because indent typically signals a semantic
+// shift (`if {}` → `if () {}` reshape, struct re-nesting, etc.).
+//
+// Lines are joined with a single "\n" between them.
+//
+// Returns an empty string and a nil error when `file` doesn't exist.
+// A non-existent file is a valid runtime state — the rule no longer
+// fires there, so there's nothing to suppress. The empty-hash sentinel
+// signals "skip this content-hash comparison" to the matcher rather
+// than blocking the whole suppression flow.
+//
+// `line` is 1-indexed (matching models.SignalLocation.Line). A line
+// of 0 or negative returns "" and a nil error.
+func ContextHash(file string, line int) (string, error) {
+	if file == "" || line <= 0 {
+		return "", nil
+	}
+	f, err := os.Open(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("contenthash: open %q: %w", file, err)
+	}
+	defer f.Close()
+
+	return contextHashFromReader(f, line)
+}
+
+// contextHashFromReader is the io.Reader-parameterized core. Exposed
+// to tests so they can hash synthetic content without touching the
+// filesystem.
+func contextHashFromReader(r io.Reader, line int) (string, error) {
+	first := line - ContextHashRadius
+	last := line + ContextHashRadius
+	if first < 1 {
+		first = 1
+	}
+
+	// Read lines [1, last]. Lines past `last` are discarded.
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 1<<16), 1<<20) // 1 MiB max line len
+	var captured []string
+	current := 0
+	for scanner.Scan() {
+		current++
+		if current > last {
+			break
+		}
+		if current >= first {
+			captured = append(captured, strings.TrimRight(scanner.Text(), " \t"))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("contenthash: scan: %w", err)
+	}
+
+	// Pad with empty strings for any positions the file ran out of
+	// content for. Result window is always 2*ContextHashRadius+1
+	// lines, regardless of where in the file `line` sits.
+	want := last - first + 1
+	for len(captured) < want {
+		captured = append(captured, "")
+	}
+	// Also pad the leading positions when line - radius < 1 (i.e.
+	// `first` was clamped to 1 but the conceptual window started
+	// earlier). This keeps the hash stable regardless of which side
+	// of the file the line is near.
+	preWant := (line - 1) - (line - ContextHashRadius - 1)
+	_ = preWant // pre-window padding folds into the "first clamped to 1" branch above
+	if leading := ContextHashRadius - (line - 1); leading > 0 {
+		empties := make([]string, leading)
+		captured = append(empties, captured...)
+	}
+
+	joined := strings.Join(captured, "\n")
+	sum := sha256.Sum256([]byte(joined))
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/suppression/suppression.go
+++ b/internal/suppression/suppression.go
@@ -67,23 +67,91 @@ func pathPkgMatch(pattern, name string) (bool, error) {
 // Default location for the suppression file, relative to the repo root.
 const DefaultPath = ".terrain/suppressions.yaml"
 
+// Scope classifies the breadth of a suppression entry. The scope
+// label is documentary on the file (the user declares intent) and
+// drives the default-expiry policy in the suppress CLI:
+//
+//	ScopeInstance  — rule_id + file + content_hash. One specific
+//	                 finding. Default expiry: +90 days. The hash
+//	                 invalidates on edits to the suppressed line so
+//	                 the suppression doesn't outlive its rationale.
+//	ScopeFile      — rule_id + file (exact). Every finding of the
+//	                 rule in that file is suppressed. Default expiry:
+//	                 +180 days.
+//	ScopeDirectory — rule_id + file (glob). Every finding of the rule
+//	                 across the matched paths is suppressed. Default
+//	                 expiry: +180 days.
+//	ScopeRepo      — rule_id only (no file). Disable the rule for the
+//	                 whole repository. Default expiry: +365 days.
+//
+// A FindingID-based entry has no explicit scope; its match shape is
+// equivalent to ScopeInstance (one specific finding).
+type Scope string
+
+const (
+	ScopeInstance  Scope = "instance"
+	ScopeFile      Scope = "file"
+	ScopeDirectory Scope = "directory"
+	ScopeRepo      Scope = "repo"
+)
+
 // Entry is one suppression rule. Either FindingID (exact match) or
-// SignalType + File (class match) must be set; the loader rejects
-// entries that satisfy neither.
+// SignalType (+ optional File / ContentHash) must be set; the loader
+// rejects entries that satisfy neither.
+//
+// Schema v1 (legacy): `finding_id` OR (`signal_type` AND `file`).
+// Schema v2 (current): adds `scope` (documentary; default-expiry
+// hint) and `content_hash` (SHA-256 of the 5-line normalized context
+// window — when set, the matcher recomputes the current hash and
+// requires equality, so the suppression invalidates when the line
+// changes).
+//
+// Loading is backwards-compatible: a v1 file loads as v2 entries with
+// empty `Scope` and `ContentHash`. The match-time semantics are
+// unchanged for the unset case.
 type Entry struct {
-	FindingID  string    `yaml:"finding_id,omitempty"`
-	SignalType string    `yaml:"signal_type,omitempty"`
-	File       string    `yaml:"file,omitempty"` // glob pattern
-	Reason     string    `yaml:"reason"`
-	Expires    string    `yaml:"expires,omitempty"` // ISO 8601 date
-	Owner      string    `yaml:"owner,omitempty"`
-	expiresAt  time.Time // parsed during load; zero for "no expiry"
+	FindingID   string    `yaml:"finding_id,omitempty"`
+	SignalType  string    `yaml:"signal_type,omitempty"`
+	File        string    `yaml:"file,omitempty"`         // glob pattern
+	Scope       Scope     `yaml:"scope,omitempty"`        // optional; documentary + drives default-expiry
+	ContentHash string    `yaml:"content_hash,omitempty"` // SHA-256 of 5-line normalized context
+	Reason      string    `yaml:"reason"`
+	Expires     string    `yaml:"expires,omitempty"` // ISO 8601 date
+	Owner       string    `yaml:"owner,omitempty"`
+	expiresAt   time.Time // parsed during load; zero for "no expiry"
 }
 
-// File is the YAML envelope.
+// File is the YAML envelope. SchemaVersion is "1" (legacy) or "2"
+// (current); both load through the same path.
 type File struct {
 	SchemaVersion string  `yaml:"schema_version"`
 	Suppressions  []Entry `yaml:"suppressions"`
+}
+
+// CurrentSchemaVersion is what new files should declare. Reader
+// accepts "1" and "2" (and empty, treated as "2").
+const CurrentSchemaVersion = "2"
+
+// DefaultExpiryForScope returns the recommended default expiry
+// duration for a scope. The suppress CLI uses this when the user
+// doesn't pass an explicit --expires. The schema does not enforce
+// these — adopters can override per-entry.
+//
+//	instance  → 90 days
+//	file      → 180 days
+//	directory → 180 days
+//	repo      → 365 days
+//	(unknown) → 90 days (conservative)
+func DefaultExpiryForScope(s Scope) time.Duration {
+	switch s {
+	case ScopeRepo:
+		return 365 * 24 * time.Hour
+	case ScopeFile, ScopeDirectory:
+		return 180 * 24 * time.Hour
+	case ScopeInstance:
+		return 90 * 24 * time.Hour
+	}
+	return 90 * 24 * time.Hour
 }
 
 // LoadResult is what callers actually use: validated entries + per-
@@ -109,8 +177,11 @@ func Load(path string) (*LoadResult, error) {
 	if err := yaml.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("parse %q: %w", path, err)
 	}
-	if raw.SchemaVersion != "" && raw.SchemaVersion != "1" {
-		return nil, fmt.Errorf("unsupported suppressions schema_version %q (expected \"1\")", raw.SchemaVersion)
+	switch raw.SchemaVersion {
+	case "", "1", "2":
+		// supported
+	default:
+		return nil, fmt.Errorf("unsupported suppressions schema_version %q (expected \"1\" or \"2\")", raw.SchemaVersion)
 	}
 
 	result := &LoadResult{}
@@ -119,11 +190,29 @@ func Load(path string) (*LoadResult, error) {
 		hasID := strings.TrimSpace(e.FindingID) != ""
 		hasType := strings.TrimSpace(e.SignalType) != ""
 		hasFile := strings.TrimSpace(e.File) != ""
+		isRepoScope := e.Scope == ScopeRepo
 		switch {
 		case hasID && (hasType || hasFile):
 			return nil, fmt.Errorf("suppressions[%d]: cannot combine finding_id with signal_type/file — use one or the other", i)
-		case !hasID && !(hasType && hasFile):
-			return nil, fmt.Errorf("suppressions[%d]: must set either finding_id, or both signal_type and file", i)
+		case !hasID && !hasType:
+			return nil, fmt.Errorf("suppressions[%d]: must set either finding_id, or signal_type (plus file unless scope=repo)", i)
+		case !hasID && hasType && !hasFile && !isRepoScope:
+			return nil, fmt.Errorf("suppressions[%d]: signal_type entries require either a file pattern or scope: repo", i)
+		}
+		// Validate Scope value (when provided).
+		if e.Scope != "" {
+			switch e.Scope {
+			case ScopeInstance, ScopeFile, ScopeDirectory, ScopeRepo:
+				// ok
+			default:
+				return nil, fmt.Errorf("suppressions[%d]: unknown scope %q (expected: instance, file, directory, repo)", i, e.Scope)
+			}
+		}
+		// ContentHash validation: requires SignalType + File.
+		if strings.TrimSpace(e.ContentHash) != "" {
+			if !hasType || !hasFile {
+				return nil, fmt.Errorf("suppressions[%d]: content_hash requires signal_type and file", i)
+			}
 		}
 
 		// reason is required — every suppression must justify itself.
@@ -236,15 +325,46 @@ func ApplyWithAliases(snapshot *models.TestSuiteSnapshot, entries []Entry, reg *
 	return matched, expired
 }
 
+// hashCache memoizes ContextHash computations across a single
+// filterSignals invocation. Signals with the same (file, line) share
+// a single hash compute. Built per-call so it doesn't leak across
+// snapshots or test runs.
+type hashCache struct {
+	cache map[string]string
+}
+
+func newHashCache() *hashCache { return &hashCache{cache: map[string]string{}} }
+
+// Get returns the cached ContextHash for (file, line), computing once
+// on the first request. Errors propagate from the underlying
+// ContextHash call (file I/O errors); a non-existent file returns the
+// sentinel empty string with nil error.
+func (c *hashCache) Get(file string, line int) (string, error) {
+	if file == "" || line <= 0 {
+		return "", nil
+	}
+	key := fmt.Sprintf("%s:%d", file, line)
+	if h, ok := c.cache[key]; ok {
+		return h, nil
+	}
+	h, err := ContextHash(file, line)
+	if err != nil {
+		return "", err
+	}
+	c.cache[key] = h
+	return h, nil
+}
+
 func filterSignals(signals []models.Signal, active []Entry, expanded []map[string]bool, matchedIdx map[int]bool) []models.Signal {
 	if len(signals) == 0 {
 		return signals
 	}
+	cache := newHashCache()
 	kept := signals[:0]
 	for _, s := range signals {
 		hitIdx := -1
 		for i, e := range active {
-			if matches(e, s, expanded[i]) {
+			if matches(e, s, expanded[i], cache) {
 				hitIdx = i
 				break
 			}
@@ -258,19 +378,27 @@ func filterSignals(signals []models.Signal, active []Entry, expanded []map[strin
 	return kept
 }
 
-// matches returns true if entry e suppresses signal s. `expandedTypes`
-// is the pre-computed set of signal-type strings that count as a hit
-// for e (the literal e.SignalType plus any new IDs from the alias
-// registry). Nil/empty set falls back to literal-equality on
-// e.SignalType.
-func matches(e Entry, s models.Signal, expandedTypes map[string]bool) bool {
+// matches returns true if entry e suppresses signal s.
+//
+//   - `expandedTypes` is the pre-computed set of signal-type strings
+//     that count as a hit for e (the literal e.SignalType plus any
+//     new IDs from the alias registry). Nil/empty set falls back to
+//     literal-equality on e.SignalType.
+//   - `cache` memoizes ContextHash computations across the
+//     filterSignals invocation. Required only when one or more
+//     entries set ContentHash; passed unconditionally to keep the
+//     signature stable.
+//
+// When the entry sets ContentHash, the matcher recomputes the
+// current context hash at (s.Location.File, s.Location.Line) and
+// requires equality. A non-existent file silently fails the hash
+// check (returns "" sentinel) so the suppression doesn't fire on a
+// finding for a file that no longer exists.
+func matches(e Entry, s models.Signal, expandedTypes map[string]bool, cache *hashCache) bool {
 	if e.FindingID != "" {
 		return e.FindingID == s.FindingID
 	}
-	// signal_type + file path match.
-	if e.File == "" {
-		return false
-	}
+	// SignalType match (with alias expansion if provided).
 	if expandedTypes != nil {
 		if !expandedTypes[string(s.Type)] {
 			return false
@@ -278,11 +406,33 @@ func matches(e Entry, s models.Signal, expandedTypes map[string]bool) bool {
 	} else if string(s.Type) != e.SignalType {
 		return false
 	}
-	matched, err := pathMatch(e.File, s.Location.File)
-	if err != nil {
-		return false
+	// File match: required unless scope is repo-wide.
+	if e.File == "" {
+		// scope=repo: rule_id only, applies everywhere. Schema v1
+		// rejected this shape; v2 allows it via explicit scope.
+		if e.Scope != ScopeRepo {
+			return false
+		}
+	} else {
+		matched, err := pathMatch(e.File, s.Location.File)
+		if err != nil || !matched {
+			return false
+		}
 	}
-	return matched
+	// Content-hash check (when the entry pins one).
+	if e.ContentHash != "" {
+		if cache == nil {
+			return false
+		}
+		current, err := cache.Get(s.Location.File, s.Location.Line)
+		if err != nil || current == "" {
+			return false
+		}
+		if current != e.ContentHash {
+			return false
+		}
+	}
+	return true
 }
 
 // pathMatch is a glob match that supports `**` (recursive) on top of

--- a/internal/suppression/suppression_test.go
+++ b/internal/suppression/suppression_test.go
@@ -486,3 +486,318 @@ aliases:
 		t.Errorf("post-Apply signals = %d, want 1 (suppression expired)", len(snap.Signals))
 	}
 }
+
+// ── Schema v2 — content_hash + scope ──────────────────────────────
+
+// TestContextHash_Stable confirms the hash is deterministic across
+// repeat calls and identical for the same window content.
+func TestContextHash_Stable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src.go")
+	body := "line1\nline2\nline3 // finding\nline4\nline5\nline6\nline7\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1, err := ContextHash(path, 3)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	h2, err := ContextHash(path, 3)
+	if err != nil {
+		t.Fatalf("repeat: %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("non-deterministic: %s vs %s", h1, h2)
+	}
+	if len(h1) != 64 {
+		t.Errorf("expected 64-char SHA-256 hex, got %d chars", len(h1))
+	}
+}
+
+// TestContextHash_WhitespaceTolerance pins the spec: trailing
+// whitespace on each line should not change the hash. Leading
+// whitespace and internal whitespace are part of the hash.
+func TestContextHash_WhitespaceTolerance(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.go")
+	b := filepath.Join(dir, "b.go")
+	clean := "line1\nline2\nline3\nline4\nline5\n"
+	trailing := "line1   \nline2\t\nline3 \nline4   \nline5\t\t\n"
+	if err := os.WriteFile(a, []byte(clean), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte(trailing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ha, _ := ContextHash(a, 3)
+	hb, _ := ContextHash(b, 3)
+	if ha != hb {
+		t.Errorf("trailing-whitespace variation changed hash: %s vs %s", ha, hb)
+	}
+}
+
+// TestContextHash_LineChangeInvalidates pins the spec: editing the
+// suppressed line itself must change the hash.
+func TestContextHash_LineChangeInvalidates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "v1.go")
+	if err := os.WriteFile(path, []byte("a\nb\nORIGINAL\nd\ne\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1, _ := ContextHash(path, 3)
+
+	path2 := filepath.Join(dir, "v2.go")
+	if err := os.WriteFile(path2, []byte("a\nb\nCHANGED\nd\ne\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h2, _ := ContextHash(path2, 3)
+	if h1 == h2 {
+		t.Errorf("line change did not invalidate hash: both %s", h1)
+	}
+}
+
+// TestContextHash_SurroundingLineEditsAllowed: edits to non-suppressed
+// lines OUTSIDE the 5-line window should not change the hash. Edits
+// WITHIN the window do change it (window is 5 lines = ±2).
+func TestContextHash_SurroundingLineEditsAllowed(t *testing.T) {
+	dir := t.TempDir()
+	pathA := filepath.Join(dir, "a.go")
+	pathB := filepath.Join(dir, "b.go")
+	// File A: 9 lines, finding on line 5 (window covers lines 3-7).
+	if err := os.WriteFile(pathA, []byte("L1\nL2\nL3\nL4\nFINDING\nL6\nL7\nL8\nL9\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// File B: line 1 and line 9 changed (outside the window).
+	if err := os.WriteFile(pathB, []byte("XX\nL2\nL3\nL4\nFINDING\nL6\nL7\nL8\nYY\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hA, _ := ContextHash(pathA, 5)
+	hB, _ := ContextHash(pathB, 5)
+	if hA != hB {
+		t.Errorf("outside-window edits invalidated hash: %s vs %s", hA, hB)
+	}
+}
+
+// TestContextHash_MissingFileReturnsEmpty pins the spec: a finding
+// against a non-existent file produces "" (not an error). The matcher
+// treats "" as "skip hash check, fail to match" so the suppression
+// doesn't fire on a deleted file.
+func TestContextHash_MissingFileReturnsEmpty(t *testing.T) {
+	h, err := ContextHash(filepath.Join(t.TempDir(), "does-not-exist.go"), 1)
+	if err != nil {
+		t.Errorf("missing file should not error: %v", err)
+	}
+	if h != "" {
+		t.Errorf("missing file should return \"\", got %q", h)
+	}
+}
+
+// TestContextHash_NearStartOfFile: when line < ContextHashRadius+1
+// the window is clamped to the file start. The hash is still stable.
+func TestContextHash_NearStartOfFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tiny.go")
+	if err := os.WriteFile(path, []byte("L1\nL2\nL3\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1, _ := ContextHash(path, 1)
+	h1again, _ := ContextHash(path, 1)
+	if h1 != h1again {
+		t.Errorf("non-deterministic near start: %s vs %s", h1, h1again)
+	}
+	if h1 == "" {
+		t.Error("near-start hash should not be empty")
+	}
+}
+
+// TestLoad_SchemaV2 confirms v2 fields load cleanly.
+func TestLoad_SchemaV2(t *testing.T) {
+	t.Parallel()
+	yaml := `
+schema_version: "2"
+suppressions:
+  - signal_type: ruleA
+    file: src/a.go
+    scope: instance
+    content_hash: deadbeef
+    reason: "test"
+`
+	path := writeTemp(t, yaml)
+	res, err := Load(path)
+	if err != nil {
+		t.Fatalf("load v2: %v", err)
+	}
+	if len(res.Entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(res.Entries))
+	}
+	e := res.Entries[0]
+	if e.Scope != ScopeInstance {
+		t.Errorf("scope = %q, want %q", e.Scope, ScopeInstance)
+	}
+	if e.ContentHash != "deadbeef" {
+		t.Errorf("content_hash = %q, want %q", e.ContentHash, "deadbeef")
+	}
+}
+
+// TestLoad_RepoScopeAllowsNoFile confirms scope=repo with no file
+// loads cleanly (the rule-disabled-for-the-whole-repo shape).
+func TestLoad_RepoScopeAllowsNoFile(t *testing.T) {
+	t.Parallel()
+	yaml := `
+schema_version: "2"
+suppressions:
+  - signal_type: ruleA
+    scope: repo
+    reason: "disable until 0.3"
+`
+	res, err := Load(writeTemp(t, yaml))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(res.Entries) != 1 || res.Entries[0].Scope != ScopeRepo {
+		t.Fatalf("entries = %+v", res.Entries)
+	}
+}
+
+// TestLoad_RejectsUnknownScope validates the scope allowlist.
+func TestLoad_RejectsUnknownScope(t *testing.T) {
+	t.Parallel()
+	yaml := `
+schema_version: "2"
+suppressions:
+  - signal_type: ruleA
+    file: src/a.go
+    scope: bogus
+    reason: "test"
+`
+	if _, err := Load(writeTemp(t, yaml)); err == nil {
+		t.Error("expected error for unknown scope")
+	}
+}
+
+// TestLoad_RejectsContentHashWithoutFile pins the schema rule.
+func TestLoad_RejectsContentHashWithoutFile(t *testing.T) {
+	t.Parallel()
+	yaml := `
+schema_version: "2"
+suppressions:
+  - signal_type: ruleA
+    content_hash: abc123
+    reason: "test"
+`
+	if _, err := Load(writeTemp(t, yaml)); err == nil {
+		t.Error("expected error for content_hash without file")
+	}
+}
+
+// TestApplyWithAliases_ContentHashMatches: when the entry's
+// content_hash matches the current file content, the suppression fires.
+func TestApplyWithAliases_ContentHashMatches(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src.go")
+	if err := os.WriteFile(path, []byte("L1\nL2\nL3\nL4\nL5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hash, _ := ContextHash(path, 3)
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{
+				Type:     "ruleA",
+				Location: models.SignalLocation{File: path, Line: 3},
+			},
+		},
+	}
+	entry := Entry{
+		SignalType:  "ruleA",
+		File:        path,
+		ContentHash: hash,
+		Reason:      "test",
+	}
+	matched, _ := ApplyWithAliases(snap, []Entry{entry}, nil, time.Now())
+	if len(matched) != 1 {
+		t.Errorf("matched = %d, want 1 (hash matches current content)", len(matched))
+	}
+	if len(snap.Signals) != 0 {
+		t.Errorf("signal not suppressed: %+v", snap.Signals)
+	}
+}
+
+// TestApplyWithAliases_ContentHashMismatchSkipsSuppression: when the
+// entry's content_hash does NOT match (file was edited), the
+// suppression does not fire — the assumption is the user's rationale
+// was tied to the old code.
+func TestApplyWithAliases_ContentHashMismatchSkipsSuppression(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "src.go")
+	if err := os.WriteFile(path, []byte("L1\nL2\nNEW_CONTENT\nL4\nL5\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{
+				Type:     "ruleA",
+				Location: models.SignalLocation{File: path, Line: 3},
+			},
+		},
+	}
+	entry := Entry{
+		SignalType:  "ruleA",
+		File:        path,
+		ContentHash: "0000000000000000000000000000000000000000000000000000000000000000",
+		Reason:      "test",
+	}
+	matched, _ := ApplyWithAliases(snap, []Entry{entry}, nil, time.Now())
+	if len(matched) != 0 {
+		t.Errorf("matched = %d, want 0 (hash should not match)", len(matched))
+	}
+	if len(snap.Signals) != 1 {
+		t.Errorf("signal was suppressed despite hash mismatch")
+	}
+}
+
+// TestApplyWithAliases_RepoScopeNoFile: scope=repo + no file applies
+// to every finding of the rule.
+func TestApplyWithAliases_RepoScopeNoFile(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: "ruleA", Location: models.SignalLocation{File: "a.go"}},
+			{Type: "ruleA", Location: models.SignalLocation{File: "b.go"}},
+			{Type: "ruleA", Location: models.SignalLocation{File: "c.go"}},
+			{Type: "ruleB", Location: models.SignalLocation{File: "d.go"}},
+		},
+	}
+	entry := Entry{
+		SignalType: "ruleA",
+		Scope:      ScopeRepo,
+		Reason:     "disable everywhere",
+	}
+	matched, _ := ApplyWithAliases(snap, []Entry{entry}, nil, time.Now())
+	if len(matched) != 1 {
+		t.Errorf("matched entries = %d, want 1", len(matched))
+	}
+	if len(snap.Signals) != 1 || snap.Signals[0].Type != "ruleB" {
+		t.Errorf("post-Apply types should be [ruleB], got %+v", snap.Signals)
+	}
+}
+
+// TestDefaultExpiryForScope pins the per-scope defaults.
+func TestDefaultExpiryForScope(t *testing.T) {
+	day := 24 * time.Hour
+	cases := []struct {
+		scope Scope
+		want  time.Duration
+	}{
+		{ScopeInstance, 90 * day},
+		{ScopeFile, 180 * day},
+		{ScopeDirectory, 180 * day},
+		{ScopeRepo, 365 * day},
+		{"", 90 * day}, // unknown defaults to instance-like
+	}
+	for _, c := range cases {
+		if got := DefaultExpiryForScope(c.scope); got != c.want {
+			t.Errorf("DefaultExpiryForScope(%q) = %v, want %v", c.scope, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
**P5.6** — Suppression persistence with content-hash keying.

Schema v2 additions (backward-compat: v1 files load as v2 entries with empty scope/hash):
- \`scope\`: \`instance\` / \`file\` / \`directory\` / \`repo\`. Documentary + drives per-scope default expiry (90d / 180d / 180d / 365d).
- \`content_hash\`: SHA-256 of the 5-line normalized context window (trailing whitespace trimmed; leading and internal whitespace preserved). When set, the matcher recomputes the hash at match time — suppression invalidates when the suppressed line changes.

\`scope: repo\` unlocks rule_id-only entries (no file). Previously rejected by v1.

**New API**:
- \`suppression.ContextHash(file, line) (string, error)\`
- \`suppression.DefaultExpiryForScope(scope) time.Duration\`
- \`suppression.CurrentSchemaVersion = "2"\`
- \`matches()\` caches ContextHash per (file, line) to bound I/O.

**CLI**:
- \`terrain suppress --scope instance|file|directory|repo\`
- When \`--scope=instance\` (default for FindingID), auto-computes \`content_hash\` from the file at the finding's anchor line.
- When \`--expires\` not passed, applies per-scope default. Permanent waivers require editing the file directly (by design).

12 new tests cover hash stability, whitespace tolerance, suppressed-line invalidation, surrounding-line edits tolerated, missing-file empty-hash sentinel, near-start-of-file clamping, v2 schema load, repo-scope-no-file, content-hash without file rejected, unknown-scope rejected, hash-matches → suppression fires, hash-mismatches → suppression skipped, repo-scope-applies-everywhere, per-scope default expiry.