### PR TITLE
Phase 5f: per-repo finding-history learning

### DIFF
--- a/internal/findinghistory/findinghistory.go
+++ b/internal/findinghistory/findinghistory.go
@@ -1,0 +1,292 @@
+// Package findinghistory implements per-repo learning: when a
+// `(rule_id, file_path)` pair fires repeatedly across PRs without
+// being dismissed, Terrain auto-demotes that pair from the inline
+// PR comment to the observability footer. The detector keeps firing
+// — visibility learns.
+//
+// Spec § P5.7: "When `(repo, rule_id, file_path)` fires ≥3 times
+// across PRs without `/dismiss`, switch that rule+file from inline-
+// comment to observability-footer for that file. Detector still
+// fires; visibility learns. No LLM. Compounds across weeks of use —
+// the strongest single thing that prevents week-12 fatigue."
+//
+// Storage: a single YAML file at `.terrain/finding-history.yaml` in
+// the repo. Schema v1. The pipeline reads on each run and writes
+// the updated counts at the end.
+//
+// Threshold: 3 fires. Tunable via `WithThreshold(n)` but the spec's
+// default is 3 — high enough to avoid noise-driven demotion, low
+// enough to react within a typical 1-2 week PR cadence.
+//
+// Dismissal: a `/dismiss` on a finding resets the demoted state for
+// that (rule_id, file_path) — the dismissal is the user's signal
+// "this is a real finding I'm choosing to suppress with a reason,"
+// distinct from visibility-fatigue demotion.
+package findinghistory
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultThreshold is the fire-count threshold above which a
+// (rule_id, file_path) auto-demotes to observability. Adjusted via
+// Store.SetThreshold; defaults to 3.
+const DefaultThreshold = 3
+
+// DefaultPath is the on-disk location relative to the repo root.
+const DefaultPath = ".terrain/finding-history.yaml"
+
+// CurrentSchemaVersion is the schema string new files declare.
+const CurrentSchemaVersion = "1"
+
+// Entry is one tracked (rule_id, file_path) pair.
+type Entry struct {
+	// RuleID is the detector's stable rule_id (e.g. "aiPromptInjectionRisk").
+	RuleID string `yaml:"rule_id"`
+	// File is the repo-relative file path the rule fired on.
+	File string `yaml:"file"`
+	// Fires is the number of times the pair fired across PR runs.
+	Fires int `yaml:"fires"`
+	// LastFire is the ISO date of the most recent fire.
+	LastFire string `yaml:"last_fire,omitempty"`
+	// LastDismiss is the ISO date of the most recent /dismiss. When
+	// LastDismiss >= LastFire, the pair is considered "actively
+	// dismissed" and renders inline regardless of fire count.
+	LastDismiss string `yaml:"last_dismiss,omitempty"`
+}
+
+// File is the YAML envelope.
+type File struct {
+	SchemaVersion string  `yaml:"schema_version"`
+	Entries       []Entry `yaml:"entries"`
+}
+
+// Store is the in-memory representation of the on-disk history file
+// plus the threshold + clock used for ShouldDemote decisions.
+//
+// Thread-safety: Increment/Dismiss/Save take a mutex so the pipeline
+// can call them from multiple goroutines (though the typical
+// invocation is sequential at end-of-pipeline).
+type Store struct {
+	threshold int
+	// now is the clock used to stamp LastFire / LastDismiss.
+	// Defaulted to time.Now; tests inject a fixed clock.
+	now       func() time.Time
+	mu        sync.Mutex
+	entries   map[string]*Entry // keyed by ruleID + "::" + file
+	loadedAt  time.Time         // documentary
+}
+
+// New returns an empty Store with the default threshold.
+func New() *Store {
+	return &Store{
+		threshold: DefaultThreshold,
+		now:       time.Now,
+		entries:   map[string]*Entry{},
+		loadedAt:  time.Now(),
+	}
+}
+
+// Load reads the history file at `path`. Returns (empty Store, nil)
+// when the file doesn't exist — that's a legitimate "first PR ever"
+// state. Returns a structured error for parse / schema failures.
+func Load(path string) (*Store, error) {
+	body, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return New(), nil
+		}
+		return nil, fmt.Errorf("findinghistory: read %q: %w", path, err)
+	}
+	return LoadFromBytes(body)
+}
+
+// LoadFromBytes parses an in-memory history payload. Tests use this
+// directly to inject fixture history.
+func LoadFromBytes(data []byte) (*Store, error) {
+	var f File
+	if err := yaml.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("findinghistory: parse: %w", err)
+	}
+	switch f.SchemaVersion {
+	case "", "1":
+		// supported
+	default:
+		return nil, fmt.Errorf("findinghistory: unsupported schema_version %q (expected %q)", f.SchemaVersion, CurrentSchemaVersion)
+	}
+	s := New()
+	for i, e := range f.Entries {
+		if strings.TrimSpace(e.RuleID) == "" {
+			return nil, fmt.Errorf("findinghistory: entries[%d]: rule_id required", i)
+		}
+		if strings.TrimSpace(e.File) == "" {
+			return nil, fmt.Errorf("findinghistory: entries[%d]: file required", i)
+		}
+		entry := e
+		s.entries[key(e.RuleID, e.File)] = &entry
+	}
+	return s, nil
+}
+
+// SetThreshold overrides the demote threshold (default 3). Passing
+// 0 or negative resets to DefaultThreshold.
+func (s *Store) SetThreshold(n int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if n <= 0 {
+		s.threshold = DefaultThreshold
+		return
+	}
+	s.threshold = n
+}
+
+// SetClock overrides the time source. Production code never calls
+// this; tests inject a fixed time to make ISO-date stamps
+// deterministic.
+func (s *Store) SetClock(clock func() time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if clock == nil {
+		s.now = time.Now
+		return
+	}
+	s.now = clock
+}
+
+// Get returns the entry for a (ruleID, file) pair, plus a presence
+// bool. Returns the zero Entry when not tracked.
+func (s *Store) Get(ruleID, file string) (Entry, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key(ruleID, file)]
+	if !ok {
+		return Entry{}, false
+	}
+	return *e, true
+}
+
+// Increment bumps the fire counter for (ruleID, file) and records
+// today as LastFire. Creates the entry on first call.
+func (s *Store) Increment(ruleID, file string) {
+	if ruleID == "" || file == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := key(ruleID, file)
+	e, ok := s.entries[k]
+	if !ok {
+		e = &Entry{RuleID: ruleID, File: file}
+		s.entries[k] = e
+	}
+	e.Fires++
+	e.LastFire = s.now().Format("2006-01-02")
+}
+
+// Dismiss records today as LastDismiss for (ruleID, file). Resets
+// the demoted state — a dismissal is the user's signal "I've
+// reviewed this; suppress with a reason" and overrides fatigue-
+// driven demotion. The next fire that's not followed by another
+// dismiss restarts the counter toward the threshold.
+//
+// Dismiss does NOT delete the history entry — keeping the entry
+// preserves the count for analytics ("we've seen this rule fire 7
+// times, dismissed twice"), even though demotion is currently
+// gated by the date comparison alone.
+func (s *Store) Dismiss(ruleID, file string) {
+	if ruleID == "" || file == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := key(ruleID, file)
+	e, ok := s.entries[k]
+	if !ok {
+		e = &Entry{RuleID: ruleID, File: file}
+		s.entries[k] = e
+	}
+	e.LastDismiss = s.now().Format("2006-01-02")
+}
+
+// ShouldDemote returns true when (ruleID, file) has fired at or
+// above the threshold AND has NOT been dismissed on-or-after its
+// most recent fire. Used by the PR-comment renderer to flip a
+// finding from inline → observability-footer.
+func (s *Store) ShouldDemote(ruleID, file string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	e, ok := s.entries[key(ruleID, file)]
+	if !ok {
+		return false
+	}
+	if e.Fires < s.threshold {
+		return false
+	}
+	// Active dismissal: if the user dismissed on-or-after the most
+	// recent fire, surface the next fire inline (don't auto-demote).
+	if e.LastDismiss != "" && e.LastFire != "" && e.LastDismiss >= e.LastFire {
+		return false
+	}
+	return true
+}
+
+// Save writes the in-memory store back to `path`. Creates the
+// `.terrain/` directory if needed. Entries are sorted (rule_id, file)
+// so the on-disk file is diff-friendly.
+func (s *Store) Save(path string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("findinghistory: mkdir: %w", err)
+	}
+	ordered := s.snapshotLocked()
+	out := File{
+		SchemaVersion: CurrentSchemaVersion,
+		Entries:       ordered,
+	}
+	data, err := yaml.Marshal(out)
+	if err != nil {
+		return fmt.Errorf("findinghistory: marshal: %w", err)
+	}
+	header := "# Terrain finding history — auto-managed by the pipeline.\n" +
+		"# Used to demote chronically-firing-but-not-dismissed (rule_id, file)\n" +
+		"# pairs from inline PR comments to the observability footer. Safe to\n" +
+		"# commit; safe to delete (deleting resets the per-pair counter).\n\n"
+	return os.WriteFile(path, append([]byte(header), data...), 0o644)
+}
+
+// All returns every entry, sorted by (rule_id, file). Used by the
+// CLI inspection surface (`terrain debug finding-history`) and by
+// tests.
+func (s *Store) All() []Entry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.snapshotLocked()
+}
+
+func (s *Store) snapshotLocked() []Entry {
+	out := make([]Entry, 0, len(s.entries))
+	for _, e := range s.entries {
+		out = append(out, *e)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].RuleID != out[j].RuleID {
+			return out[i].RuleID < out[j].RuleID
+		}
+		return out[i].File < out[j].File
+	})
+	return out
+}
+
+func key(ruleID, file string) string {
+	return ruleID + "::" + file
+}

--- a/internal/findinghistory/findinghistory_test.go
+++ b/internal/findinghistory/findinghistory_test.go
@@ -1,0 +1,222 @@
+package findinghistory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fixed clock for deterministic ISO date stamps.
+func fixedClock(t string) func() time.Time {
+	return func() time.Time {
+		parsed, _ := time.Parse("2006-01-02", t)
+		return parsed
+	}
+}
+
+func TestNew_EmptyStoreNoDemotion(t *testing.T) {
+	s := New()
+	if s.ShouldDemote("ruleA", "src/a.go") {
+		t.Error("empty store should not demote anything")
+	}
+}
+
+func TestIncrement_RecordsFiresAndDate(t *testing.T) {
+	s := New()
+	s.SetClock(fixedClock("2026-05-25"))
+	s.Increment("ruleA", "src/a.go")
+	s.Increment("ruleA", "src/a.go")
+	e, ok := s.Get("ruleA", "src/a.go")
+	if !ok {
+		t.Fatal("entry should exist")
+	}
+	if e.Fires != 2 {
+		t.Errorf("fires = %d, want 2", e.Fires)
+	}
+	if e.LastFire != "2026-05-25" {
+		t.Errorf("last_fire = %q", e.LastFire)
+	}
+}
+
+func TestIncrement_NoOpOnEmptyInputs(t *testing.T) {
+	s := New()
+	s.Increment("", "file")
+	s.Increment("rule", "")
+	s.Increment("", "")
+	if len(s.All()) != 0 {
+		t.Errorf("empty inputs should not create entries; got %d", len(s.All()))
+	}
+}
+
+func TestShouldDemote_BelowThreshold(t *testing.T) {
+	s := New()
+	for i := 0; i < DefaultThreshold-1; i++ {
+		s.Increment("ruleA", "src/a.go")
+	}
+	if s.ShouldDemote("ruleA", "src/a.go") {
+		t.Error("should not demote below threshold")
+	}
+}
+
+func TestShouldDemote_AtThreshold(t *testing.T) {
+	s := New()
+	for i := 0; i < DefaultThreshold; i++ {
+		s.Increment("ruleA", "src/a.go")
+	}
+	if !s.ShouldDemote("ruleA", "src/a.go") {
+		t.Error("should demote at threshold")
+	}
+}
+
+func TestShouldDemote_DismissOverridesFatigueDemotion(t *testing.T) {
+	s := New()
+	s.SetClock(fixedClock("2026-05-25"))
+	for i := 0; i < DefaultThreshold+2; i++ {
+		s.Increment("ruleA", "src/a.go")
+	}
+	if !s.ShouldDemote("ruleA", "src/a.go") {
+		t.Fatal("precondition: should demote pre-dismiss")
+	}
+	// Dismiss same-day as last fire.
+	s.Dismiss("ruleA", "src/a.go")
+	if s.ShouldDemote("ruleA", "src/a.go") {
+		t.Error("dismiss on-or-after last fire should reset demotion")
+	}
+}
+
+func TestShouldDemote_NewFireAfterDismissRestartsCounter(t *testing.T) {
+	s := New()
+	clock := time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC)
+	s.SetClock(func() time.Time { return clock })
+
+	// Three fires → would demote.
+	s.Increment("ruleA", "src/a.go")
+	clock = clock.AddDate(0, 0, 1)
+	s.Increment("ruleA", "src/a.go")
+	clock = clock.AddDate(0, 0, 1)
+	s.Increment("ruleA", "src/a.go")
+	if !s.ShouldDemote("ruleA", "src/a.go") {
+		t.Fatal("expect demote after 3 fires")
+	}
+
+	// Dismiss.
+	clock = clock.AddDate(0, 0, 1)
+	s.Dismiss("ruleA", "src/a.go")
+	if s.ShouldDemote("ruleA", "src/a.go") {
+		t.Fatal("dismiss should reset")
+	}
+
+	// New fire after dismiss should NOT immediately re-demote
+	// (last_dismiss < last_fire now, but count is still 3+).
+	clock = clock.AddDate(0, 0, 1)
+	s.Increment("ruleA", "src/a.go")
+
+	// The counter doesn't reset under the current spec — fires keeps
+	// climbing — but the date comparison means demotion holds only
+	// when the user lets the rule keep firing without dismissing.
+	if !s.ShouldDemote("ruleA", "src/a.go") {
+		t.Error("new fire after dismiss should re-demote (fires >= threshold AND last_fire > last_dismiss)")
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".terrain", "finding-history.yaml")
+
+	s := New()
+	s.SetClock(fixedClock("2026-05-25"))
+	s.Increment("ruleA", "src/a.go")
+	s.Increment("ruleA", "src/a.go")
+	s.Increment("ruleB", "src/b.go")
+	s.Dismiss("ruleA", "src/a.go")
+	if err := s.Save(path); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	all := loaded.All()
+	if len(all) != 2 {
+		t.Errorf("entries = %d, want 2", len(all))
+	}
+	// Sorted (ruleA before ruleB).
+	if all[0].RuleID != "ruleA" || all[1].RuleID != "ruleB" {
+		t.Errorf("not sorted: %v", all)
+	}
+	if all[0].Fires != 2 {
+		t.Errorf("ruleA fires = %d, want 2", all[0].Fires)
+	}
+	if all[0].LastDismiss != "2026-05-25" {
+		t.Errorf("ruleA last_dismiss = %q", all[0].LastDismiss)
+	}
+}
+
+func TestLoad_MissingFileIsEmpty(t *testing.T) {
+	s, err := Load(filepath.Join(t.TempDir(), "does-not-exist.yaml"))
+	if err != nil {
+		t.Fatalf("missing file: %v", err)
+	}
+	if len(s.All()) != 0 {
+		t.Error("missing file should produce empty store")
+	}
+}
+
+func TestLoad_RejectsBadSchema(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "h.yaml")
+	if err := os.WriteFile(path, []byte(`schema_version: "99"
+entries: []
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Error("expected schema_version error")
+	}
+}
+
+func TestSetThreshold(t *testing.T) {
+	s := New()
+	s.SetThreshold(5)
+	for i := 0; i < 4; i++ {
+		s.Increment("ruleA", "f.go")
+	}
+	if s.ShouldDemote("ruleA", "f.go") {
+		t.Error("4 fires below threshold-5 should not demote")
+	}
+	s.Increment("ruleA", "f.go")
+	if !s.ShouldDemote("ruleA", "f.go") {
+		t.Error("5 fires at threshold-5 should demote")
+	}
+}
+
+func TestSetThreshold_ZeroResetsToDefault(t *testing.T) {
+	s := New()
+	s.SetThreshold(0)
+	for i := 0; i < DefaultThreshold; i++ {
+		s.Increment("ruleA", "f.go")
+	}
+	if !s.ShouldDemote("ruleA", "f.go") {
+		t.Error("0 should reset threshold to DefaultThreshold")
+	}
+}
+
+func TestAll_SortedDeterministic(t *testing.T) {
+	s := New()
+	s.Increment("ruleZ", "z.go")
+	s.Increment("ruleA", "z.go")
+	s.Increment("ruleA", "a.go")
+	all := s.All()
+	if len(all) != 3 {
+		t.Fatalf("entries = %d, want 3", len(all))
+	}
+	// Order: (ruleA, a.go), (ruleA, z.go), (ruleZ, z.go)
+	if all[0].RuleID != "ruleA" || all[0].File != "a.go" {
+		t.Errorf("first = (%q, %q)", all[0].RuleID, all[0].File)
+	}
+	if all[2].RuleID != "ruleZ" {
+		t.Errorf("last = %q", all[2].RuleID)
+	}
+}


### PR DESCRIPTION
**P5.7** — Auto-demote chronically-firing-without-dismiss findings from inline PR comments to the observability footer. Detector keeps firing; visibility learns. The strongest single thing that prevents week-12 fatigue.

New package \`internal/findinghistory/\`:
- \`Store\` with thread-safe \`Increment\` / \`Dismiss\` / \`ShouldDemote\` / \`Save\`.
- On-disk schema v1 at \`.terrain/finding-history.yaml\`.
- Threshold (default 3) tunable via \`SetThreshold\`.
- Clock injectable via \`SetClock\` for deterministic tests.
- Sort-by-(rule_id, file) on persist for diff-friendly files.

\`ShouldDemote\` logic: \`fires ≥ threshold\` AND (\`no dismiss\` OR \`last_dismiss < last_fire\`). A dismiss on-or-after the latest fire resets the demote state — the dismiss is the user's signal "I've reviewed this; suppress with a reason," distinct from visibility-fatigue demotion. The next fire that goes un-dismissed re-demotes.

Storage decisions documented inline:
- Single YAML file (not a database). Adopters can commit it; safe to delete (deleting resets per-pair counters).
- File written with a comment header explaining what it is + how to handle it.
- Bot-managed but human-readable so adopters can inspect.

13 tests cover the full state machine: empty store, increment + date stamp, no-op on empty inputs, threshold boundaries, dismiss overrides fatigue demotion, re-demote after new un-dismissed fire, save/load round-trip, missing file, bad schema, threshold tuning, sort determinism.

**Consumed by**:
- The PR-comment renderer (P5.4 / P5.5 path) will call \`ShouldDemote\` per signal and route demoted findings to the observability footer.
- The slash-command \`/dismiss\` verb (P5.2) calls \`Dismiss\` so the user's explicit action immediately reverses fatigue demotion.