### PR TITLE
Phase 5.5a: wire labels, templates, and visibility floor into the PR-comment renderer

### DIFF
--- a/internal/changescope/dedup_test.go
+++ b/internal/changescope/dedup_test.go
@@ -417,16 +417,19 @@ func TestRenderPRSummaryMarkdown_DirectVsIndirectSections(t *testing.T) {
 	if !strings.Contains(output, "### Coverage gaps in changed code") {
 		t.Errorf("expected 'Coverage gaps in changed code' heading; got:\n%s", output)
 	}
-	if !strings.Contains(output, "**`src/a.ts`** [HIGH] — Direct gap") {
-		t.Errorf("expected card-shape direct finding; got:\n%s", output)
+	// PR-comment labels use the BLOCK/GATE/WATCH/NOTE vocabulary
+	// (P5.5) — protection-gap defaults to gate-tier; high severity
+	// + gate-tier = [GATE].
+	if !strings.Contains(output, "**`src/a.ts`** [GATE] — Direct gap") {
+		t.Errorf("expected card-shape direct finding with [GATE] label; got:\n%s", output)
 	}
 
 	// Indirect risks in collapsed section — singular "gap" for count=1.
 	if !strings.Contains(output, "1 indirectly impacted protection gap") {
 		t.Errorf("expected indirect section with count; got:\n%s", output)
 	}
-	if !strings.Contains(output, "**`src/b.ts`** [MED] — Indirect gap") {
-		t.Errorf("expected card-shape indirect finding; got:\n%s", output)
+	if !strings.Contains(output, "**`src/b.ts`** [GATE] — Indirect gap") {
+		t.Errorf("expected card-shape indirect finding with [GATE] label; got:\n%s", output)
 	}
 }
 

--- a/internal/changescope/render.go
+++ b/internal/changescope/render.go
@@ -6,6 +6,9 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/pmclSF/terrain/internal/models"
+	"github.com/pmclSF/terrain/internal/prtemplates"
+	"github.com/pmclSF/terrain/internal/signals"
 	"github.com/pmclSF/terrain/internal/uitokens"
 )
 
@@ -117,28 +120,23 @@ func RenderPRSummaryMarkdown(w io.Writer, pr *PRAnalysis) {
 	}
 
 	// --- Pre-existing gaps touched by this change ---
+	//
+	// existingDebt contains existing_signal findings (SignalType-bearing,
+	// detector-emitted). Apply the per-detector visibility floor
+	// (§ P5.4): every detector that fired gets at least one card; co-
+	// fires within a detector collapse to "↳ +N more". Small lists
+	// (≤3) skip the <details> wrap so the reader doesn't have to
+	// click through trivial findings.
 	if len(existingDebt) > 0 {
 		if len(existingDebt) <= 3 {
 			hr()
 			line("### Pre-existing issues (%d)", len(existingDebt))
 			line("")
-			for _, f := range existingDebt {
-				renderFindingCard(line, f)
-			}
+			renderFindingsCardsByDetector(line, existingDebt, 1)
 		} else {
 			line("<details><summary><b>%d pre-existing %s on changed files</b></summary>", len(existingDebt), pluralize(len(existingDebt), "issue", "issues"))
 			line("")
-			limit := 5
-			if len(existingDebt) < limit {
-				limit = len(existingDebt)
-			}
-			for _, f := range existingDebt[:limit] {
-				renderFindingCard(line, f)
-			}
-			if len(existingDebt) > limit {
-				line("- _...and %d more_", len(existingDebt)-limit)
-				line("")
-			}
+			renderFindingsCardsByDetector(line, existingDebt, 1)
 			line("</details>")
 			line("")
 		}
@@ -361,16 +359,75 @@ func findingSeverityRank(s string) int {
 
 // renderFindingCard emits one finding as a card-style bullet:
 //
-//	- **`path/to/file.go`** [HIGH] — <explanation>
+//	- **`path/to/file.go`** [BLOCK|GATE|WATCH|NOTE] — <explanation>
 //	  → <suggested action>
 //
 // Suggested action is omitted when the finding doesn't carry one.
+// Info-tier findings (PRLabel == "") render with no badge — they
+// drop from the PR surface entirely per § P5.5, but the rendering
+// helpers don't filter at this level; the caller (renderFindingsCards,
+// renderFindingsCardsByDetector) decides whether to emit the card
+// at all.
+//
+// The tier is looked up from the finding's SignalType via the
+// manifest (signals.IsObservabilityTier). Protection-gap findings
+// (no SignalType) default to gate-tier — they're coverage issues
+// meant to block.
 func renderFindingCard(line func(string, ...any), f ChangeScopedFinding) {
-	badge := severityIcon(f.Severity)
-	line("- **`%s`** %s — %s", f.Path, badge, f.Explanation)
-	if f.SuggestedAction != "" {
-		line("  → %s", f.SuggestedAction)
+	badge := prLabelBadge(f)
+	summary, action := summaryAndActionForFinding(f)
+	line("- **`%s`** %s — %s", f.Path, badge, summary)
+	if action != "" {
+		line("  → %s", action)
 	}
+}
+
+// summaryAndActionForFinding looks up a curated template for the
+// finding's SignalType in prtemplates (§ P5.1) and returns the
+// template's Summary + Action. Falls back to the detector-emitted
+// Explanation / SuggestedAction when no template is registered —
+// protection-gap findings (no SignalType) always fall through.
+//
+// The trailing newline a YAML block-scalar leaves on Summary is
+// stripped — render output should be a single line.
+func summaryAndActionForFinding(f ChangeScopedFinding) (summary, action string) {
+	summary = f.Explanation
+	action = f.SuggestedAction
+	if f.SignalType == "" {
+		return
+	}
+	reg, err := prtemplates.Default()
+	if err != nil || reg == nil {
+		return
+	}
+	tpl, ok := reg.Get(f.SignalType)
+	if !ok {
+		return
+	}
+	summary = strings.TrimSpace(tpl.Summary)
+	action = strings.TrimSpace(tpl.Action)
+	return
+}
+
+// prLabelBadge returns the bracketed user-visible PR-comment label
+// (BLOCK / GATE / WATCH / NOTE) for a finding. Empty string when the
+// finding should drop from the PR surface (info-tier).
+func prLabelBadge(f ChangeScopedFinding) string {
+	tier := tierForFinding(f)
+	return uitokens.BracketedPRLabel(tier, f.Severity)
+}
+
+// tierForFinding returns "gate" or "observability" for a finding.
+// SignalType-bearing findings consult the manifest; protection-gap
+// findings (no SignalType) default to gate.
+func tierForFinding(f ChangeScopedFinding) string {
+	if f.SignalType == "" {
+		return "gate"
+	}
+	if signals.IsObservabilityTier(models.SignalType(f.SignalType)) {
+		return "observability"
+	}
+	return "gate"
 }
 
 // pluralize returns "finding" or "findings" based on count. Used to

--- a/internal/changescope/unified_render_test.go
+++ b/internal/changescope/unified_render_test.go
@@ -123,7 +123,9 @@ func TestRenderPRSummaryMarkdown_UnifiedShape(t *testing.T) {
 	// "advisory finding") rather than per bullet, which is a
 	// deliberate UX choice — section-level grouping is documented in
 	// `docs/product/unified-pr-comment.md`.
-	bracketBadge := regexp.MustCompile(`\[(PASS|WARN|RISK|FAIL|INFO|HIGH|MED|LOW|----?)\]`)
+	// Post-P5.5 vocabulary: coverage cards carry BLOCK/GATE/WATCH/NOTE
+	// labels; the header posture badge still uses PASS/WARN/RISK/FAIL/INFO.
+	bracketBadge := regexp.MustCompile(`\[(PASS|WARN|RISK|FAIL|INFO|BLOCK|GATE|WATCH|NOTE|----?)\]`)
 	matches := bracketBadge.FindAllString(output, -1)
 	if len(matches) < 3 {
 		t.Errorf("gate 1 (unified badge shape): expected at least 3 [LABEL] badges (header + per-coverage-gap), got %d:\n%s", len(matches), output)
@@ -134,9 +136,10 @@ func TestRenderPRSummaryMarkdown_UnifiedShape(t *testing.T) {
 		t.Errorf("gate 1 (header badge): header verdict should use [LABEL] shape; got:\n%s", firstNLines(output, 3))
 	}
 
-	// Coverage-gap cards should carry [HIGH] / [MED] / [LOW] inline.
-	if !strings.Contains(output, "[HIGH]") || !strings.Contains(output, "[MED]") {
-		t.Errorf("gate 1 (severity badges): coverage cards should carry [HIGH] and [MED]; got:\n%s", output)
+	// Coverage-gap cards should carry [GATE] (gate-tier finding,
+	// any severity above low) inline.
+	if !strings.Contains(output, "[GATE]") {
+		t.Errorf("gate 1 (PR labels): coverage cards should carry [GATE]; got:\n%s", output)
 	}
 
 	// AI section's severity grouping should appear at the section-
@@ -148,9 +151,11 @@ func TestRenderPRSummaryMarkdown_UnifiedShape(t *testing.T) {
 
 	// --- Gate 2: file-path locator format is unified ---
 	// Both coverage cards and AI bullets should bold + mono the path.
-	// Coverage card shape: `- **`src/auth/login.ts`** [HIGH] — ...`
-	if !regexp.MustCompile("(?m)^- \\*\\*`src/auth/login\\.ts`\\*\\* \\[HIGH\\]").MatchString(output) {
-		t.Errorf("gate 2 (coverage locator): expected card-shape `- **\\`path\\`** [SEV]`; got:\n%s", output)
+	// Coverage card shape: `- **`src/auth/login.ts`** [GATE] — ...`
+	// (post-P5.5: PR-comment labels are BLOCK/GATE/WATCH/NOTE, not
+	// the internal CRIT/HIGH/MED/LOW/INFO ladder).
+	if !regexp.MustCompile("(?m)^- \\*\\*`src/auth/login\\.ts`\\*\\* \\[GATE\\]").MatchString(output) {
+		t.Errorf("gate 2 (coverage locator): expected card-shape `- **\\`path\\`** [GATE]`; got:\n%s", output)
 	}
 	// AI bullet shape: `- **`src/agent/prompt.ts:88`** ...`
 	if !regexp.MustCompile("(?m)^- \\*\\*`src/agent/prompt\\.ts:88`\\*\\*").MatchString(output) {


### PR DESCRIPTION
## Summary

Wires three pieces from #191/#193/#196 into the existing PR-comment
renderer (`internal/changescope`):

- `uitokens.PRLabel(tier, severity)` — BLOCK/GATE/WATCH/NOTE labels
- `prtemplates` registry — Title / Summary / Action / SlashHints quartet
- Per-detector visibility floor — at least one inline per detector that fired

Before this PR, those packages existed but nothing called them. This
is the renderer-side migration; pipeline + dispatcher wiring lands
in 5.5b.

## Type of change

- [x] New feature (additive at the render layer; no caller-visible change)

## Reviewer checklist

- [x] `go test ./internal/changescope/...` passes locally
- [x] No snapshot or signal-catalog shape changes
- [x] No new `Signal*` constants

## Security / privacy implications

None. Pure rendering change; no I/O, no network, no LLM.

## Breaking changes

None — the renderer's external contract is unchanged.

## Test plan

- `dedup_test.go` and `unified_render_test.go` updated to assert the
  new label/template-driven format.
- Full `go test ./...` clean.

## Stack position

Stacked on #196 (`phase-5f-history-learning`). Part of the phase-5.5
follow-up series (5.5a → 5.5b → 5.5c → 5.5d → 5.5e).