### PR TITLE
Phase 5.5c: deploy two GitHub check-runs via gh api + slash-receiver setup docs

### DIFF
--- a/.github/workflows/terrain-pr.yml
+++ b/.github/workflows/terrain-pr.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
+  checks: write
 
 jobs:
   analyze:
@@ -110,6 +111,45 @@ jobs:
           body: |
             <!-- terrain-pr-analysis -->
             ${{ steps.terrain-comment.outputs.body }}
+
+      # ----------------------------------------------------------------
+      # Two GitHub check runs: terrain (gate) + terrain (observability)
+      # ----------------------------------------------------------------
+      # Terrain emits a JSON bundle; this workflow POSTs each half through
+      # `gh api`. The binary never makes outbound HTTP — auth + transport
+      # live in the workflow, never in terrain itself. See
+      # `docs/integrations/github-checks.md` for the full deploy story.
+      - name: Build Terrain check-runs bundle
+        id: check-runs-bundle
+        run: |
+          ./terrain report check-runs \
+            --head-sha "${{ github.event.pull_request.head.sha }}" \
+            --out /tmp/terrain-checks.json
+          # Split into two files so each `gh api --input` call gets a
+          # standalone CheckRun document. `jq` here is just a splitter —
+          # the bundle's shape is documented in internal/checkruns.
+          jq '.gate_check'          /tmp/terrain-checks.json > /tmp/check-gate.json
+          jq '.observability_check' /tmp/terrain-checks.json > /tmp/check-observability.json
+
+      - name: Post terrain (gate) check run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/check-runs" \
+            --input /tmp/check-gate.json
+
+      - name: Post terrain (observability) check run
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/check-runs" \
+            --input /tmp/check-observability.json
 
       - name: Fail if selected tests failed
         if: steps.go-tests.outcome == 'failure'

--- a/cmd/terrain/cmd_report_namespace.go
+++ b/cmd/terrain/cmd_report_namespace.go
@@ -99,6 +99,7 @@ func printReportUsage() {
 	fmt.Println("  pr            PR-level summary (--format=markdown|comment|annotation)")
 	fmt.Println("  posture       release readiness posture")
 	fmt.Println("  select-tests  protective test selection for a change")
+	fmt.Println("  check-runs    emit two GitHub Checks-API check-run bodies (gate + observability)")
 	fmt.Println()
 	fmt.Println("Common flags (all verbs):")
 	fmt.Println("  --root <path>       repository root (default .)")

--- a/docs/integrations/github-checks.md
+++ b/docs/integrations/github-checks.md
@@ -1,0 +1,161 @@
+# GitHub Checks + slash-command integration
+
+Terrain emits structured outputs. GitHub auth + transport live in your
+workflow — the binary never makes outbound HTTP calls.
+
+## The two check runs
+
+Each PR analysis produces two check-run bodies:
+
+| Check run | Required? | Conclusion |
+|---|---|---|
+| `terrain (gate)` | yes | `failure` when an undismissed gate-tier finding fires; `success` otherwise |
+| `terrain (observability)` | no | always `neutral` (informational footer of findings the gate doesn't block on) |
+
+Generate both from one analyze pass:
+
+```bash
+terrain report check-runs \
+  --head-sha "$GITHUB_SHA" \
+  --out /tmp/terrain-checks.json
+```
+
+The bundle has two top-level keys — `gate_check` and
+`observability_check` — each shaped exactly like a `POST /check-runs`
+request body. Split + post:
+
+```bash
+jq '.gate_check'          /tmp/terrain-checks.json > /tmp/check-gate.json
+jq '.observability_check' /tmp/terrain-checks.json > /tmp/check-obs.json
+
+gh api --method POST \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/$GITHUB_REPOSITORY/check-runs" \
+  --input /tmp/check-gate.json
+
+gh api --method POST \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/$GITHUB_REPOSITORY/check-runs" \
+  --input /tmp/check-obs.json
+```
+
+`.github/workflows/terrain-pr.yml` in this repo is the reference
+implementation.
+
+### Required permissions
+
+The workflow needs `checks: write` (plus the existing `contents: read`
+and `pull-requests: write` for the PR-comment job). The default
+`GITHUB_TOKEN` issued to a workflow run is enough — no PAT, no app
+installation, no extra secrets.
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+```
+
+### Branch-protection wiring
+
+Mark `terrain (gate)` as a required check in the branch-protection
+rules for `main`. Leave `terrain (observability)` unselected — that
+check should never block a merge.
+
+## The slash-command receiver
+
+`/dismiss`, `/terrain explain`, `/terrain show`, `/terrain commands`
+arrive as GitHub `issue_comment` webhook deliveries. Terrain ships a
+receiver binary:
+
+```bash
+TERRAIN_DEV=1 \
+TERRAIN_WEBHOOK_SECRET="<same secret you set on the GitHub webhook>" \
+  terrain webhook --addr=":8080"
+```
+
+The receiver:
+
+- validates each request's `X-Hub-Signature-256` against the secret
+  (HMAC-SHA256 of the raw body),
+- parses the comment body for slash verbs,
+- dispatches to the in-process runner — `/dismiss` writes a
+  suppression to `.terrain/suppressions.yaml`, `/terrain explain`
+  renders rule docs, `/terrain show` renders one finding,
+- responds 200 with the reply text in the body.
+
+The receiver is a long-lived service — it does not belong inside a
+per-PR GitHub Action workflow. Deploy it next to your repo's git
+host (a small VM, a Fly machine, a Cloud Run service). A reference
+container is below.
+
+### Reference Dockerfile
+
+```dockerfile
+FROM golang:1.25 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /out/terrain ./cmd/terrain
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/terrain /usr/local/bin/terrain
+EXPOSE 8080
+ENV TERRAIN_DEV=1
+USER nonroot
+ENTRYPOINT ["/usr/local/bin/terrain", "webhook", "--addr=:8080"]
+```
+
+`TERRAIN_WEBHOOK_SECRET` is set in the deploy environment (Cloud Run
+secret, Fly secret, Kubernetes Secret) — never in the image, never
+in source.
+
+### GitHub webhook configuration
+
+Repository → Settings → Webhooks → Add webhook:
+
+| Field | Value |
+|---|---|
+| Payload URL | `https://<your-receiver-host>/webhook` |
+| Content type | `application/json` |
+| Secret | the value you put in `TERRAIN_WEBHOOK_SECRET` |
+| Events | `Issue comments` (only) |
+
+The receiver replies in the HTTP response body. To surface the reply
+back on the PR thread, run it behind a thin proxy that re-posts the
+body through `gh api repos/:owner/:repo/issues/:n/comments`. The
+proxy is not part of terrain — it's deployment glue. A minimal
+example lives in `docs/integrations/slash-proxy-example.sh` (also
+shipped under `examples/slash-proxy/`).
+
+## Why no built-in HTTP client?
+
+Terrain's contract: zero outbound network calls. The binary writes
+files / stdout; your workflow handles auth and transport. Three
+reasons:
+
+1. **Air-gapped friendly.** Adopters running in restricted networks
+   (regulated industries, sovereign clouds, isolated CI runners) can
+   use the same binary you do.
+2. **No token lifetime in the binary.** `GITHUB_TOKEN` lives in the
+   workflow runner for the duration of the job and disappears. A
+   long-lived terrain process never sees it.
+3. **Determinism.** A failing `gh api` call is a workflow failure,
+   not a hidden retry inside terrain. Operators see the exact HTTP
+   error in the action log.
+
+The two-output split (`terrain pr --json` + `terrain report
+check-runs`) is deliberate — one analyze pass, multiple consumers.
+
+## What lives where
+
+| Concern | Where |
+|---|---|
+| Analyze + render | `terrain` binary |
+| Auth (`GITHUB_TOKEN`) | Workflow runner / receiver environment |
+| HTTP transport | `gh api` (workflow) / proxy (webhook reply) |
+| Webhook signature validation | `terrain webhook` |
+| Slash-command dispatch | `terrain webhook` |
+| Suppression file writes | `terrain webhook` → `.terrain/suppressions.yaml` |
+| Finding-history learning | `terrain analyze` → `.terrain/finding-history.yaml` |

--- a/examples/slash-proxy/README.md
+++ b/examples/slash-proxy/README.md
@@ -1,0 +1,21 @@
+# slash-proxy
+
+Reference glue between GitHub webhook deliveries and the
+`terrain webhook` receiver.
+
+Terrain itself does no outbound HTTP. This shell script forwards
+incoming webhooks to the receiver and re-posts the reply back to
+the PR thread.
+
+See `docs/integrations/github-checks.md` for the deploy story.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `proxy.sh` | Stdin reads the raw webhook body; posts back via `gh api` |
+| `Dockerfile` | Minimal image bundling `proxy.sh` + a tiny HTTP server |
+
+Production deployments will likely replace `proxy.sh` with whatever
+HTTP framework / serverless runtime fits the host. The contract is
+narrow: forward → take reply → POST to issues/comments.

--- a/examples/slash-proxy/proxy.sh
+++ b/examples/slash-proxy/proxy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Minimal slash-proxy: receives a GitHub webhook, forwards to the
+# terrain receiver, takes the reply text, posts it back to the PR
+# thread as a comment.
+#
+# Deploy alongside the terrain webhook receiver. The terrain receiver
+# itself does no outbound HTTP; this script is the glue.
+#
+# Required env:
+#   GITHUB_TOKEN              token with repo:issues:write
+#   TERRAIN_RECEIVER_URL      http://localhost:8080/webhook (or wherever)
+#   GITHUB_WEBHOOK_SECRET     same secret terrain validates against
+#
+# Usage:
+#   Bind this behind a tiny HTTP server (caddy, traefik, fly proxy)
+#   that POSTs the raw webhook body to this script's stdin and passes
+#   GitHub's X-Hub-Signature-256 and X-GitHub-Event headers through.
+
+set -euo pipefail
+
+: "${GITHUB_TOKEN:?GITHUB_TOKEN required}"
+: "${TERRAIN_RECEIVER_URL:?TERRAIN_RECEIVER_URL required}"
+
+BODY="$(cat)"
+SIG="${HTTP_X_HUB_SIGNATURE_256:-}"
+EVENT="${HTTP_X_GITHUB_EVENT:-}"
+
+# Forward to terrain. The receiver validates the signature itself.
+REPLY="$(curl -sf -X POST "$TERRAIN_RECEIVER_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-Hub-Signature-256: $SIG" \
+  -H "X-GitHub-Event: $EVENT" \
+  --data "$BODY")"
+
+# Empty reply (e.g. an unrelated webhook) → noop, return 200.
+if [ -z "$REPLY" ]; then
+  exit 0
+fi
+
+# Extract repo + issue from the original event.
+REPO="$(echo "$BODY" | jq -r '.repository.full_name')"
+ISSUE="$(echo "$BODY" | jq -r '.issue.number // .pull_request.number')"
+
+if [ -z "$REPO" ] || [ "$REPO" = "null" ] || [ -z "$ISSUE" ] || [ "$ISSUE" = "null" ]; then
+  echo "skip: not a comment event" >&2
+  exit 0
+fi
+
+# Post the reply back as a PR comment.
+jq -n --arg body "$REPLY" '{body: $body}' \
+  | curl -sf -X POST "https://api.github.com/repos/$REPO/issues/$ISSUE/comments" \
+      -H "Authorization: Bearer $GITHUB_TOKEN" \
+      -H "Accept: application/vnd.github+json" \
+      --data @-
+
+echo "ok" >&2


### PR DESCRIPTION
## Summary

Ships the deployment surface for the phase-5d check-runs (#194) and
phase-5e slash webhook (#195):

- `.github/workflows/terrain-pr.yml` — calls `terrain report check-runs`
  then posts both bundles via `gh api`. Terrain itself stays
  network-free.
- `docs/integrations/github-checks.md` — adopter-facing setup walkthrough
  for both `terrain (gate)` and `terrain (observability)` check runs.
- `examples/slash-proxy/` — minimal proxy receiver adopters can drop
  into their infra to relay `/dismiss` and `/terrain explain` comments.

## Type of change

- [x] New feature
- [x] Documentation

## Reviewer checklist

- [x] `terrain report check-runs --head-sha=<sha>` produces the
      gate + observability bundle expected by the workflow
- [x] Setup doc walks an adopter from zero to working gate

## Security / privacy implications

The example workflow uses standard `GITHUB_TOKEN` permissions
(check-runs write, contents read). The slash-proxy example documents
HMAC-SHA256 signature validation against `TERRAIN_WEBHOOK_SECRET`;
adopters supply their own secret. No outbound calls from terrain.

## Breaking changes

None.

## Test plan

- Workflow lints clean against `actionlint`
- Setup doc reviewed for accuracy against the actual command shapes

## Stack position

Stacked on `phase-5.5b-pipeline-wiring` (#198).