### PR TITLE
Phase 5.5b: wire finding-history into the pipeline, renderer, and slash dispatcher

### DIFF
--- a/cmd/terrain/cmd_impact.go
+++ b/cmd/terrain/cmd_impact.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pmclSF/terrain/internal/engine"
 	"github.com/pmclSF/terrain/internal/explain"
 	"github.com/pmclSF/terrain/internal/impact"
+	"github.com/pmclSF/terrain/internal/logging"
 	"github.com/pmclSF/terrain/internal/metrics"
 	"github.com/pmclSF/terrain/internal/models"
 	"github.com/pmclSF/terrain/internal/reporting"
@@ -241,9 +242,24 @@ func runPR(root, baseRef string, jsonOutput bool, format string, gate severityGa
 		return gateErr()
 	}
 
+	// Load per-repo finding-history so the PR-comment renderer can
+	// demote chronically-firing-without-dismiss findings to the
+	// observability footer (§ P5.7). Missing file → empty store,
+	// the correct first-run behavior. Other errors are non-fatal:
+	// log + render without history rather than block the comment.
+	hist, histErr := engine.LoadFindingHistory(root)
+	if histErr != nil {
+		logging.L().Debug("finding history: load failed at render", "err", histErr)
+		hist = nil
+	}
+
 	switch format {
 	case "markdown", "md":
-		changescope.RenderPRSummaryMarkdown(os.Stdout, pr)
+		if hist != nil {
+			changescope.RenderPRSummaryMarkdownWithHistory(os.Stdout, pr, hist)
+		} else {
+			changescope.RenderPRSummaryMarkdown(os.Stdout, pr)
+		}
 	case "comment":
 		changescope.RenderPRCommentConcise(os.Stdout, pr)
 	case "annotation", "ci":

--- a/cmd/terrain/cmd_slash_dispatcher.go
+++ b/cmd/terrain/cmd_slash_dispatcher.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pmclSF/terrain/internal/slash"
+)
+
+// realDispatcher implements slash.Dispatcher by routing each verb to
+// the existing CLI runner that already implements the behavior. This
+// is what production webhook deployments use; DefaultDispatcher
+// (informational only) stays in internal/slash so the package can be
+// tested without depending on cmd/terrain.
+//
+// Routing:
+//
+//	/dismiss              → runSuppress (writes a content-hash entry)
+//	/terrain show <id>    → runReportShow (renders one finding)
+//	/terrain explain <id> → runReportExplain (long-form rule docs)
+//	/terrain why <id>     → runReportExplain --short
+//	/terrain commands     → slash.RenderCommandList
+//	/terrain refresh      → noop placeholder (would re-run analyze;
+//	                         deferred until the snapshot-cache lands)
+//	/terrain expand       → noop placeholder (depends on the comment-
+//	                         ID that posted the collapsed block)
+//	/terrain escalate     → noop placeholder (needs PR-state machinery)
+//	/terrain scaffold     → noop placeholder (needs scaffold engine)
+//	/terrain bench        → noop placeholder (needs bench-by-id wiring)
+//
+// The repo root that runners need defaults to ".". A future deployment
+// that routes multiple PRs through one server will compute the root
+// per-event from the GitHub clone path.
+type realDispatcher struct {
+	repoRoot string
+}
+
+func newRealDispatcher(repoRoot string) *realDispatcher {
+	if repoRoot == "" {
+		repoRoot = "."
+	}
+	return &realDispatcher{repoRoot: repoRoot}
+}
+
+// Handle implements slash.Dispatcher.
+func (d *realDispatcher) Handle(ev slash.WebhookEvent, cmd *slash.Command) (string, error) {
+	if cmd == nil {
+		return "", fmt.Errorf("nil command")
+	}
+	switch cmd.Verb {
+	case slash.VerbCommands:
+		return slash.RenderCommandList(), nil
+
+	case slash.VerbDismiss:
+		reason := cmd.Keyword["reason"]
+		if reason == "" {
+			return "", fmt.Errorf("/dismiss requires reason:<text>")
+		}
+		if ev.FindingID == "" {
+			return "Cannot dismiss: this command must be a reply to a Terrain finding's inline comment (the finding-id is read from the comment thread).", nil
+		}
+		// Default scope=instance with auto content-hash; default
+		// expiry per scope. Owner is the comment author.
+		owner := ""
+		if ev.Sender != "" {
+			owner = "@" + ev.Sender
+		}
+		if err := runSuppress(ev.FindingID, reason, "", owner, "instance", d.repoRoot); err != nil {
+			return "", fmt.Errorf("runSuppress: %w", err)
+		}
+		return fmt.Sprintf("Dismissed %s (scope=instance). Reason: %q.", ev.FindingID, reason), nil
+
+	case slash.VerbExplain, slash.VerbWhy:
+		if len(cmd.Positional) == 0 {
+			return "", fmt.Errorf("/%s requires a rule-id", cmd.Verb)
+		}
+		ruleID := strings.Join(cmd.Positional, " ")
+		verbose := cmd.Verb == slash.VerbExplain // /terrain why is the short form
+		return d.captureRun(func() error {
+			return runExplain(ruleID, d.repoRoot, "", false, verbose)
+		})
+
+	case slash.VerbShow:
+		if len(cmd.Positional) == 0 {
+			return "", fmt.Errorf("/terrain show requires an id")
+		}
+		id := strings.Join(cmd.Positional, " ")
+		return d.captureRun(func() error {
+			return runShow("finding", id, d.repoRoot, false)
+		})
+
+	case slash.VerbRefresh:
+		return "_/terrain refresh acknowledged — full re-analyze + comment-edit is deferred to a future release; the existing PR check-run already re-runs on push._", nil
+
+	case slash.VerbExpand:
+		return "_/terrain expand acknowledged — inline expansion of `+N more` blocks is deferred to a future release._", nil
+
+	case slash.VerbEscalate:
+		return "_/terrain escalate acknowledged — per-PR tier override is deferred to a future release._", nil
+
+	case slash.VerbScaffold:
+		return "_/terrain scaffold accept acknowledged — test-scaffold materialization is deferred (the underlying scaffold engine lands in a later phase)._", nil
+
+	case slash.VerbBench:
+		id := strings.Join(cmd.Positional, " ")
+		return fmt.Sprintf("_/terrain bench %s acknowledged — benchmark dispatch lands in a later phase._", id), nil
+	}
+	return fmt.Sprintf("Unhandled verb `%s`.", cmd.Verb), nil
+}
+
+// captureRun redirects the runner's stdout to a buffer for the
+// duration of fn and returns the captured output as the slash reply.
+// Runners like runExplain print directly to stdout; the webhook
+// reply needs that text as markdown.
+//
+// Not safe for concurrent dispatch across goroutines (the os.Stdout
+// swap is process-global). The webhook handler serializes incoming
+// requests so this is fine in practice.
+func (d *realDispatcher) captureRun(fn func() error) (string, error) {
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+	runErr := fn()
+	_ = w.Close()
+	<-done
+	os.Stdout = orig
+	if runErr != nil {
+		return "", runErr
+	}
+	out := strings.TrimSpace(buf.String())
+	if out == "" {
+		out = "_(no output)_"
+	}
+	// Wrap the captured text in a markdown code fence so terminal
+	// formatting (rules, badges) renders predictably on GitHub.
+	return "```\n" + out + "\n```", nil
+}
+
+// resolveRepoRoot picks the repo root for a webhook event. For now,
+// defaults to the process's cwd. Future multi-repo deployments will
+// clone the PR's commit to a temp directory per-event and pass that
+// path here.
+func resolveRepoRoot() string {
+	if cwd, err := filepath.Abs("."); err == nil {
+		return cwd
+	}
+	return "."
+}

--- a/cmd/terrain/cmd_webhook.go
+++ b/cmd/terrain/cmd_webhook.go
@@ -34,7 +34,7 @@ func runWebhook(addr string) error {
 	}
 
 	mux := http.NewServeMux()
-	mux.Handle("/webhook", slash.NewHandler(secret, slash.DefaultDispatcher{}))
+	mux.Handle("/webhook", slash.NewHandler(secret, newRealDispatcher(resolveRepoRoot())))
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	})

--- a/internal/changescope/render.go
+++ b/internal/changescope/render.go
@@ -374,12 +374,59 @@ func findingSeverityRank(s string) int {
 // (no SignalType) default to gate-tier — they're coverage issues
 // meant to block.
 func renderFindingCard(line func(string, ...any), f ChangeScopedFinding) {
-	badge := prLabelBadge(f)
+	renderFindingCardWithHistory(line, f, activeHistoryStore)
+}
+
+// renderFindingCardWithHistory is the history-aware form. The PR-
+// comment top-level renderer loads a findinghistory.Store once and
+// passes it through; tests + non-PR render paths pass nil. When the
+// store reports ShouldDemote(SignalType, File), the badge renders
+// as the observability label regardless of the manifest tier
+// (§ P5.7).
+func renderFindingCardWithHistory(line func(string, ...any), f ChangeScopedFinding, historyStore HistoryStore) {
+	badge := prLabelBadgeWithHistory(f, historyStore)
 	summary, action := summaryAndActionForFinding(f)
 	line("- **`%s`** %s — %s", f.Path, badge, summary)
 	if action != "" {
 		line("  → %s", action)
 	}
+}
+
+// HistoryStore is the minimal interface the renderer needs from
+// internal/findinghistory.Store. Declared locally so the
+// changescope package doesn't import internal/findinghistory
+// directly — callers in cmd/terrain pass the concrete store
+// through.
+type HistoryStore interface {
+	ShouldDemote(ruleID, file string) bool
+}
+
+// activeHistoryStore is the per-invocation history store the
+// top-level renderer (RenderPRSummaryMarkdownWithHistory) sets and
+// unsets. Subordinate helpers (renderFindingCard,
+// renderFindingsCardsByDetector) consult it without needing extra
+// parameters that would churn every call site.
+//
+// Not thread-safe across concurrent renders. RenderPRSummaryMarkdown
+// is documented as single-invocation per process (CLI commands run
+// once and exit); the webhook handler serializes incoming dispatch
+// so concurrent slash commands don't overlap renders either.
+var activeHistoryStore HistoryStore
+
+// RenderPRSummaryMarkdownWithHistory is the history-aware form of
+// RenderPRSummaryMarkdown. When `hist` is non-nil, every
+// SignalType-bearing card that the store reports as ShouldDemote
+// (§ P5.7) renders as the observability (WATCH) label regardless
+// of the manifest tier — chronically-firing-without-dismiss findings
+// fade to the observability footer.
+//
+// Pass nil for `hist` to get the legacy behavior (or call
+// RenderPRSummaryMarkdown directly).
+func RenderPRSummaryMarkdownWithHistory(w io.Writer, pr *PRAnalysis, hist HistoryStore) {
+	prev := activeHistoryStore
+	activeHistoryStore = hist
+	defer func() { activeHistoryStore = prev }()
+	RenderPRSummaryMarkdown(w, pr)
 }
 
 // summaryAndActionForFinding looks up a curated template for the
@@ -413,7 +460,19 @@ func summaryAndActionForFinding(f ChangeScopedFinding) (summary, action string) 
 // (BLOCK / GATE / WATCH / NOTE) for a finding. Empty string when the
 // finding should drop from the PR surface (info-tier).
 func prLabelBadge(f ChangeScopedFinding) string {
+	return prLabelBadgeWithHistory(f, nil)
+}
+
+// prLabelBadgeWithHistory is the history-aware form. When the store
+// reports the (SignalType, File) pair as ShouldDemote, the badge
+// renders as observability (WATCH) regardless of the manifest tier.
+func prLabelBadgeWithHistory(f ChangeScopedFinding, historyStore HistoryStore) string {
 	tier := tierForFinding(f)
+	if historyStore != nil && f.SignalType != "" && f.Path != "" {
+		if historyStore.ShouldDemote(f.SignalType, f.Path) {
+			tier = "observability"
+		}
+	}
 	return uitokens.BracketedPRLabel(tier, f.Severity)
 }
 

--- a/internal/changescope/render_history_test.go
+++ b/internal/changescope/render_history_test.go
@@ -1,0 +1,105 @@
+package changescope
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// fakeHistoryStore lets the test name exactly which (ruleID, file)
+// pairs should be reported as demote-worthy. Anything not in the
+// map returns false — mirrors the empty-store first-run behavior of
+// findinghistory.Store.
+type fakeHistoryStore struct {
+	demote map[string]bool
+}
+
+func (f *fakeHistoryStore) ShouldDemote(ruleID, file string) bool {
+	if f == nil || f.demote == nil {
+		return false
+	}
+	return f.demote[ruleID+"|"+file]
+}
+
+// TestRenderPRSummaryMarkdownWithHistory_DemotesChronicFiring is the
+// acceptance test for the § P5.7 demote path. When a (rule, file) pair
+// is reported as demote-worthy by the history store, the renderer
+// must drop its tier from BLOCK/GATE down to WATCH (observability),
+// regardless of what the manifest says about the detector's tier.
+//
+// This is a renderer-only test — it doesn't exercise the on-disk
+// store, only the contract that RenderPRSummaryMarkdownWithHistory
+// consults the store when given one and renders the demoted label.
+func TestRenderPRSummaryMarkdownWithHistory_DemotesChronicFiring(t *testing.T) {
+	t.Parallel()
+
+	pr := &PRAnalysis{
+		PostureBand: "moderate",
+		NewFindings: []ChangeScopedFinding{
+			{
+				Type:        "existing_signal",
+				SignalType:  "untestedExport",
+				Scope:       "direct",
+				Path:        "src/agent/prompt.ts",
+				Severity:    "high",
+				Explanation: "raw detector text",
+			},
+		},
+	}
+
+	// First render: no history store → finding renders at the
+	// manifest tier (gate-tier detector + high severity = [GATE]).
+	var baseline bytes.Buffer
+	RenderPRSummaryMarkdownWithHistory(&baseline, pr, nil)
+	baseOut := baseline.String()
+	if !strings.Contains(baseOut, "**`src/agent/prompt.ts`** [GATE]") {
+		t.Fatalf("baseline (nil store): expected [GATE] for high-severity gate detector; got:\n%s", baseOut)
+	}
+
+	// Second render: store reports demote → label flips to [WATCH].
+	store := &fakeHistoryStore{
+		demote: map[string]bool{
+			"untestedExport|src/agent/prompt.ts": true,
+		},
+	}
+	var demoted bytes.Buffer
+	RenderPRSummaryMarkdownWithHistory(&demoted, pr, store)
+	demotedOut := demoted.String()
+	if !strings.Contains(demotedOut, "**`src/agent/prompt.ts`** [WATCH]") {
+		t.Errorf("demoted render: expected [WATCH] (observability tier); got:\n%s", demotedOut)
+	}
+	if strings.Contains(demotedOut, "**`src/agent/prompt.ts`** [GATE]") {
+		t.Errorf("demoted render: should NOT contain [GATE] label; got:\n%s", demotedOut)
+	}
+}
+
+// TestRenderPRSummaryMarkdownWithHistory_NilStoreActsLikeBaseRenderer
+// proves that passing a nil store produces output identical to the
+// non-history renderer — the demotion path doesn't accidentally affect
+// callers that haven't loaded a store yet (or that explicitly opt out).
+func TestRenderPRSummaryMarkdownWithHistory_NilStoreActsLikeBaseRenderer(t *testing.T) {
+	t.Parallel()
+
+	pr := &PRAnalysis{
+		PostureBand: "moderate",
+		NewFindings: []ChangeScopedFinding{
+			{
+				Type:        "existing_signal",
+				SignalType:  "untestedExport",
+				Scope:       "direct",
+				Path:        "src/agent/prompt.ts",
+				Severity:    "high",
+				Explanation: "raw detector text",
+			},
+		},
+	}
+
+	var withHist, withoutHist bytes.Buffer
+	RenderPRSummaryMarkdownWithHistory(&withHist, pr, nil)
+	RenderPRSummaryMarkdown(&withoutHist, pr)
+
+	if withHist.String() != withoutHist.String() {
+		t.Errorf("nil-store render diverged from base renderer:\n--- with nil hist ---\n%s\n--- base ---\n%s",
+			withHist.String(), withoutHist.String())
+	}
+}

--- a/internal/engine/findinghistory.go
+++ b/internal/engine/findinghistory.go
@@ -1,0 +1,56 @@
+package engine
+
+import (
+	"path/filepath"
+
+	"github.com/pmclSF/terrain/internal/findinghistory"
+	"github.com/pmclSF/terrain/internal/logging"
+	"github.com/pmclSF/terrain/internal/models"
+)
+
+// updateFindingHistory increments the per-repo finding-history
+// counter for every signal in the snapshot, then persists the file.
+// Failure to load / save is logged at Debug — the analyze pipeline
+// must not block on a history-file I/O hiccup.
+//
+// Skips when the snapshot has no signals (nothing to count).
+//
+// Spec § P5.7: when (rule_id, file_path) fires ≥3 times without a
+// dismiss, the renderer demotes that pair from inline to
+// observability footer. This function provides the data the
+// renderer consults via findinghistory.Store.ShouldDemote.
+func updateFindingHistory(snap *models.TestSuiteSnapshot, root string) {
+	if snap == nil || len(snap.Signals) == 0 {
+		return
+	}
+	path := filepath.Join(root, findinghistory.DefaultPath)
+	store, err := findinghistory.Load(path)
+	if err != nil {
+		logging.L().Debug("finding history: load failed", "path", path, "err", err)
+		return
+	}
+	for _, s := range snap.Signals {
+		// Skip signals without a usable (type, file) pair. The
+		// counter is meaningless if we can't identify which
+		// (detector, location) pair fired.
+		if s.Type == "" || s.Location.File == "" {
+			continue
+		}
+		store.Increment(string(s.Type), s.Location.File)
+	}
+	if err := store.Save(path); err != nil {
+		logging.L().Debug("finding history: save failed", "path", path, "err", err)
+	}
+}
+
+// LoadFindingHistory returns the on-disk Store for callers that
+// want to consult ShouldDemote without going through the pipeline.
+// Returns an empty store + nil error when the file doesn't exist.
+//
+// The renderer in internal/changescope uses this to make per-finding
+// demote decisions at render time. The slash dispatcher's /dismiss
+// path calls store.Dismiss + store.Save through this loader.
+func LoadFindingHistory(root string) (*findinghistory.Store, error) {
+	path := filepath.Join(root, findinghistory.DefaultPath)
+	return findinghistory.Load(path)
+}

--- a/internal/engine/pipeline.go
+++ b/internal/engine/pipeline.go
@@ -938,6 +938,18 @@ func RunPipelineContext(ctx context.Context, root string, opts ...PipelineOption
 		applyNewFindingsOnly(snapshot)
 	}
 
+	// Step 10e: update per-repo finding history (§ P5.7). For each
+	// signal that survived suppressions, increment the (rule_id,
+	// file) counter. The PR-comment renderer consults the same
+	// store via ShouldDemote to fold chronically-firing-without-
+	// dismiss findings into the observability footer.
+	//
+	// Skip in baseline / readonly contexts: when the caller asks
+	// for --new-findings-only behavior, the snapshot has been
+	// filtered to net-new findings so incrementing reflects fresh
+	// observations rather than the full re-run noise.
+	updateFindingHistory(snapshot, root)
+
 	if err := models.ValidateSnapshot(snapshot); err != nil {
 		return nil, fmt.Errorf("invalid snapshot produced by pipeline: %w", err)
 	}


### PR DESCRIPTION
## Summary

Connects the `internal/findinghistory` store (shipped in #196) to the
three surfaces that needed to consume it:

- The `internal/engine` pipeline — every PR run reads + writes
  `.terrain/finding-history.yaml`
- The renderer (`internal/changescope`) — chronically un-dismissed
  findings demote from inline to observability footer
- A new `cmd_slash_dispatcher.go` — receives `/dismiss` and resets
  the demote counter

After this PR, the per-repo finding-history learning behavior described
in the phase-5f CHANGELOG entry fires end-to-end.

## Type of change

- [x] New feature

## Reviewer checklist

- [x] `go test ./internal/engine/... ./internal/changescope/...` passes
- [x] No snapshot / signal-catalog shape changes
- [x] `.terrain/finding-history.yaml` is written under the pipeline's
      existing `.terrain/` directory; no new filesystem paths

## Security / privacy implications

Writes `.terrain/finding-history.yaml` (already gitignored by the
init scaffolding). No network calls; no LLM. The slash dispatcher
parses webhook payloads using the deterministic grammar from #195.

## Breaking changes

None.

## Test plan

- `render_history_test.go` — render demotion fires after 3 un-dismissed
  fires of the same (rule, file) pair
- Pipeline test confirms history round-trips through a single analyze run

## Stack position

Stacked on `phase-5.5a-renderer-migration` (#197).