### PR TITLE
chore(release): promote Unreleased → 0.3.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Terrain are documented here. The format follows
 
 ## [Unreleased]
 
+## [0.3.0] — PR surface upgrade + adopter scaffolding
+
 ### Added
 
 - **`.terrain/findings.json` is written after every `terrain analyze` run.**


### PR DESCRIPTION
## Summary

Renames the in-flight \`## [Unreleased]\` section to \`## [0.3.0] — PR surface upgrade + adopter scaffolding\` and adds a fresh empty \`[Unreleased]\` above it for 0.4.0 work.

Required before tagging \`v0.3.0\` so the tarball + GitHub Release notes pull from a labeled section instead of \`[Unreleased]\`.

## Notes

- Tagline ("PR surface upgrade + adopter scaffolding") is editable in this PR before merge if you'd like a different framing — happy to amend.
- No content changes; pure section rename + new empty Unreleased.

## Test plan

- [x] CHANGELOG diff is two added lines, nothing else
- [ ] Confirm tagline reads accurately for the release shipped