### PR TITLE
Phase 5d: two GitHub Checks-API check runs (gate + observability)

### DIFF
--- a/cmd/terrain/cmd_check_runs.go
+++ b/cmd/terrain/cmd_check_runs.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pmclSF/terrain/internal/checkruns"
+	"github.com/pmclSF/terrain/internal/engine"
+)
+
+// runCheckRuns runs the analyze pipeline against `root`, builds the
+// two-check-runs bundle from the resulting snapshot, and writes the
+// JSON to stdout (or `outPath` when set).
+//
+// The JSON shape mirrors the GitHub Checks-API "create check run"
+// request body, side-by-side for the gate + observability checks.
+// Adopters' workflows post each half via `gh api`:
+//
+//	$ terrain report check-runs --head-sha=$GITHUB_SHA --out=/tmp/checks.json
+//	$ gh api -X POST /repos/$GITHUB_REPOSITORY/check-runs \
+//	    --input <(jq '.gate_check' /tmp/checks.json)
+//	$ gh api -X POST /repos/$GITHUB_REPOSITORY/check-runs \
+//	    --input <(jq '.observability_check' /tmp/checks.json)
+func runCheckRuns(root, headSHA, outPath string) error {
+	if root == "" {
+		root = "."
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return fmt.Errorf("resolve root: %w", err)
+	}
+	result, err := engine.RunPipeline(abs, engine.PipelineOptions{})
+	if err != nil {
+		return fmt.Errorf("analyze: %w", err)
+	}
+	if result == nil || result.Snapshot == nil {
+		return fmt.Errorf("analyze produced no snapshot")
+	}
+	bundle := checkruns.BuildBundle(result.Snapshot, headSHA)
+	data, err := json.MarshalIndent(bundle, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	data = append(data, '\n')
+
+	if outPath != "" {
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			return fmt.Errorf("write %q: %w", outPath, err)
+		}
+		fmt.Fprintf(os.Stderr, "wrote check-runs bundle to %s\n", outPath)
+		return nil
+	}
+	_, err = os.Stdout.Write(data)
+	return err
+}

--- a/cmd/terrain/cmd_report_namespace.go
+++ b/cmd/terrain/cmd_report_namespace.go
@@ -42,6 +42,7 @@ var reportVerbs = []string{
 	"pr",
 	"posture",
 	"select-tests",
+	"check-runs",
 }
 
 // runReportNamespaceCLI dispatches `terrain report <verb> ...`.
@@ -75,6 +76,8 @@ func runReportNamespaceCLI(args []string) error {
 		return runReportPostureCLI(rest)
 	case "select-tests":
 		return runReportSelectTestsCLI(rest)
+	case "check-runs":
+		return runReportCheckRunsCLI(rest)
 	default:
 		printReportUsage()
 		return fmt.Errorf("unknown report verb %q (valid: %s)", verb, strings.Join(reportVerbs, ", "))
@@ -220,6 +223,28 @@ func runReportPRCLI(args []string) error {
 		return err
 	}
 	return runPR(*root, *baseRef, *jsonOut, *format, gate)
+}
+
+// runReportCheckRunsCLI emits structured JSON for two GitHub Checks-
+// API check runs: `terrain (gate)` (required) and
+// `terrain (observability)` (informational). Adopters' CI workflows
+// consume the JSON and POST each half to the Checks API. Terrain
+// itself does no network I/O; the binary writes JSON, the workflow
+// handles auth + HTTP.
+//
+// Default: writes the bundle to stdout. With --out=<path>, writes to
+// the file instead.
+func runReportCheckRunsCLI(args []string) error {
+	fs := flag.NewFlagSet("report check-runs", flag.ExitOnError)
+	root := fs.String("root", ".", "repository root to analyze")
+	headSHA := fs.String("head-sha", "", "HEAD commit SHA (required; the check runs target this commit)")
+	out := fs.String("out", "", "write the JSON bundle to this path instead of stdout")
+	_ = fs.Parse(args)
+	mountPositionalAsRoot("report check-runs", fs.Args(), root)
+	if *headSHA == "" {
+		return fmt.Errorf("--head-sha is required (the check-run target commit; typically $GITHUB_SHA)")
+	}
+	return runCheckRuns(*root, *headSHA, *out)
 }
 
 func runReportPostureCLI(args []string) error {

--- a/cmd/terrain/cmd_report_namespace_test.go
+++ b/cmd/terrain/cmd_report_namespace_test.go
@@ -24,6 +24,7 @@ func TestReportNamespace_KnownVerbsAreNotRejected(t *testing.T) {
 		"pr":           true,
 		"posture":      true,
 		"select-tests": true,
+		"check-runs":   true,
 	}
 	if len(reportVerbs) != len(expected) {
 		t.Errorf("reportVerbs has %d entries, expected %d", len(reportVerbs), len(expected))

--- a/internal/checkruns/checkruns.go
+++ b/internal/checkruns/checkruns.go
@@ -1,0 +1,442 @@
+// Package checkruns produces the structured JSON for two GitHub
+// Checks-API check runs:
+//
+//   - `terrain (gate)`         — required check; fails when an
+//                                 undismissed gate-tier finding fires.
+//   - `terrain (observability)` — informational; always neutral
+//                                 conclusion.
+//
+// Terrain itself does NOT post to GitHub. Adopters' CI workflows
+// shell out to `gh api` (or actions/github-script) to post each
+// JSON to the Checks API. This keeps Terrain's no-network-calls
+// contract intact: the binary writes JSON; the workflow handles
+// auth and HTTP.
+//
+// Spec § P5.3 — "Two GitHub check runs: terrain (gate) (required,
+// fails on undismissed gate finding) and terrain (observability)
+// (informational only). Observability findings live in one
+// collapsed <details> footer in the gate check's top-level summary."
+package checkruns
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/pmclSF/terrain/internal/models"
+	"github.com/pmclSF/terrain/internal/prtemplates"
+	"github.com/pmclSF/terrain/internal/signals"
+	"github.com/pmclSF/terrain/internal/uitokens"
+)
+
+// CheckRun mirrors the GitHub Checks-API "create check run" request
+// shape (https://docs.github.com/en/rest/checks/runs).
+//
+// Only the fields Terrain actually populates are exposed; an adopter's
+// workflow can extend the marshaled JSON with additional fields
+// (started_at, completed_at, details_url, etc.) before posting if
+// needed.
+type CheckRun struct {
+	// Name is what GitHub shows in the PR's "Checks" tab. Stable
+	// across runs so PRs see a single check rather than a new one
+	// per re-run.
+	Name string `json:"name"`
+	// HeadSHA is the commit being checked. Required by the API.
+	HeadSHA string `json:"head_sha"`
+	// Status is one of "queued", "in_progress", "completed".
+	// Terrain emits "completed" — the binary already ran.
+	Status string `json:"status"`
+	// Conclusion is set when Status="completed". One of "action_required",
+	// "cancelled", "failure", "neutral", "success", "skipped",
+	// "stale", "timed_out". Terrain emits "failure" / "success" /
+	// "neutral".
+	Conclusion string `json:"conclusion,omitempty"`
+	// Output carries the human-readable surface: title, summary
+	// (markdown), text (full body markdown), and per-line annotations.
+	Output Output `json:"output"`
+}
+
+// Output is the human-readable surface of a check run.
+type Output struct {
+	// Title is the one-line headline (max ~100 chars per the API).
+	Title string `json:"title"`
+	// Summary is the short summary in markdown (max ~65k chars).
+	// Renders in the check-run pane before "Show more".
+	Summary string `json:"summary"`
+	// Text is the full body in markdown (max ~65k chars). Renders
+	// after "Show more" — the place for long detail.
+	Text string `json:"text,omitempty"`
+	// Annotations are per-line callouts shown inline on the diff.
+	// Each annotation has a path, line range, severity level, and
+	// short message. The GitHub API accepts up to 50 per request;
+	// callers exceeding 50 should batch follow-up requests with the
+	// same check-run name.
+	Annotations []Annotation `json:"annotations,omitempty"`
+}
+
+// Annotation is one per-line callout.
+type Annotation struct {
+	// Path is the repo-relative file path.
+	Path string `json:"path"`
+	// StartLine and EndLine are 1-indexed.
+	StartLine int `json:"start_line"`
+	EndLine   int `json:"end_line"`
+	// AnnotationLevel is "notice", "warning", or "failure".
+	AnnotationLevel string `json:"annotation_level"`
+	// Title is the short headline (max ~256 chars).
+	Title string `json:"title,omitempty"`
+	// Message is the body (max ~64k chars).
+	Message string `json:"message"`
+	// RawDetails is optional extended detail rendered in a
+	// collapsible section.
+	RawDetails string `json:"raw_details,omitempty"`
+}
+
+// CheckRunsBundle is the package's headline output type: both check
+// runs serialized side-by-side. Adopter workflows can write the
+// whole bundle to disk and split during posting, or post each half
+// separately.
+type CheckRunsBundle struct {
+	Gate          CheckRun `json:"gate_check"`
+	Observability CheckRun `json:"observability_check"`
+}
+
+// BuildBundle constructs both check runs from a snapshot. The
+// `headSHA` and `repoRoot` come from the calling workflow.
+//
+// Splitting rules:
+//   - A signal's Tier (gate vs observability) determines which check
+//     run it lands in. Tier is read from the manifest entry; signals
+//     without a manifest entry default to gate-tier (legacy CI gate
+//     relevance).
+//   - Within the gate check, the per-detector visibility floor (P5.4)
+//     applies: one headline annotation per detector that fired,
+//     co-fires collapse to "+N more" in the message.
+//   - The observability check carries every observability-tier
+//     finding (no per-detector collapse) in a `<details>` footer
+//     section in the Text. Annotations are present for each so they
+//     still render inline on the diff, just without a required-check
+//     conclusion.
+func BuildBundle(snap *models.TestSuiteSnapshot, headSHA string) CheckRunsBundle {
+	if snap == nil {
+		return CheckRunsBundle{}
+	}
+	gateSignals, obsSignals := splitByTier(snap.Signals)
+
+	gateOut := buildGateOutput(gateSignals)
+	obsOut := buildObservabilityOutput(obsSignals)
+
+	gateConclusion := "success"
+	if hasBlockingFinding(gateSignals) {
+		gateConclusion = "failure"
+	}
+
+	return CheckRunsBundle{
+		Gate: CheckRun{
+			Name:       "terrain (gate)",
+			HeadSHA:    headSHA,
+			Status:     "completed",
+			Conclusion: gateConclusion,
+			Output:     gateOut,
+		},
+		Observability: CheckRun{
+			Name:       "terrain (observability)",
+			HeadSHA:    headSHA,
+			Status:     "completed",
+			Conclusion: "neutral", // never blocks merge
+			Output:     obsOut,
+		},
+	}
+}
+
+// splitByTier partitions signals into gate vs observability based on
+// the manifest Tier. Signals with no manifest entry are treated as
+// gate-relevant (legacy behavior; runtime/ingestion-derived signals
+// keep the previous "treat as gate" semantics).
+func splitByTier(in []models.Signal) (gate, obs []models.Signal) {
+	for _, s := range in {
+		if signals.IsObservabilityTier(s.Type) {
+			obs = append(obs, s)
+		} else {
+			gate = append(gate, s)
+		}
+	}
+	return gate, obs
+}
+
+// hasBlockingFinding returns true if any signal in the gate set has
+// a severity at or above Medium (the "would fail --fail-on=medium or
+// stricter" threshold). Info-tier signals don't block; Low/Medium/
+// High/Critical do.
+func hasBlockingFinding(gate []models.Signal) bool {
+	for _, s := range gate {
+		sev := strings.ToLower(string(s.Severity))
+		switch sev {
+		case "critical", "high", "medium":
+			return true
+		}
+	}
+	return false
+}
+
+// buildGateOutput renders the gate check's title, summary, text, and
+// annotations.
+func buildGateOutput(gate []models.Signal) Output {
+	if len(gate) == 0 {
+		return Output{
+			Title:   "No gate-tier findings",
+			Summary: "Terrain found no blocking issues in this PR.",
+		}
+	}
+
+	groups := groupByDetector(gate)
+
+	// Title: short headline with finding count.
+	title := fmt.Sprintf("%d gate %s", len(gate), pluralize(len(gate), "finding", "findings"))
+
+	// Summary: severity-bucketed counts.
+	var summary strings.Builder
+	counts := severityCounts(gate)
+	summary.WriteString("Gate-tier findings by label:\n")
+	for _, label := range []string{"BLOCK", "GATE", "NOTE"} {
+		n := counts[label]
+		if n > 0 {
+			summary.WriteString(fmt.Sprintf("- **%s**: %d\n", label, n))
+		}
+	}
+
+	// Text: per-detector headline cards with co-fire collapse.
+	var text strings.Builder
+	for _, g := range groups {
+		text.WriteString(renderDetectorBlock(g))
+		text.WriteString("\n")
+	}
+
+	// Annotations: one per detector group (the headline finding).
+	var ann []Annotation
+	for _, g := range groups {
+		if len(g.signals) == 0 {
+			continue
+		}
+		head := g.signals[0]
+		ann = append(ann, signalToAnnotation(head, len(g.signals)-1))
+	}
+
+	return Output{
+		Title:       title,
+		Summary:     summary.String(),
+		Text:        text.String(),
+		Annotations: ann,
+	}
+}
+
+// buildObservabilityOutput renders the observability check. Always
+// neutral conclusion; every finding renders in a collapsed footer
+// section in the Text, plus one notice-level annotation per finding
+// so they still appear inline on the diff.
+func buildObservabilityOutput(obs []models.Signal) Output {
+	if len(obs) == 0 {
+		return Output{
+			Title:   "No observability findings",
+			Summary: "Terrain found no informational signals in this PR.",
+		}
+	}
+
+	title := fmt.Sprintf("%d observability %s", len(obs), pluralize(len(obs), "finding", "findings"))
+	summary := fmt.Sprintf("Terrain emitted %d informational %s. These don't block merge; see the details section for the full list.",
+		len(obs), pluralize(len(obs), "finding", "findings"))
+
+	// Text: collapsed footer section listing every finding.
+	var text strings.Builder
+	text.WriteString("<details><summary><b>")
+	text.WriteString(fmt.Sprintf("%d observability %s", len(obs), pluralize(len(obs), "finding", "findings")))
+	text.WriteString("</b></summary>\n\n")
+
+	groups := groupByDetector(obs)
+	for _, g := range groups {
+		text.WriteString(renderDetectorBlock(g))
+		text.WriteString("\n")
+	}
+	text.WriteString("</details>\n")
+
+	// Annotations: every observability finding gets a notice-level
+	// callout so the inline diff still shows them.
+	var ann []Annotation
+	for _, s := range obs {
+		ann = append(ann, signalToAnnotationNotice(s))
+	}
+
+	return Output{
+		Title:       title,
+		Summary:     summary,
+		Text:        text.String(),
+		Annotations: ann,
+	}
+}
+
+// detectorGroup is a per-detector cluster used by the gate render.
+type detectorGroup struct {
+	SignalType string
+	signals    []models.Signal // severity-sorted desc
+}
+
+func groupByDetector(in []models.Signal) []detectorGroup {
+	idx := map[string]*detectorGroup{}
+	var keys []string
+	for _, s := range in {
+		key := string(s.Type)
+		g, ok := idx[key]
+		if !ok {
+			g = &detectorGroup{SignalType: key}
+			idx[key] = g
+			keys = append(keys, key)
+		}
+		g.signals = append(g.signals, s)
+	}
+	for _, g := range idx {
+		sort.SliceStable(g.signals, func(i, j int) bool {
+			return severityRank(g.signals[i].Severity) > severityRank(g.signals[j].Severity)
+		})
+	}
+	out := make([]detectorGroup, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, *idx[k])
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		// Highest-severity-of-group first; tie-break by detector key.
+		si := severityRank(out[i].signals[0].Severity)
+		sj := severityRank(out[j].signals[0].Severity)
+		if si != sj {
+			return si > sj
+		}
+		return out[i].SignalType < out[j].SignalType
+	})
+	return out
+}
+
+// renderDetectorBlock emits one detector's section: title from
+// prtemplates, headline card, "+N more" collapse if applicable.
+func renderDetectorBlock(g detectorGroup) string {
+	if len(g.signals) == 0 {
+		return ""
+	}
+	head := g.signals[0]
+	var b strings.Builder
+
+	// Title (from template if registered, else SignalType verbatim).
+	title := g.SignalType
+	summary := ""
+	action := ""
+	if reg, err := prtemplates.Default(); err == nil && reg != nil {
+		if tpl, ok := reg.Get(g.SignalType); ok {
+			title = tpl.Title
+			summary = tpl.Summary
+			action = tpl.Action
+		}
+	}
+
+	label := uitokens.BracketedPRLabel(tierFor(head.Type), string(head.Severity))
+	loc := head.Location.File
+	if head.Location.Line > 0 {
+		loc = fmt.Sprintf("%s:%d", loc, head.Location.Line)
+	}
+
+	b.WriteString(fmt.Sprintf("### %s %s\n\n", label, title))
+	b.WriteString(fmt.Sprintf("**`%s`** — %s\n", loc, strings.TrimSpace(summary)))
+	if action != "" {
+		b.WriteString(fmt.Sprintf("\n→ %s\n", action))
+	}
+	if rest := len(g.signals) - 1; rest > 0 {
+		b.WriteString(fmt.Sprintf("\n_+%d more co-firing in this detector. Run `terrain explain %s` for the full list._\n",
+			rest, g.SignalType))
+	}
+	return b.String()
+}
+
+// signalToAnnotation maps a Signal to a Checks-API annotation.
+// `extraCount` is the count of additional co-firing signals; folded
+// into the annotation message so the inline diff annotation
+// acknowledges the +N collapse the Text section shows.
+func signalToAnnotation(s models.Signal, extraCount int) Annotation {
+	line := s.Location.Line
+	if line == 0 {
+		line = 1 // Checks API requires start_line ≥ 1
+	}
+	msg := s.Explanation
+	if msg == "" {
+		msg = string(s.Type)
+	}
+	if extraCount > 0 {
+		msg += fmt.Sprintf("\n\n(+%d more co-firing in this detector)", extraCount)
+	}
+	return Annotation{
+		Path:            s.Location.File,
+		StartLine:       line,
+		EndLine:         line,
+		AnnotationLevel: annotationLevel(string(s.Severity)),
+		Title:           string(s.Type),
+		Message:         msg,
+	}
+}
+
+func signalToAnnotationNotice(s models.Signal) Annotation {
+	a := signalToAnnotation(s, 0)
+	a.AnnotationLevel = "notice" // observability findings are never warning/failure
+	return a
+}
+
+func annotationLevel(severity string) string {
+	switch strings.ToLower(severity) {
+	case "critical", "high":
+		return "failure"
+	case "medium":
+		return "warning"
+	}
+	return "notice"
+}
+
+func severityRank(sev models.SignalSeverity) int {
+	switch strings.ToLower(string(sev)) {
+	case "critical":
+		return 5
+	case "high":
+		return 4
+	case "medium":
+		return 3
+	case "low":
+		return 2
+	case "info":
+		return 1
+	}
+	return 0
+}
+
+// severityCounts buckets the gate signals into BLOCK/GATE/NOTE
+// labels per the PR-comment label scheme (P5.5).
+func severityCounts(in []models.Signal) map[string]int {
+	out := map[string]int{}
+	for _, s := range in {
+		label := uitokens.PRLabel(tierFor(s.Type), string(s.Severity))
+		if label == "" {
+			continue
+		}
+		out[label]++
+	}
+	return out
+}
+
+// tierFor returns "gate" or "observability" for a SignalType by
+// consulting the manifest. Default "gate" for unknown types.
+func tierFor(t models.SignalType) string {
+	if signals.IsObservabilityTier(t) {
+		return "observability"
+	}
+	return "gate"
+}
+
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/internal/checkruns/checkruns_test.go
+++ b/internal/checkruns/checkruns_test.go
@@ -1,0 +1,225 @@
+package checkruns
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/pmclSF/terrain/internal/models"
+	"github.com/pmclSF/terrain/internal/signals"
+)
+
+// TestBuildBundle_EmptySnapshot returns clean empty check runs that
+// the API still accepts (both pass / neutral).
+func TestBuildBundle_EmptySnapshot(t *testing.T) {
+	b := BuildBundle(&models.TestSuiteSnapshot{}, "abc123")
+	if b.Gate.Name != "terrain (gate)" {
+		t.Errorf("gate name: %q", b.Gate.Name)
+	}
+	if b.Observability.Name != "terrain (observability)" {
+		t.Errorf("observability name: %q", b.Observability.Name)
+	}
+	if b.Gate.Conclusion != "success" {
+		t.Errorf("empty gate should be success, got %q", b.Gate.Conclusion)
+	}
+	if b.Observability.Conclusion != "neutral" {
+		t.Errorf("observability is always neutral, got %q", b.Observability.Conclusion)
+	}
+	if b.Gate.HeadSHA != "abc123" {
+		t.Errorf("head_sha not propagated")
+	}
+}
+
+// TestBuildBundle_NilSnapshot is no-op safe.
+func TestBuildBundle_NilSnapshot(t *testing.T) {
+	b := BuildBundle(nil, "abc123")
+	// Both check runs are zero-value but the function doesn't panic.
+	if b.Gate.HeadSHA != "" {
+		t.Errorf("nil snapshot should produce zero-value bundle")
+	}
+}
+
+// TestBuildBundle_GateFinding_FailsConclusion: a Medium-or-above
+// gate-tier finding produces conclusion="failure".
+func TestBuildBundle_GateFinding_FailsConclusion(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{
+				Type:     signals.SignalUntestedExport, // TierGate per manifest
+				Severity: models.SeverityHigh,
+				Location: models.SignalLocation{File: "src/exported.go", Line: 42},
+				Explanation: "exported function has no covering test",
+			},
+		},
+	}
+	b := BuildBundle(snap, "head1")
+	if b.Gate.Conclusion != "failure" {
+		t.Errorf("high gate severity should fail; got %q", b.Gate.Conclusion)
+	}
+	if len(b.Gate.Output.Annotations) != 1 {
+		t.Errorf("expected 1 annotation, got %d", len(b.Gate.Output.Annotations))
+	}
+	if b.Gate.Output.Annotations[0].AnnotationLevel != "failure" {
+		t.Errorf("annotation level for high: %q, want failure", b.Gate.Output.Annotations[0].AnnotationLevel)
+	}
+}
+
+// TestBuildBundle_ObservabilityFinding_NeutralOnly: observability-tier
+// findings never produce a "failure" — even at declared High severity
+// (which capSeverity would have demoted earlier in the pipeline).
+func TestBuildBundle_ObservabilityFinding_NeutralOnly(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{
+				Type:     signals.SignalMockHeavyTest, // TierObservability
+				Severity: models.SeverityMedium,
+				Location: models.SignalLocation{File: "tests/mocks_test.go", Line: 10},
+				Explanation: "test relies on mocks heavily",
+			},
+		},
+	}
+	b := BuildBundle(snap, "head1")
+	if b.Gate.Conclusion != "success" {
+		t.Errorf("no gate findings should pass; got %q", b.Gate.Conclusion)
+	}
+	if b.Observability.Conclusion != "neutral" {
+		t.Errorf("observability conclusion: %q, want neutral", b.Observability.Conclusion)
+	}
+	if len(b.Observability.Output.Annotations) != 1 {
+		t.Errorf("expected 1 observability annotation, got %d", len(b.Observability.Output.Annotations))
+	}
+	if b.Observability.Output.Annotations[0].AnnotationLevel != "notice" {
+		t.Errorf("observability annotation level: %q, want notice", b.Observability.Output.Annotations[0].AnnotationLevel)
+	}
+}
+
+// TestBuildBundle_PerDetectorCollapse: 5 co-firing instances of the
+// same detector produce ONE annotation with a "+4 more" mention in
+// the message, not 5 annotations.
+func TestBuildBundle_PerDetectorCollapse(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{}
+	for i := 0; i < 5; i++ {
+		snap.Signals = append(snap.Signals, models.Signal{
+			Type:     signals.SignalUntestedExport,
+			Severity: models.SeverityMedium,
+			Location: models.SignalLocation{File: "src/file.go", Line: 10 + i},
+			Explanation: "exported function has no covering test",
+		})
+	}
+	b := BuildBundle(snap, "head1")
+	if len(b.Gate.Output.Annotations) != 1 {
+		t.Errorf("expected 1 collapsed annotation, got %d", len(b.Gate.Output.Annotations))
+	}
+	if !strings.Contains(b.Gate.Output.Annotations[0].Message, "+4 more") {
+		t.Errorf("expected +4 more in collapsed message; got %q", b.Gate.Output.Annotations[0].Message)
+	}
+	if !strings.Contains(b.Gate.Output.Text, "co-firing in this detector") {
+		t.Errorf("text should mention co-firing collapse; got %q", b.Gate.Output.Text)
+	}
+}
+
+// TestBuildBundle_GateAndObservabilityCoexist: a PR with both kinds
+// of findings produces a bundle where each check run only carries its
+// respective findings.
+func TestBuildBundle_GateAndObservabilityCoexist(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: signals.SignalUntestedExport, Severity: models.SeverityHigh,
+				Location: models.SignalLocation{File: "src/a.go", Line: 1}},
+			{Type: signals.SignalMockHeavyTest, Severity: models.SeverityMedium,
+				Location: models.SignalLocation{File: "tests/b.go", Line: 1}},
+		},
+	}
+	b := BuildBundle(snap, "head1")
+	if b.Gate.Conclusion != "failure" {
+		t.Errorf("gate should fail (high finding); got %q", b.Gate.Conclusion)
+	}
+	if len(b.Gate.Output.Annotations) != 1 {
+		t.Errorf("gate should have 1 annotation; got %d", len(b.Gate.Output.Annotations))
+	}
+	if len(b.Observability.Output.Annotations) != 1 {
+		t.Errorf("observability should have 1 annotation; got %d", len(b.Observability.Output.Annotations))
+	}
+	if b.Gate.Output.Annotations[0].Path != "src/a.go" {
+		t.Errorf("gate annotation wrong file")
+	}
+	if b.Observability.Output.Annotations[0].Path != "tests/b.go" {
+		t.Errorf("observability annotation wrong file")
+	}
+}
+
+// TestBuildBundle_JSONMarshalRoundtrip confirms the API JSON shape
+// round-trips cleanly and produces parseable output for `gh api`.
+func TestBuildBundle_JSONMarshalRoundtrip(t *testing.T) {
+	snap := &models.TestSuiteSnapshot{
+		Signals: []models.Signal{
+			{Type: signals.SignalUntestedExport, Severity: models.SeverityHigh,
+				Location: models.SignalLocation{File: "src/a.go", Line: 42}},
+		},
+	}
+	b := BuildBundle(snap, "abc123")
+	data, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var roundtrip CheckRunsBundle
+	if err := json.Unmarshal(data, &roundtrip); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if roundtrip.Gate.HeadSHA != "abc123" {
+		t.Errorf("head_sha did not roundtrip")
+	}
+	if roundtrip.Gate.Name != "terrain (gate)" {
+		t.Errorf("name did not roundtrip")
+	}
+	// Required Checks-API fields present.
+	if roundtrip.Gate.Status != "completed" {
+		t.Errorf("status: %q", roundtrip.Gate.Status)
+	}
+	if len(roundtrip.Gate.Output.Annotations) != 1 {
+		t.Errorf("annotations didn't roundtrip")
+	}
+}
+
+// TestSeverityCounts_PRLabels confirms BLOCK / GATE / NOTE
+// bucketization matches the uitokens.PRLabel contract.
+func TestSeverityCounts_PRLabels(t *testing.T) {
+	in := []models.Signal{
+		{Type: signals.SignalUntestedExport, Severity: models.SeverityCritical},
+		{Type: signals.SignalUntestedExport, Severity: models.SeverityHigh},
+		{Type: signals.SignalUntestedExport, Severity: models.SeverityMedium},
+		{Type: signals.SignalUntestedExport, Severity: models.SeverityLow},
+		{Type: signals.SignalUntestedExport, Severity: models.SeverityInfo},
+	}
+	counts := severityCounts(in)
+	if counts["BLOCK"] != 1 {
+		t.Errorf("BLOCK count: %d, want 1", counts["BLOCK"])
+	}
+	if counts["GATE"] != 2 {
+		t.Errorf("GATE count: %d, want 2 (high + medium)", counts["GATE"])
+	}
+	if counts["NOTE"] != 1 {
+		t.Errorf("NOTE count: %d, want 1 (low)", counts["NOTE"])
+	}
+	// Info-tier drops from PR surface entirely.
+	if counts["INFO"] != 0 {
+		t.Errorf("info should drop; counts[INFO]=%d", counts["INFO"])
+	}
+}
+
+// TestAnnotationLevel_Mapping pins severity -> annotation_level.
+func TestAnnotationLevel_Mapping(t *testing.T) {
+	cases := []struct{ severity, want string }{
+		{"critical", "failure"},
+		{"high", "failure"},
+		{"medium", "warning"},
+		{"low", "notice"},
+		{"info", "notice"},
+		{"unknown", "notice"},
+	}
+	for _, c := range cases {
+		if got := annotationLevel(c.severity); got != c.want {
+			t.Errorf("annotationLevel(%q) = %q, want %q", c.severity, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
**P5.3** — Two named GitHub check runs.

New package \`internal/checkruns/\` builds Checks-API JSON for:
- \`terrain (gate)\` — required check. Conclusion = \`failure\` when any Medium+ gate-tier finding fires, else \`success\`.
- \`terrain (observability)\` — informational. Conclusion always \`neutral\`; never blocks merge.

Splitting rules:
- \`signals.IsObservabilityTier(SignalType)\` partitions findings.
- The gate check applies the per-detector visibility floor (P5.4): one headline annotation per detector, co-fires collapse to \`+N more\` in the message.
- The observability check carries every finding in a collapsed \`<details>\` footer in \`Output.Text\` plus one notice-level annotation per finding so they still show inline on the diff.

Output uses the prtemplates (P5.1) Title/Summary/Action when registered; falls back to detector-emitted Explanation otherwise.

**Terrain does NOT post to GitHub** — adopters' workflows consume the JSON and POST each half via \`gh api\`. Keeps the no-network-calls contract intact.

CLI: \`terrain report check-runs --head-sha=<sha> [--out=<path>]\`.

9 tests cover empty/nil snapshots, gate finding produces failure, observability never fails, per-detector collapse, gate+observability coexist, JSON marshal round-trip, BLOCK/GATE/NOTE severity counts, severity → annotation_level mapping.