### PR TITLE
Phase 5e: slash-command grammar + GitHub webhook receiver

### DIFF
--- a/cmd/terrain/cmd_webhook.go
+++ b/cmd/terrain/cmd_webhook.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/pmclSF/terrain/internal/slash"
+)
+
+// runWebhook starts an HTTP server that receives GitHub webhook
+// deliveries, validates signatures, parses slash-command bodies,
+// and dispatches them through a Dispatcher. The default dispatcher
+// is informational — it returns markdown describing what the verb
+// would do without mutating state. Adopters override this in their
+// own integration code.
+//
+// The secret is read from TERRAIN_WEBHOOK_SECRET (no flag — secrets
+// in CLI args show up in process lists and shell history). Empty
+// secret fails fast.
+//
+// Graceful shutdown: SIGINT/SIGTERM trigger a 5s drain via
+// http.Server.Shutdown. Existing in-flight requests get a chance to
+// finish; new connections are refused.
+func runWebhook(addr string) error {
+	secret := os.Getenv("TERRAIN_WEBHOOK_SECRET")
+	if secret == "" {
+		return fmt.Errorf("TERRAIN_WEBHOOK_SECRET is required (set the same value GitHub uses in the webhook configuration)")
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/webhook", slash.NewHandler(secret, slash.DefaultDispatcher{}))
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	// Listen for shutdown signals.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Fprintf(os.Stderr, "terrain webhook server listening on %s (POST /webhook)\n", addr)
+		err := srv.ListenAndServe()
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+		close(errCh)
+	}()
+
+	select {
+	case <-ctx.Done():
+		fmt.Fprintln(os.Stderr, "shutdown signal received; draining (5s timeout)...")
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			return fmt.Errorf("shutdown: %w", err)
+		}
+		return nil
+	case err, ok := <-errCh:
+		if !ok {
+			return nil
+		}
+		return err
+	}
+}

--- a/cmd/terrain/main.go
+++ b/cmd/terrain/main.go
@@ -382,6 +382,42 @@ func main() {
 			os.Exit(1)
 		}
 
+	case "webhook":
+		// Maintainer / self-host surface: receives GitHub webhook
+		// deliveries, parses slash commands, dispatches through a
+		// Dispatcher (default: informational, no GitHub write-back).
+		// Adopters override the dispatcher in their integration code.
+		// Gated behind TERRAIN_DEV so adopters don't accidentally run
+		// the no-write-back default in production.
+		if os.Getenv("TERRAIN_DEV") == "" {
+			fmt.Fprintln(os.Stderr, "error: unknown command \"webhook\"")
+			os.Exit(2)
+		}
+		addr := ":4242"
+		for i := 2; i < len(os.Args); i++ {
+			a := os.Args[i]
+			if a == "--addr" && i+1 < len(os.Args) {
+				addr = os.Args[i+1]
+				i++
+				continue
+			}
+			if len(a) > len("--addr=") && a[:len("--addr=")] == "--addr=" {
+				addr = a[len("--addr="):]
+				continue
+			}
+			if isHelpArg(a) {
+				fmt.Fprintln(os.Stderr, "Usage: terrain webhook [--addr=:4242]")
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintln(os.Stderr, "Start the GitHub webhook server.")
+				fmt.Fprintln(os.Stderr, "Requires TERRAIN_WEBHOOK_SECRET (same value GitHub uses).")
+				return
+			}
+		}
+		if err := runWebhook(addr); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+
 	case "reset":
 		legacyDeprecationNotice("reset", "config reset")
 		if err := runResetCLI(os.Args[2:]); err != nil {

--- a/internal/slash/commandlist.go
+++ b/internal/slash/commandlist.go
@@ -1,0 +1,52 @@
+package slash
+
+import "strings"
+
+// RenderCommandList produces the markdown for the pinned
+// command-list comment Terrain posts on first interaction with a PR.
+// The comment stays pinned (re-rendered into the same comment ID on
+// every PR-comment hook) so users always know which verbs are
+// available.
+//
+// Spec § P5.2: "First-time bot interaction pins a top-level
+// command-list comment."
+//
+// The output is stable across calls (no timestamps, no randomized
+// ordering) so a re-render produces byte-identical text — the
+// webhook handler can compare and skip the edit when there's no
+// change.
+func RenderCommandList() string {
+	var b strings.Builder
+	b.WriteString("**Terrain — slash commands**\n\n")
+	b.WriteString("Reply to any inline finding with one of:\n\n")
+	for _, line := range commandLines() {
+		b.WriteString("- `")
+		b.WriteString(line.Syntax)
+		b.WriteString("` — ")
+		b.WriteString(line.Help)
+		b.WriteString("\n")
+	}
+	b.WriteString("\n_Commands are case-insensitive. Quoted values support spaces. ")
+	b.WriteString("All actions are deterministic — no LLM parsing._\n")
+	return b.String()
+}
+
+type commandHelp struct {
+	Syntax string
+	Help   string
+}
+
+func commandLines() []commandHelp {
+	return []commandHelp{
+		{"/dismiss reason:<text>", "Suppress this finding. Adds an entry to .terrain/suppressions.yaml with content_hash so the suppression invalidates if the line changes."},
+		{"/terrain explain <rule-id>", "Long-form explanation of a rule (what it catches, why, how to fix)."},
+		{"/terrain why <rule-id>", "One-paragraph rationale for why a rule exists."},
+		{"/terrain show <id>", "Render one finding by its ID."},
+		{"/terrain expand", "Expand a collapsed `+N more` block inline."},
+		{"/terrain refresh", "Re-run analyze and update this PR comment."},
+		{"/terrain escalate", "Promote a finding from observability to gate for this PR only."},
+		{"/terrain scaffold accept", "Accept the test scaffold this finding suggested."},
+		{"/terrain bench <id>", "Run a benchmark suite by ID against this PR."},
+		{"/terrain commands", "Re-print this command list."},
+	}
+}

--- a/internal/slash/dispatcher.go
+++ b/internal/slash/dispatcher.go
@@ -1,0 +1,54 @@
+package slash
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultDispatcher is a zero-config Dispatcher useful for local
+// testing and for the `terrain serve --webhook` mode. It produces a
+// markdown reply that describes what the verb would do, without
+// actually mutating state or running the underlying analysis.
+//
+// Production deployments override this with a Dispatcher that's
+// wired to the existing CLI runners (runShow, runExplain,
+// runSuppress) plus a GitHub-API client that posts the reply back
+// to the PR.
+//
+// The intent: ship a working webhook receiver in P5.2 so adopters
+// can validate the wiring end-to-end; the dispatch table they
+// override is the only piece they need to provide.
+type DefaultDispatcher struct{}
+
+// Handle implements Dispatcher. Returns a markdown reply describing
+// what the verb would do.
+func (DefaultDispatcher) Handle(ev WebhookEvent, cmd *Command) (string, error) {
+	if cmd == nil {
+		return "", fmt.Errorf("nil command")
+	}
+	switch cmd.Verb {
+	case VerbCommands:
+		return RenderCommandList(), nil
+	case VerbDismiss:
+		reason := cmd.Keyword["reason"]
+		return fmt.Sprintf("`/dismiss` recorded with reason: %q. Wire a Dispatcher that calls into `internal/suppression` to materialize the entry.", reason), nil
+	case VerbExplain, VerbWhy:
+		ruleID := strings.Join(cmd.Positional, " ")
+		return fmt.Sprintf("`/%s %s` — wire a Dispatcher that consults `internal/severity/rubric` and renders the rule's stable clause IDs.", cmd.Verb, ruleID), nil
+	case VerbShow:
+		id := strings.Join(cmd.Positional, " ")
+		return fmt.Sprintf("`/terrain show %s` — wire a Dispatcher that runs `runReportShow` against the latest snapshot.", id), nil
+	case VerbExpand:
+		return "`/terrain expand` — wire a Dispatcher that re-renders the collapsed `+N more` block inline.", nil
+	case VerbRefresh:
+		return "`/terrain refresh` — wire a Dispatcher that re-runs analyze and edits the pinned comment.", nil
+	case VerbEscalate:
+		return "`/terrain escalate` — wire a Dispatcher that flips the active finding's tier for this PR only.", nil
+	case VerbScaffold:
+		return "`/terrain scaffold accept` — wire a Dispatcher that materializes the test scaffold the finding suggested.", nil
+	case VerbBench:
+		id := strings.Join(cmd.Positional, " ")
+		return fmt.Sprintf("`/terrain bench %s` — wire a Dispatcher that runs the benchmark suite by id.", id), nil
+	}
+	return fmt.Sprintf("Unhandled verb `%s` — extend DefaultDispatcher.Handle().", cmd.Verb), nil
+}

--- a/internal/slash/grammar.go
+++ b/internal/slash/grammar.go
@@ -1,0 +1,330 @@
+// Package slash implements Terrain's deterministic slash-command
+// grammar for PR-comment interaction. No LLM parsing — every verb is
+// a literal string match with explicit positional + keyword args.
+//
+// The 10-verb canonical set (per § P5.2):
+//
+//	/terrain bench <id>            — run a benchmark suite by ID.
+//	/terrain commands              — re-print the pinned command list.
+//	/dismiss reason:<text>         — suppress the active finding (must
+//	                                  be invoked as a reply to a
+//	                                  finding's inline comment).
+//	/terrain escalate              — flip the active finding from
+//	                                  observability to gate for this
+//	                                  PR (one-off).
+//	/terrain explain <rule-id>     — long-form explanation of a rule.
+//	/terrain expand                — expand a `+N more` collapsed
+//	                                  block (replies inline).
+//	/terrain refresh               — re-run analyze + replace the PR
+//	                                  comment with fresh output.
+//	/terrain scaffold accept       — accept the test scaffold the
+//	                                  active finding suggested.
+//	/terrain show <id>             — render one finding by ID.
+//	/terrain why <rule-id>         — short rationale for a rule.
+//
+// Grammar shape: leading `/`, verb (with optional `terrain` prefix
+// for verbs that need to disambiguate from third-party bots), then
+// either positional args or `key:value` pairs. Whitespace is the
+// only separator. Quoted values support spaces in the reason text.
+//
+// Unknown verbs produce a ParseError with the closest match
+// suggestion (Levenshtein-like) so users see helpful corrections.
+package slash
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Verb enumerates the 10 canonical slash commands. Values are the
+// canonical literal the user types. The package also accepts an
+// optional `/terrain ` prefix on every verb so users can be explicit
+// about which bot they're talking to.
+type Verb string
+
+const (
+	VerbBench         Verb = "bench"
+	VerbCommands      Verb = "commands"
+	VerbDismiss       Verb = "dismiss"
+	VerbEscalate      Verb = "escalate"
+	VerbExplain       Verb = "explain"
+	VerbExpand        Verb = "expand"
+	VerbRefresh       Verb = "refresh"
+	VerbScaffold      Verb = "scaffold"
+	VerbShow          Verb = "show"
+	VerbWhy           Verb = "why"
+)
+
+// AllVerbs lists every canonical verb. Used by the grammar parser
+// for autocomplete-style "did you mean" hints and by the command-list
+// renderer to generate the pinned comment.
+var AllVerbs = []Verb{
+	VerbBench, VerbCommands, VerbDismiss, VerbEscalate,
+	VerbExplain, VerbExpand, VerbRefresh, VerbScaffold,
+	VerbShow, VerbWhy,
+}
+
+// Command is one parsed slash-command invocation.
+type Command struct {
+	// Verb is the canonical verb.
+	Verb Verb
+	// Positional carries any positional args after the verb (e.g.
+	// the `<id>` for `/terrain show <id>`). Always normalized — no
+	// surrounding whitespace.
+	Positional []string
+	// Keyword carries `key:value` pairs (e.g. `reason:false-positive`
+	// for `/dismiss`). Always present, may be empty.
+	Keyword map[string]string
+	// Raw is the original input line for logging / audit.
+	Raw string
+}
+
+// ParseError is the parser's error type. Includes a Suggestion when
+// the closest registered verb is within edit distance 2.
+type ParseError struct {
+	Input      string
+	Reason     string
+	Suggestion string
+}
+
+func (e *ParseError) Error() string {
+	if e.Suggestion != "" {
+		return fmt.Sprintf("slash: %s (did you mean %q?)", e.Reason, e.Suggestion)
+	}
+	return fmt.Sprintf("slash: %s", e.Reason)
+}
+
+// Parse turns a single PR-comment line into a Command. Lines that
+// don't start with `/` return (nil, nil) — they're not slash commands
+// and the caller should ignore them. Malformed slash commands return
+// (nil, *ParseError).
+//
+// Accepted shapes:
+//
+//	/terrain <verb> [positional...] [key:value...]
+//	/<verb> [positional...] [key:value...]      (no /terrain prefix)
+//	/dismiss reason:<text>                       (alias: /dismiss is
+//	                                              special-cased as a
+//	                                              top-level verb so
+//	                                              users don't have to
+//	                                              remember the prefix
+//	                                              for the most common
+//	                                              command).
+//
+// Quoted values: `key:"value with spaces"` is supported. Backslash-
+// escape inside quoted values for embedded quotes (`\"`).
+func Parse(input string) (*Command, error) {
+	line := strings.TrimSpace(input)
+	if !strings.HasPrefix(line, "/") {
+		return nil, nil
+	}
+	body := strings.TrimPrefix(line, "/")
+	if body == "" {
+		return nil, &ParseError{Input: input, Reason: "empty slash command"}
+	}
+
+	tokens, err := tokenize(body)
+	if err != nil {
+		return nil, &ParseError{Input: input, Reason: err.Error()}
+	}
+	if len(tokens) == 0 {
+		return nil, &ParseError{Input: input, Reason: "empty slash command"}
+	}
+
+	// Determine the verb. If the first token is "terrain", the verb
+	// is the second token (canonical `/terrain <verb>` shape). Else
+	// the first token is the verb directly (compact shape).
+	var verb string
+	var rest []string
+	if strings.EqualFold(tokens[0], "terrain") {
+		if len(tokens) < 2 {
+			return nil, &ParseError{Input: input, Reason: "missing verb after /terrain"}
+		}
+		verb = tokens[1]
+		rest = tokens[2:]
+	} else {
+		verb = tokens[0]
+		rest = tokens[1:]
+	}
+
+	// Validate verb.
+	canonical, ok := canonicalVerb(verb)
+	if !ok {
+		return nil, &ParseError{
+			Input:      input,
+			Reason:     fmt.Sprintf("unknown verb %q", verb),
+			Suggestion: suggestVerb(verb),
+		}
+	}
+
+	cmd := &Command{
+		Verb:    canonical,
+		Keyword: map[string]string{},
+		Raw:     line,
+	}
+
+	// Partition rest into positional and keyword args.
+	for _, tok := range rest {
+		if k, v, ok := splitKeyword(tok); ok {
+			cmd.Keyword[k] = v
+		} else {
+			cmd.Positional = append(cmd.Positional, tok)
+		}
+	}
+
+	if err := validate(cmd); err != nil {
+		return nil, err
+	}
+	return cmd, nil
+}
+
+// canonicalVerb returns the Verb constant for a typed string, plus a
+// presence bool. Case-insensitive match.
+func canonicalVerb(s string) (Verb, bool) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	for _, v := range AllVerbs {
+		if string(v) == s {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// splitKeyword pulls a `key:value` token apart. Returns ok=false when
+// the token has no colon, starts with one, or the key segment looks
+// like part of an identifier (contains `@`, `.`, `/`, `#`). The
+// identifier-shape rejection lets positional tokens like finding-IDs
+// (`weakAssertion@path:Symbol#hash`) pass through as a single
+// positional rather than being mis-split on the colon.
+func splitKeyword(tok string) (key, value string, ok bool) {
+	idx := strings.Index(tok, ":")
+	if idx <= 0 || idx == len(tok)-1 {
+		return "", "", false
+	}
+	k := strings.ToLower(strings.TrimSpace(tok[:idx]))
+	if !isSimpleIdent(k) {
+		return "", "", false
+	}
+	v := strings.TrimSpace(tok[idx+1:])
+	v = unquote(v)
+	if k == "" || v == "" {
+		return "", "", false
+	}
+	return k, v, true
+}
+
+// isSimpleIdent returns true when s is an unqualified lowercase
+// identifier (letters / digits / underscore, must start with letter).
+// Used to distinguish keyword keys (e.g. "reason") from the colon
+// that appears inside compound IDs (e.g. "type@path:symbol#hash").
+func isSimpleIdent(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	if !(s[0] >= 'a' && s[0] <= 'z') {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// validate enforces per-verb argument requirements.
+func validate(c *Command) error {
+	switch c.Verb {
+	case VerbBench:
+		if len(c.Positional) == 0 {
+			return &ParseError{Input: c.Raw, Reason: "bench requires a benchmark id (usage: /terrain bench <id>)"}
+		}
+	case VerbDismiss:
+		if c.Keyword["reason"] == "" {
+			return &ParseError{Input: c.Raw, Reason: "dismiss requires reason:<text> (usage: /dismiss reason:\"why\")"}
+		}
+	case VerbExplain, VerbWhy:
+		if len(c.Positional) == 0 {
+			return &ParseError{Input: c.Raw, Reason: fmt.Sprintf("%s requires a rule-id (usage: /terrain %s <rule-id>)", c.Verb, c.Verb)}
+		}
+	case VerbShow:
+		if len(c.Positional) == 0 {
+			return &ParseError{Input: c.Raw, Reason: "show requires an id (usage: /terrain show <finding-id-or-rule-id>)"}
+		}
+	case VerbScaffold:
+		// /terrain scaffold accept — requires the literal "accept" subverb.
+		if len(c.Positional) == 0 || c.Positional[0] != "accept" {
+			return &ParseError{Input: c.Raw, Reason: "scaffold requires the 'accept' subverb (usage: /terrain scaffold accept)"}
+		}
+	}
+	return nil
+}
+
+// suggestVerb returns the closest canonical verb to s within edit
+// distance 2, or "" when no good match exists.
+func suggestVerb(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	best := ""
+	bestDist := 3
+	for _, v := range AllVerbs {
+		d := editDistance(s, string(v))
+		if d < bestDist {
+			bestDist = d
+			best = string(v)
+		}
+	}
+	return best
+}
+
+// editDistance computes the Levenshtein edit distance between a and b.
+// Used by suggestVerb; small inputs only.
+func editDistance(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	la, lb := len(ar), len(br)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			curr[j] = min3(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}
+
+func min3(a, b, c int) int {
+	m := a
+	if b < m {
+		m = b
+	}
+	if c < m {
+		m = c
+	}
+	return m
+}
+
+func unquote(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/internal/slash/signature.go
+++ b/internal/slash/signature.go
@@ -1,0 +1,51 @@
+package slash
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// VerifySignature validates a GitHub webhook payload's HMAC-SHA256
+// signature. GitHub computes the signature as
+// `sha256=<hex(hmac_sha256(secret, body))>` and sends it in the
+// `X-Hub-Signature-256` header. This function returns nil on a
+// valid signature, a non-nil error otherwise.
+//
+// Uses constant-time comparison (hmac.Equal) so timing-side-channel
+// attacks can't leak the secret one byte at a time.
+//
+// Empty secret returns an error explicitly — silently accepting an
+// unsigned webhook is the wrong default.
+func VerifySignature(headerValue string, body []byte, secret string) error {
+	if secret == "" {
+		return fmt.Errorf("verify signature: webhook secret not configured")
+	}
+	const prefix = "sha256="
+	if !strings.HasPrefix(headerValue, prefix) {
+		return fmt.Errorf("verify signature: header missing 'sha256=' prefix")
+	}
+	sig := headerValue[len(prefix):]
+	want, err := hex.DecodeString(sig)
+	if err != nil {
+		return fmt.Errorf("verify signature: header is not hex: %w", err)
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	got := mac.Sum(nil)
+	if !hmac.Equal(want, got) {
+		return fmt.Errorf("verify signature: signature mismatch")
+	}
+	return nil
+}
+
+// ComputeSignatureHeader is the symmetric helper for tests: given a
+// body and secret, return the `sha256=...` header value GitHub
+// would send. Production code never calls this.
+func ComputeSignatureHeader(body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/slash/slash_test.go
+++ b/internal/slash/slash_test.go
@@ -1,0 +1,356 @@
+package slash
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ── Grammar / Parse ─────────────────────────────────────────────────
+
+func TestParse_NonSlashReturnsNil(t *testing.T) {
+	c, err := Parse("not a slash command")
+	if c != nil || err != nil {
+		t.Errorf("non-slash should return (nil, nil); got (%+v, %v)", c, err)
+	}
+	c, err = Parse("")
+	if c != nil || err != nil {
+		t.Errorf("empty should return (nil, nil)")
+	}
+}
+
+func TestParse_DismissWithReason(t *testing.T) {
+	c, err := Parse(`/dismiss reason:"false positive"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Verb != VerbDismiss {
+		t.Errorf("verb = %q, want %q", c.Verb, VerbDismiss)
+	}
+	if c.Keyword["reason"] != "false positive" {
+		t.Errorf("reason = %q", c.Keyword["reason"])
+	}
+}
+
+func TestParse_DismissRequiresReason(t *testing.T) {
+	_, err := Parse(`/dismiss`)
+	if err == nil {
+		t.Fatal("dismiss without reason should error")
+	}
+	if !strings.Contains(err.Error(), "reason") {
+		t.Errorf("error should mention 'reason'; got %v", err)
+	}
+}
+
+func TestParse_TerrainPrefixOptional(t *testing.T) {
+	c1, err := Parse(`/terrain explain ai.surface.missing_eval`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	// `/explain` directly should also work — verb-only shape.
+	c2, err := Parse(`/explain ai.surface.missing_eval`)
+	if err != nil {
+		t.Fatalf("parse no-prefix: %v", err)
+	}
+	if c1.Verb != c2.Verb || c1.Positional[0] != c2.Positional[0] {
+		t.Errorf("prefix vs no-prefix differ: %+v vs %+v", c1, c2)
+	}
+}
+
+func TestParse_UnknownVerbSuggestion(t *testing.T) {
+	_, err := Parse(`/terrain explan some-rule`)
+	if err == nil {
+		t.Fatal("typo should error")
+	}
+	pe, ok := err.(*ParseError)
+	if !ok {
+		t.Fatalf("expected *ParseError, got %T", err)
+	}
+	if pe.Suggestion != "explain" {
+		t.Errorf("expected suggestion 'explain', got %q", pe.Suggestion)
+	}
+}
+
+func TestParse_CaseInsensitiveVerb(t *testing.T) {
+	c, err := Parse(`/TERRAIN Dismiss reason:test`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Verb != VerbDismiss {
+		t.Errorf("verb = %q, want %q", c.Verb, VerbDismiss)
+	}
+}
+
+func TestParse_ScaffoldAcceptRequired(t *testing.T) {
+	if _, err := Parse(`/terrain scaffold`); err == nil {
+		t.Error("scaffold without subverb should error")
+	}
+	c, err := Parse(`/terrain scaffold accept`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Verb != VerbScaffold {
+		t.Errorf("verb = %q", c.Verb)
+	}
+}
+
+func TestParse_BenchRequiresID(t *testing.T) {
+	if _, err := Parse(`/terrain bench`); err == nil {
+		t.Error("bench without id should error")
+	}
+	if _, err := Parse(`/terrain bench latency-001`); err != nil {
+		t.Errorf("bench with id should parse: %v", err)
+	}
+}
+
+func TestParse_ShowRequiresID(t *testing.T) {
+	if _, err := Parse(`/terrain show`); err == nil {
+		t.Error("show without id should error")
+	}
+	c, err := Parse(`/terrain show weakAssertion@a.go:X#abc12345`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if c.Positional[0] != "weakAssertion@a.go:X#abc12345" {
+		t.Errorf("positional = %v", c.Positional)
+	}
+}
+
+func TestParse_QuotedReasonWithEscapes(t *testing.T) {
+	c, err := Parse(`/dismiss reason:"says \"hello\" politely"`)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !strings.Contains(c.Keyword["reason"], `"hello"`) {
+		t.Errorf("escape did not preserve embedded quotes; got %q", c.Keyword["reason"])
+	}
+}
+
+func TestParse_UnterminatedQuote(t *testing.T) {
+	if _, err := Parse(`/dismiss reason:"never closed`); err == nil {
+		t.Error("unterminated quote should error")
+	}
+}
+
+func TestEditDistance(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"explain", "explain", 0},
+		{"explan", "explain", 1}, // missing letter
+		{"explayn", "explain", 1},
+		{"", "abc", 3},
+		{"abc", "", 3},
+	}
+	for _, c := range cases {
+		if got := editDistance(c.a, c.b); got != c.want {
+			t.Errorf("editDistance(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// ── Command list rendering ─────────────────────────────────────────
+
+func TestRenderCommandList_HasAllTenVerbs(t *testing.T) {
+	out := RenderCommandList()
+	// Each of the 10 verbs should appear in the rendered list.
+	for _, verb := range AllVerbs {
+		// `/dismiss` is special-cased without `/terrain` prefix in
+		// the command-list output; check for either shape.
+		v := "/" + string(verb)
+		v2 := "/terrain " + string(verb)
+		if !strings.Contains(out, v) && !strings.Contains(out, v2) {
+			t.Errorf("rendered command list missing verb %q; output:\n%s", verb, out)
+		}
+	}
+}
+
+func TestRenderCommandList_DeterministicAcrossCalls(t *testing.T) {
+	a := RenderCommandList()
+	b := RenderCommandList()
+	if a != b {
+		t.Error("command list should be byte-identical across calls")
+	}
+}
+
+// ── Signature ──────────────────────────────────────────────────────
+
+func TestVerifySignature_Valid(t *testing.T) {
+	body := []byte(`{"action":"created"}`)
+	secret := "very-secret"
+	header := ComputeSignatureHeader(body, secret)
+	if err := VerifySignature(header, body, secret); err != nil {
+		t.Errorf("expected valid signature, got %v", err)
+	}
+}
+
+func TestVerifySignature_TamperedBody(t *testing.T) {
+	body := []byte(`{"action":"created"}`)
+	secret := "very-secret"
+	header := ComputeSignatureHeader(body, secret)
+	// Mutate the body.
+	if err := VerifySignature(header, []byte(`{"action":"different"}`), secret); err == nil {
+		t.Error("tampered body should fail signature check")
+	}
+}
+
+func TestVerifySignature_NoSecret(t *testing.T) {
+	if err := VerifySignature("sha256=abc", []byte("x"), ""); err == nil {
+		t.Error("empty secret should error")
+	}
+}
+
+func TestVerifySignature_BadHeader(t *testing.T) {
+	body := []byte("x")
+	secret := "s"
+	if err := VerifySignature("notsha256=abc", body, secret); err == nil {
+		t.Error("missing prefix should error")
+	}
+	if err := VerifySignature("sha256=not-hex", body, secret); err == nil {
+		t.Error("non-hex header should error")
+	}
+}
+
+// ── Webhook handler ─────────────────────────────────────────────────
+
+// echoDispatcher returns the command's verb in the reply for assertion.
+type echoDispatcher struct{}
+
+func (echoDispatcher) Handle(_ WebhookEvent, cmd *Command) (string, error) {
+	return string(cmd.Verb), nil
+}
+
+func makeEvent(t *testing.T, body string, commentBody string) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"action": "created",
+		"comment": map[string]any{
+			"id":   42,
+			"body": commentBody,
+			"user": map[string]any{"login": "alice"},
+		},
+		"issue": map[string]any{"number": 1},
+		"repository": map[string]any{
+			"full_name": "org/repo",
+		},
+		"sender": map[string]any{"login": "alice"},
+	}
+	data, _ := json.Marshal(payload)
+	if body != "" {
+		return []byte(body)
+	}
+	return data
+}
+
+func TestHandler_NewHandlerRefusesEmptySecret(t *testing.T) {
+	if h := NewHandler("", echoDispatcher{}); h != nil {
+		t.Error("empty secret should produce nil handler")
+	}
+}
+
+func TestHandler_RejectsBadSignature(t *testing.T) {
+	body := makeEvent(t, "", "/dismiss reason:test")
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", "sha256=wrong")
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	rr := httptest.NewRecorder()
+	h := NewHandler("the-secret", echoDispatcher{})
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("expected 401, got %d", rr.Code)
+	}
+}
+
+func TestHandler_DispatchesDismiss(t *testing.T) {
+	body := makeEvent(t, "", `/dismiss reason:"false-positive"`)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", ComputeSignatureHeader(body, "the-secret"))
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	rr := httptest.NewRecorder()
+	NewHandler("the-secret", echoDispatcher{}).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d (body=%s)", rr.Code, rr.Body.String())
+	}
+	out, _ := io.ReadAll(rr.Body)
+	if !strings.Contains(string(out), "dismiss") {
+		t.Errorf("expected reply to contain 'dismiss'; got %s", string(out))
+	}
+}
+
+func TestHandler_IgnoresBotComments(t *testing.T) {
+	payload := map[string]any{
+		"action": "created",
+		"comment": map[string]any{
+			"id":   42,
+			"body": "/dismiss reason:x",
+			"user": map[string]any{"login": "terrain-bot[bot]"},
+		},
+		"issue":      map[string]any{"number": 1},
+		"repository": map[string]any{"full_name": "org/repo"},
+		"sender":     map[string]any{"login": "terrain-bot[bot]"},
+	}
+	body, _ := json.Marshal(payload)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", ComputeSignatureHeader(body, "secret"))
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	rr := httptest.NewRecorder()
+	NewHandler("secret", echoDispatcher{}).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "ignored (bot sender)") {
+		t.Errorf("expected bot-ignore message; got %s", rr.Body.String())
+	}
+}
+
+func TestHandler_AcceptsPing(t *testing.T) {
+	body := []byte(`{"zen":"pong"}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", ComputeSignatureHeader(body, "secret"))
+	req.Header.Set("X-GitHub-Event", "ping")
+	rr := httptest.NewRecorder()
+	NewHandler("secret", echoDispatcher{}).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Errorf("status: %d", rr.Code)
+	}
+}
+
+func TestHandler_RejectsNonPost(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/webhook", nil)
+	rr := httptest.NewRecorder()
+	NewHandler("secret", echoDispatcher{}).ServeHTTP(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status: %d", rr.Code)
+	}
+}
+
+func TestHandler_MultiCommandReply(t *testing.T) {
+	body := makeEvent(t, "", "/terrain show abc\n/terrain refresh")
+	req := httptest.NewRequest(http.MethodPost, "/webhook", bytes.NewReader(body))
+	req.Header.Set("X-Hub-Signature-256", ComputeSignatureHeader(body, "secret"))
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	rr := httptest.NewRecorder()
+	NewHandler("secret", echoDispatcher{}).ServeHTTP(rr, req)
+	out := rr.Body.String()
+	if !strings.Contains(out, "show") || !strings.Contains(out, "refresh") {
+		t.Errorf("multi-command reply missing verbs; got:\n%s", out)
+	}
+}
+
+// ── Default dispatcher ─────────────────────────────────────────────
+
+func TestDefaultDispatcher_CommandsRendersList(t *testing.T) {
+	cmd, _ := Parse(`/terrain commands`)
+	r, err := (DefaultDispatcher{}).Handle(WebhookEvent{}, cmd)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if !strings.Contains(r, "Terrain — slash commands") {
+		t.Errorf("expected command-list header in reply; got:\n%s", r)
+	}
+}

--- a/internal/slash/tokenize.go
+++ b/internal/slash/tokenize.go
@@ -1,0 +1,75 @@
+package slash
+
+import (
+	"fmt"
+	"strings"
+)
+
+// tokenize splits a slash-command body into tokens. Whitespace
+// separates tokens; quoted strings preserve internal whitespace.
+//
+// Supported quotes: `"..."` and `'...'`. Backslash inside double
+// quotes escapes the next character literally.
+//
+// Examples:
+//
+//	"dismiss reason:false-positive"     → ["dismiss", "reason:false-positive"]
+//	"dismiss reason:\"line N\""          → ["dismiss", "reason:line N"]
+//	"explain terrain/ai/x"               → ["explain", "terrain/ai/x"]
+func tokenize(body string) ([]string, error) {
+	var tokens []string
+	var buf strings.Builder
+	inQuote := byte(0) // 0 = not in quote; '"' or '\'' otherwise
+	i := 0
+	for i < len(body) {
+		c := body[i]
+		if inQuote != 0 {
+			if c == '\\' && inQuote == '"' && i+1 < len(body) {
+				// Escape sequence inside double quotes.
+				buf.WriteByte(body[i+1])
+				i += 2
+				continue
+			}
+			if c == inQuote {
+				// Close quote.
+				inQuote = 0
+				i++
+				continue
+			}
+			buf.WriteByte(c)
+			i++
+			continue
+		}
+		// Not in a quote.
+		if c == ' ' || c == '\t' {
+			if buf.Len() > 0 {
+				tokens = append(tokens, buf.String())
+				buf.Reset()
+			}
+			i++
+			continue
+		}
+		if c == '"' || c == '\'' {
+			inQuote = c
+			i++
+			continue
+		}
+		// `key:` followed by an open quote — handle by treating the
+		// quote as the start of the value.
+		if c == ':' && i+1 < len(body) && (body[i+1] == '"' || body[i+1] == '\'') {
+			buf.WriteByte(':')
+			inQuote = body[i+1]
+			i += 2
+			continue
+		}
+		buf.WriteByte(c)
+		i++
+	}
+	if inQuote != 0 {
+		return nil, fmt.Errorf("unterminated quote (%c)", inQuote)
+	}
+	if buf.Len() > 0 {
+		tokens = append(tokens, buf.String())
+	}
+	return tokens, nil
+}

--- a/internal/slash/webhook.go
+++ b/internal/slash/webhook.go
@@ -1,0 +1,212 @@
+package slash
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// WebhookEvent is the parsed shape of a GitHub `issue_comment` or
+// `pull_request_review_comment` event after the slash-command body
+// has been extracted. Only the fields the dispatcher needs.
+type WebhookEvent struct {
+	// Action is the GitHub event action (e.g. "created", "edited").
+	// Terrain only acts on "created" by default.
+	Action string `json:"action"`
+	// Sender is the GitHub login of the comment author. Used to
+	// filter bot-authored comments so Terrain doesn't act on its
+	// own posts.
+	Sender string `json:"sender"`
+	// CommentID is the GitHub comment ID. Used for replies.
+	CommentID int64 `json:"comment_id"`
+	// CommentBody is the raw comment markdown.
+	CommentBody string `json:"comment_body"`
+	// PRNumber is the pull-request number the comment is on.
+	PRNumber int `json:"pr_number"`
+	// Repository is "owner/name".
+	Repository string `json:"repository"`
+	// FindingID is the finding the comment is attached to, when the
+	// comment is a reply to a Terrain-posted inline annotation.
+	// Empty for top-level PR comments.
+	FindingID string `json:"finding_id,omitempty"`
+}
+
+// Dispatcher executes parsed Commands against the snapshot/repo.
+// Implementations are typically backed by the existing CLI runners
+// (runShow, runExplain, runSuppress, etc.) — slash commands are a
+// remote-control surface over the same primitives.
+//
+// Each Handle returns a markdown response that the webhook handler
+// posts back to the PR as a reply comment.
+type Dispatcher interface {
+	// Handle dispatches the command and returns the reply markdown.
+	// An error is treated as a 500 by the HTTP handler; the message
+	// is written to the response body (the GitHub event delivery
+	// retry path expects 5xx for transient failures).
+	Handle(ev WebhookEvent, cmd *Command) (replyMarkdown string, err error)
+}
+
+// Handler is the HTTP handler for GitHub webhook deliveries.
+// Construct with NewHandler(secret, dispatcher). Wire to a server
+// (`internal/server`, terrain serve --webhook) or any net/http
+// server.
+type Handler struct {
+	Secret     string
+	Dispatcher Dispatcher
+}
+
+// NewHandler builds a webhook handler. Returns nil when secret is
+// empty — the package refuses to accept unsigned webhooks.
+func NewHandler(secret string, dispatcher Dispatcher) *Handler {
+	if secret == "" {
+		return nil
+	}
+	return &Handler{Secret: secret, Dispatcher: dispatcher}
+}
+
+// ServeHTTP implements http.Handler. Validates the signature, parses
+// the event, extracts any slash commands from the comment body, and
+// dispatches each through h.Dispatcher.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := VerifySignature(r.Header.Get("X-Hub-Signature-256"), body, h.Secret); err != nil {
+		http.Error(w, "signature: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	eventType := r.Header.Get("X-GitHub-Event")
+	switch eventType {
+	case "ping":
+		// GitHub sends a `ping` event when a webhook is first
+		// configured. Return 200 with the standard reply so the
+		// hook shows as "delivered" in the UI.
+		_, _ = w.Write([]byte("pong"))
+		return
+	case "issue_comment", "pull_request_review_comment":
+		// Continue to slash-command parsing.
+	default:
+		// Quietly accept other event types so unsubscribing is a
+		// GitHub-side configuration rather than a 4xx noise spike.
+		_, _ = w.Write([]byte("ignored"))
+		return
+	}
+
+	ev, err := parseEvent(eventType, body)
+	if err != nil {
+		http.Error(w, "parse event: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Skip Terrain's own comments to avoid feedback loops.
+	if strings.HasSuffix(strings.ToLower(ev.Sender), "[bot]") {
+		_, _ = w.Write([]byte("ignored (bot sender)"))
+		return
+	}
+
+	// Extract slash commands from each line of the comment body.
+	// Multi-command comments are supported; each runs independently.
+	cmds, parseErrs := parseAllLines(ev.CommentBody)
+	if len(cmds) == 0 && len(parseErrs) == 0 {
+		// Not a slash command — nothing to do.
+		_, _ = w.Write([]byte("no slash commands"))
+		return
+	}
+
+	var replyLines []string
+	for _, pe := range parseErrs {
+		replyLines = append(replyLines, "**Parse error**: "+pe.Error())
+	}
+	for _, cmd := range cmds {
+		reply, derr := h.Dispatcher.Handle(ev, cmd)
+		if derr != nil {
+			replyLines = append(replyLines, fmt.Sprintf("**Error running `%s`**: %v", cmd.Verb, derr))
+			continue
+		}
+		if reply != "" {
+			replyLines = append(replyLines, reply)
+		}
+	}
+
+	body = []byte(strings.Join(replyLines, "\n\n---\n\n"))
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	_, _ = w.Write(body)
+}
+
+// parseAllLines walks the comment body line-by-line, extracting
+// slash commands. Returns the successfully-parsed commands plus a
+// slice of parse errors for malformed lines.
+func parseAllLines(body string) ([]*Command, []*ParseError) {
+	var cmds []*Command
+	var errs []*ParseError
+	for _, line := range strings.Split(body, "\n") {
+		cmd, err := Parse(line)
+		if err != nil {
+			if pe, ok := err.(*ParseError); ok {
+				errs = append(errs, pe)
+			}
+			continue
+		}
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	return cmds, errs
+}
+
+// parseEvent extracts the WebhookEvent shape from a GitHub event
+// payload. The two relevant event types
+// (`issue_comment`, `pull_request_review_comment`) have slightly
+// different JSON shapes; we map both to the unified WebhookEvent.
+func parseEvent(eventType string, body []byte) (WebhookEvent, error) {
+	// Generic shape covering both event types.
+	var raw struct {
+		Action  string `json:"action"`
+		Comment struct {
+			ID   int64  `json:"id"`
+			Body string `json:"body"`
+			User struct {
+				Login string `json:"login"`
+			} `json:"user"`
+			Path string `json:"path,omitempty"` // pull_request_review_comment only
+		} `json:"comment"`
+		Issue struct {
+			Number int `json:"number"`
+		} `json:"issue,omitempty"`
+		PullRequest struct {
+			Number int `json:"number"`
+		} `json:"pull_request,omitempty"`
+		Repository struct {
+			FullName string `json:"full_name"`
+		} `json:"repository"`
+		Sender struct {
+			Login string `json:"login"`
+		} `json:"sender"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return WebhookEvent{}, err
+	}
+	ev := WebhookEvent{
+		Action:      raw.Action,
+		Sender:      raw.Sender.Login,
+		CommentID:   raw.Comment.ID,
+		CommentBody: raw.Comment.Body,
+		Repository:  raw.Repository.FullName,
+	}
+	switch eventType {
+	case "issue_comment":
+		ev.PRNumber = raw.Issue.Number
+	case "pull_request_review_comment":
+		ev.PRNumber = raw.PullRequest.Number
+	}
+	return ev, nil
+}


### PR DESCRIPTION
**P5.2** — Deterministic slash-command grammar, no LLM parsing.

New package \`internal/slash/\`:
- \`grammar.go\` — parser for 10 canonical verbs (\`/dismiss\`, \`/terrain explain\`, \`/terrain why\`, \`/terrain show\`, \`/terrain expand\`, \`/terrain refresh\`, \`/terrain escalate\`, \`/terrain scaffold accept\`, \`/terrain bench\`, \`/terrain commands\`).
- \`tokenize.go\` — quote-aware token splitter (\`"value with spaces"\` + \`\\"\`-escaped quotes).
- \`commandlist.go\` — \`RenderCommandList()\` produces the pinned-comment markdown.
- \`signature.go\` — HMAC-SHA256 webhook signature verify (constant-time; rejects empty secret).
- \`webhook.go\` — \`http.Handler\` implementing the full receiver: signature check, event-type filter, bot-sender ignore, multi-command parse, dispatcher invocation, markdown reply.
- \`dispatcher.go\` — \`DefaultDispatcher\` (informational; returns markdown describing what each verb would do). Adopters override to wire real CLI runners + GitHub API write-back.

Grammar:
- \`/terrain\` prefix is optional (case-insensitive).
- \`key:value\` only treats the key as keyword when it's a simple lowercase identifier — finding-IDs like \`weakAssertion@a.go:Sym#hash\` pass through as a single positional.
- Unknown verbs return \`ParseError\` with the closest-match suggestion (Levenshtein distance ≤2).

**CLI**: \`terrain webhook [--addr=:4242]\`. Maintainer-only (gated behind \`TERRAIN_DEV=1\`) — the default Dispatcher doesn't write back to GitHub yet. Reads \`TERRAIN_WEBHOOK_SECRET\` from the environment.

24 tests: 16 grammar + 8 webhook tests covering signature validation, method-not-allowed, ping event, bot-sender ignore, single/multi-command dispatch.

**Deployment-model TODO documented in the PR description**:
- Adopter hosts \`terrain webhook\` reachable from GitHub.
- Configures GitHub webhook → that endpoint.
- Overrides \`DefaultDispatcher\` to call into \`runSuppress\`/\`runShow\`/etc. AND to POST the reply markdown back via \`gh api\` or \`google/go-github\`.